### PR TITLE
This patch allows to cleanup the nxcomp resources to allow for a seco…

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -1311,6 +1311,11 @@ void NXTransCleanup()
   HandleCleanup();
 }
 
+void NXTransCleanupForReconnect()
+{
+  HandleCleanupForReconnect();
+}
+
 //
 // Check the parameters for subsequent
 // initialization of the NX transport.
@@ -4873,6 +4878,28 @@ int StartKeeper()
   return 1;
 }
 
+void HandleCleanupForReconnect()
+{
+  #ifdef TEST
+  *logofs << "Loop: Going to clean up system resources for Reconnect "
+          << "in process '" << getpid() << "'.\n"
+          << logofs_flush;
+  #endif
+  handleTerminatedInLoop();
+  DisableSignals();
+  if (control)
+    CleanupChildren();
+  CleanupListeners();
+  CleanupSockets();
+  CleanupKeeper();
+  CleanupStreams();
+  CleanupLocal();
+  CleanupGlobal();
+  RestoreSignals();
+  ServerCache::lastInitReply.set(0,NULL);
+  ServerCache::lastKeymap.set(0,NULL);
+  ServerCache::getKeyboardMappingLastMap.set(0,NULL);
+}
 void HandleCleanup(int code)
 {
   #ifdef TEST

--- a/nxcomp/Misc.h
+++ b/nxcomp/Misc.h
@@ -140,6 +140,7 @@ void HandleShutdown() __attribute__((noreturn));
 extern "C"
 {
   void HandleCleanup(int code = 0) __attribute__((noreturn));
+  void HandleCleanupForReconnect();
 }
 
 //

--- a/nxcomp/NX.h
+++ b/nxcomp/NX.h
@@ -442,6 +442,14 @@ extern int NXTransParseEnvironment(const char *env, int force);
 
 extern void NXTransCleanup(void) __attribute__((noreturn));
 
+/*
+ * Cleans up the global and local state
+ * (the same way as NXTransCleanup does)
+ * but does not exit the process
+ * Needed for IOS platform
+ */
+extern void NXTransCleanupForReconnect(void);
+
 extern const char* NXVersion();
 extern int NXMajorVersion();
 extern int NXMinorVersion();


### PR DESCRIPTION
…nd connection inside the same process, instead of a new process as is the nxproxy case.

This involves creating a new API call

void NXTransCleanupForReconnect(void);

which basically cleans up the global state for the connection but does not exit the process.
# Background

This is needed for the IOS platform, where the nxproxy model of forking does not work.
Also NX handles most of the errors with an "exit" call which in IOS cannot be easily handled.
