### PR TITLE
libnx-xinerama1: also create libXinerama symlink in postinst (and remove in prerm.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,11 +155,12 @@ install-full:
 	    done; \
 
 	# Provide means for Xinerama support in NX/X2Go sessions. This
-	# This also requires two post-install symlinks:
-	# (DESTDIR)$(NXLIBDIR)/X11/Xinerama/libNX_X11.so.6 -> /usr/<libdir>/libX11.so.6
-	# (DESTDIR)$(NXLIBDIR)/X11/Xinerama/libNX_Xext.so.6 -> /usr/<libdir>/libXext.so.6
-	$(INSTALL_DIR) $(DESTDIR)$(NXLIBDIR)/X11/Xinerama
-	$(INSTALL_SYMLINK) $(USRLIBDIR)/libNX_Xinerama.so.1 $(DESTDIR)$(NXLIBDIR)/X11/Xinerama/libXinerama.so.1
+	# This also requires three post-install symlinks created by libnx-xinerama1:
+	# $(DESTDIR)$(NXLIBDIR)/X11/Xinerama/libNX_X11.so.6 -> /usr/<libdir>/libX11.so.6
+	# $(DESTDIR)$(NXLIBDIR)/X11/Xinerama/libNX_Xext.so.6 -> /usr/<libdir>/libXext.so.6
+	# $(DESTDIR)$(NXLIBDIR)/X11/Xinerama/libXinerama.so.1 -> /usr/<libdir>/libNX_Xinerama.so.1
+	# Only create the owned directory here for nx-x11-common.
+	$(INSTALL_DIR) $(DESTDIR)$(NXLIBDIR)/X11
 
 	$(INSTALL_DIR) $(DESTDIR)/$(ETCDIR_NX)
 	$(INSTALL_DIR) $(DESTDIR)/$(ETCDIR_X2GO)

--- a/debian/libnx-xinerama1.postinst.in
+++ b/debian/libnx-xinerama1.postinst.in
@@ -26,13 +26,21 @@ case "$1" in
 
 		libdir=/usr/lib/#DEB_BUILD_MULTIARCH#
 
-		rm -f /usr/lib/nx/X11/Xinerama/libNX_X11.so.6
-		rm -f /usr/lib/nx/X11/Xinerama/libNX_Xext.so.6
+		# Already existent files and directories are not removed.
+		# Users will need to explicitly remove them and (re-) configure this package.
+
+		if test ! -e /usr/lib/nx/X11/Xinerama; then
+			install -d -m 755 /usr/lib/nx/X11/Xinerama
+		fi
+
 		if test -e $libdir/libX11.so.6; then
 			ln -s $libdir/libX11.so.6 /usr/lib/nx/X11/Xinerama/libNX_X11.so.6
 		fi
 		if test -e $libdir/libXext.so.6; then
 			ln -s $libdir/libXext.so.6 /usr/lib/nx/X11/Xinerama/libNX_Xext.so.6
+		fi
+		if test -e $libdir/libNX_Xinerama.so.1; then
+			ln -s $libdir/libNX_Xinerama.so.1 /usr/lib/nx/X11/Xinerama/libXinerama.so.1
 		fi
 	;;
 

--- a/debian/libnx-xinerama1.prerm
+++ b/debian/libnx-xinerama1.prerm
@@ -1,37 +1,35 @@
 #!/bin/sh
-# postrm script for x2goserver-fmbindings
+# prerm script for libnx-xinerama1
 #
 # see: dh_installdeb(1)
-
-set -e
-
 # summary of how this script can be called:
-#        * <postrm> `remove'
-#        * <postrm> `purge'
-#        * <old-postrm> `upgrade' <new-version>
-#        * <new-postrm> `failed-upgrade' <old-version>
-#        * <new-postrm> `abort-install'
-#        * <new-postrm> `abort-install' <old-version>
-#        * <new-postrm> `abort-upgrade' <old-version>
-#        * <disappearer's-postrm> `disappear' <overwriter>
-#          <overwriter-version>
+#        * <prerm> `remove'
+#        * <old-prerm> `upgrade' <new-version>
+#        * <new-prerm> `failed-upgrade' <old-version>
+#        * <conflictor's-prerm> `remove' `in-favour' <package> <new-version>
+#        * <deconfigured's-prerm> `deconfigure' `in-favour'
+#        <package-being-installed> <version> `removing'
+#        <conflicting-package> <version>
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+set -e
+
+
 
 case "$1" in
-	purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-		if test -e /usr/lib/nx/X11/Xinerama/libNX_X11.so.6; then
-			rm -f /usr/lib/nx/X11/Xinerama/libNX_X11.so.6
+	remove)
+		if test -d /usr/lib/nx/X11/Xinerama; then
+			rm -rf /usr/lib/nx/X11/Xinerama
 		fi
-		if test -e /usr/lib/nx/X11/Xinerama/libNX_Xext.so.6; then
-			rm -f /usr/lib/nx/X11/Xinerama/libNX_Xext.so.6
-		fi
-	;;
+		;;
+	deconfigure|upgrade|failed-upgrade)
+		:
+		;;
 	*)
-		echo "postrm called with unknown argument \`$1'" >&2
+		echo "prerm called with unknown argument \`$1'" >&2
 		exit 1
-	;;
+		;;
 esac
 
 # dh_installdeb will replace this with shell code automatically


### PR DESCRIPTION
Due to the `nx-x11-common` package being a `noarch`/`allarch` package,
creating the symlink in nx-libs' `Makefile` will lead to the symlink
referencing the "default" architecture dpkg uses for building
`noarch`/`allarch` packages.

Incidentally, this worked fine for Debian, as `amd64` seems to be the
default architecture. On Ubuntu, however, the default architecture up to
Vivid (15.04) was `i386`. For those builds, the symlink pointed to the 32
bit library of `libNX_Xinerama.so.1` -- essentially breaking this feature.

Move the symlink creation to the arch-sensitive `libnx-xinerama1` package.
The `postinst` and `prerm` scriptlets will work fine, unless someone
installs the `i386` package version **after** the `amd64` version. Given that
we already create symlinks to `libNX_X11` and friends using that method,
no new regression is introduced. Strictly speaking that's a bug, but
we'll hopefully clean that up later...
