### PR TITLE
Fix patch rollout in tarball

### DIFF
--- a/debian/roll-tarballs.sh
+++ b/debian/roll-tarballs.sh
@@ -82,9 +82,9 @@ mkdir -p doc/applied-patches
 
 # prepare patches for lite and full tarball
 if [ "x$MODE" = "xfull" ]; then
-    find debian/patches  | sort | egrep "(debian/patches/[0-9]+_.*\.(full|full\+lite)\.patch)" | while read file
+    cat debian/patches/series | sort | grep -v ^# | egrep "([0-9]+_.*\.(full|full\+lite)\.patch)" | while read file
     do
-        cp -v $file doc/applied-patches
+        cp -v debian/patches/$file doc/applied-patches
         echo ${file##*/} >> doc/applied-patches/series
     done
     mkdir -p ./etc/
@@ -96,9 +96,9 @@ else
     rm -Rf "nxcompshad"*
     rm -Rf "nxcompext"*
     rm -Rf "nx-X11"*
-    find debian/patches | sort | egrep "(debian/patches/[0-9]+_.*\.full\+lite\.patch)" | while read file
+    cat debian/patches/series | sort | grep -v ^# | egrep "([0-9]+_.*\.full\+lite\.patch)" | while read file
     do
-        cp -v $file doc/applied-patches
+        cp -v debian/patches/$file doc/applied-patches
         echo ${file##*/} >> doc/applied-patches/series
     done
 fi


### PR DESCRIPTION
the tarball contained too many patches because it ignored the series file completely
