### PR TITLE
dix: Allow zero-height PutImage requests (fix for X.Org's CVE-2015-3418).

### DIFF
--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -2071,7 +2071,7 @@ ProcPutImage(register ClientPtr client)
 
     tmpImage = (char *)&stuff[1];
     lengthProto = length;
-    if (lengthProto >= (INT32_MAX / stuff->height))
+    if (stuff->height != 0 && lengthProto >= (INT32_MAX / stuff->height))
         return BadLength;
 
     if (((((lengthProto * stuff->height) + (unsigned)3) >> 2) + 


### PR DESCRIPTION
 The length checking code validates PutImage height and byte width by
 making sure that byte-width >= INT32_MAX / height. If height is zero,
 this generates a divide by zero exception. Allow zero height requests
 explicitly, bypassing the INT32_MAX check.

 Fix for regression introduced by fix for CVE-2014-8092.

 v2: backports to nx-libs 3.6.x (Mike Gabriel)
 Signed-off-by: Keith Packard keithp@keithp.com
