### PR TITLE
This patch is some code fixes to allow developer debuging by using TEST macros in the NX code

### DIFF
--- a/nxcomp/Agent.h
+++ b/nxcomp/Agent.h
@@ -217,7 +217,7 @@ class Agent
 
     #if defined(TEST) || defined(INFO)
     *logofs << "Agent: proxyCanRead() is "
-            << ((int) FD_ISSET(proxy -> getFd(), &readWorkSet)
+            << ((int) FD_ISSET(proxy -> getFd(), &readWorkSet))
             << ".\n" << logofs_flush;
     #endif
 

--- a/nxcomp/ClearArea.cpp
+++ b/nxcomp/ClearArea.cpp
@@ -92,7 +92,7 @@ void ClearAreaStore::dumpIdentity(const Message *message) const
 
   ClearAreaMessage *clearArea = (ClearAreaMessage *) message;
 
-  *logofs << name() << ": Identity exposures " << clearArea -> (unsigned int) exposures 
+  *logofs << name() << ": Identity exposures " << (unsigned int) clearArea -> exposures 
           << ", window " << clearArea -> window  << ", x " << clearArea -> x 
           << ", y " << clearArea -> y << ", width  " << clearArea -> width 
           << ", height " << clearArea -> height << ", size " << clearArea -> size_ 

--- a/nxcomp/Proxy.cpp
+++ b/nxcomp/Proxy.cpp
@@ -5176,7 +5176,7 @@ char *Proxy::handleSaveAllStores(const char *savePath) const
 
   *(cacheDumpName + DEFAULT_STRING_LENGTH - 1) = '\0';
 
-  mode_t fileMode = umask(0077);
+  fileMode = umask(0077);
 
   cacheDump = new ofstream(cacheDumpName, ios::out);
 


### PR DESCRIPTION
Particularly the following macros have been tested -DTEST -DDEBUG -DDUMP -DFLUSH -DTOKEN -DSPLIT -DPING -DMIXED -DMATCH -DTIME
