### PR TITLE
Document retroactive re-licensing of the original DXPC code (closes #30).

### DIFF
--- a/doc/DXPC_re-licensed::debbug_784565.mbox
+++ b/doc/DXPC_re-licensed::debbug_784565.mbox
@@ -1,0 +1,3769 @@
+From invernomuto@paranoici.org Wed May 06 17:36:12 2015
+Received: (at submit) by bugs.debian.org; 6 May 2015 17:36:12 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-12.0 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,HAS_PACKAGE,SPF_HELO_PASS,SPF_PASS,
+	XMAILER_REPORTBUG autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 12; hammy, 150; neutral, 79; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*M:reportbug, 0.000-+--H*MI:reportbug,
+	0.000-+--H*x:reportbug, 0.000-+--H*UA:reportbug, 0.000-+--H*x:6.6.3
+Return-path: <invernomuto@paranoici.org>
+Received: from perdizione.investici.org ([94.23.50.208])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1Yq3Ex-0001dB-Ks
+	for submit@bugs.debian.org; Wed, 06 May 2015 17:36:11 +0000
+Received: from [94.23.50.208] (perdizione [94.23.50.208]) (Authenticated sender: invernomuto@paranoici.org) by localhost (Postfix) with ESMTPSA id 3987C120F77;
+	Wed,  6 May 2015 17:36:07 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=paranoici.org;
+	s=stigmate; t=1430933767;
+	bh=QAdaIheSnzoHI301+0HPUrAK62wjbKWg7iWEzGzlOTs=;
+	h=From:To:Subject:Date;
+	b=X/2YGWFWL2KRAVqONR2Q6Q6HuMii+1WfGCbSpf8XvQesaf7qWlvY2u1IVKgKVpN2m
+	 Baq+3OrQ1adlmdHQQJm7tLfv37vRZVNOUpP3lyKQX4v3B/Gos63+1GqfyJ7qGkvQha
+	 4qwytZrPI20VmUswHf7qhgSGIVQmy0COEZZX0PF8=
+Received: from frx by homebrew with local (Exim 4.85)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1Yq3EK-0001ye-Bx; Wed, 06 May 2015 19:35:32 +0200
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+From: "Francesco Poli \(wintermute\)" <invernomuto@paranoici.org>
+To: Debian Bug Tracking System <submit@bugs.debian.org>
+Subject: nx-libs-lite: parts are derived from non-free code
+Message-ID: <20150506173532.7531.31389.reportbug@homebrew>
+X-Mailer: reportbug 6.6.3
+Date: Wed, 06 May 2015 19:35:32 +0200
+Delivered-To: submit@bugs.debian.org
+
+Package: nx-libs-lite
+Version: 3.5.0.27-1
+Severity: serious
+Justification: Policy 2.2.1
+
+Hello and thanks for maintaining this package in Debian!
+
+I noticed that the debian/copyright states:
+
+[...]
+| Parts of this software are derived from DXPC project. These copyright
+| notices apply to original DXPC code:
+| 
+|    Redistribution and use in source and binary forms are permitted provided
+|    that the above copyright notice and this paragraph are duplicated in all
+|    such forms.
+| 
+|    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+|    WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+|    MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+| 
+|    Copyright (c) 1995,1996 Brian Pane
+|    Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
+|    Copyright (c) 1999 Kevin Vigor and Brian Pane
+|    Copyright (c) 2000,2001 Gian Filippo Pinzari and Brian Pane
+[...]
+
+This license lacks the permission to modify the DXPC code.
+Hence, the original DXPC code does not appear to comply with the
+DFSG. And the nx-libs-lite is in part derived from DXPC code.
+
+This basically means that nx-libs-lite includes parts which are
+non-free (as they are derived from non-modifiable code) and
+are also possibly legally undistributable (as they are non-modifiable,
+but actually modified). The combination with the rest of nx-libs-lite
+(which is GPL-licensed) may also be legally undistributable (since
+the license with no permission to modify is GPL-incompatible).
+
+
+If there's anything I misunderstood, please clarify.
+
+Otherwise, please address this issue as soon as possible.
+The copyright owners for the original DXPC code should be
+contacted and persuaded to re-license under GPL-compatible
+terms.
+
+Thanks for your time.
+Bye.
+
+
+
+From mike.gabriel@das-netzwerkteam.de Mon May 11 09:07:54 2015
+Received: (at 784565) by bugs.debian.org; 11 May 2015 09:07:54 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 24; hammy, 150; neutral, 203; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1Yrjgn-0001o6-MP
+	for 784565@bugs.debian.org; Mon, 11 May 2015 09:07:54 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 85F37E4B;
+	Mon, 11 May 2015 11:07:49 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id F1CFF3C20D;
+	Mon, 11 May 2015 11:07:48 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id wKYnujH8-HJ8; Mon, 11 May 2015 11:07:48 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 960E33C18A;
+	Mon, 11 May 2015 11:07:48 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Mon, 11 May 2015 09:07:48 +0000
+Date: Mon, 11 May 2015 09:07:48 +0000
+Message-ID: <20150511090748.Horde.Edus-FOfuc519TjISGi1vQ2@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: "Francesco Poli (wintermute)" <invernomuto@paranoici.org>,
+ 784565@bugs.debian.org
+Cc: x2go-dev@lists.x2go.org, Nito Martinez <nito.martinez@qindel.com>,
+ opensource@gznianguan.com, dktrkranz@debian.org
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+In-Reply-To: <20150506173532.7531.31389.reportbug@homebrew>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_ALb-1vQm6P3YAYx12TU2SQ1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_ALb-1vQm6P3YAYx12TU2SQ1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi Francesco,
+Cc:ing a couple of people/groups being affected by the below.
+
+On  Mi 06 Mai 2015 19:35:32 CEST, Francesco Poli (wintermute) wrote:
+
+> Package: nx-libs-lite
+> Version: 3.5.0.27-1
+> Severity: serious
+> Justification: Policy 2.2.1
+>
+> Hello and thanks for maintaining this package in Debian!
+>
+> I noticed that the debian/copyright states:
+>
+> [...]
+> | Parts of this software are derived from DXPC project. These copyright
+> | notices apply to original DXPC code:
+> |
+> |    Redistribution and use in source and binary forms are permitted prov=
+ided
+> |    that the above copyright notice and this paragraph are duplicated in=
+ all
+> |    such forms.
+> |
+> |    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLI=
+ED
+> |    WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+> |    MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+> |
+> |    Copyright (c) 1995,1996 Brian Pane
+> |    Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
+> |    Copyright (c) 1999 Kevin Vigor and Brian Pane
+> |    Copyright (c) 2000,2001 Gian Filippo Pinzari and Brian Pane
+> [...]
+>
+> This license lacks the permission to modify the DXPC code.
+> Hence, the original DXPC code does not appear to comply with the
+> DFSG. And the nx-libs-lite is in part derived from DXPC code.
+>
+> This basically means that nx-libs-lite includes parts which are
+> non-free (as they are derived from non-modifiable code) and
+> are also possibly legally undistributable (as they are non-modifiable,
+> but actually modified). The combination with the rest of nx-libs-lite
+> (which is GPL-licensed) may also be legally undistributable (since
+> the license with no permission to modify is GPL-incompatible).
+>
+>
+> If there's anything I misunderstood, please clarify.
+>
+> Otherwise, please address this issue as soon as possible.
+> The copyright owners for the original DXPC code should be
+> contacted and persuaded to re-license under GPL-compatible
+> terms.
+>
+> Thanks for your time.
+> Bye.
+
+I/we will investigate this asap. Thanks for bringing this up.
+
+Greets,
+Mike
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_ALb-1vQm6P3YAYx12TU2SQ1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVUHFkAAoJEJr0azAldxsxbNYP/jqxwacIBSYlAhaZEf62JFtt
+ObBSEqUQfjljkolnzeaf2K4lBT6dl1x9VxGvIM5S8y9H/qpbFW+XWNHIR1BpdAsw
+TgKuqb6giM+28V9pMaHuqwPwMQ7YnFsfSKf/YCEs0AvJJKsf5jSUbeHAJ/RHwC4Z
+iGOj/KRqQ3tqIZJbzV2TCMNYnPm4sttcvKcRIOnBLDEVn1CRhlYX93v/pP87iPok
+wvvnbPpM+D2oq1JjS6mR2JbVHspc9/ZGq5I100Cdo5r3Y3upunNyG4IRCL0ttBzg
+nRjEiktViU/hhBB2xjYRaDsEpRFSsOeItLWss2PNYER2uIYuimvUsJzhtj7IwsV8
+4J8wlvn0uRZRiQwSWI/UaL1r1eqI4AlMA4hzDnWR7cBB4nTNE6YWzTpYYhsqNVfJ
+jURTKIwGzDVVcpU5UZZhEtPcD5utkd8eYn4fA68pvkje3OFpLjfQnFWUcjIn5ywb
+mejuW08cnsdfB0he+NTFXpK4p4wiu92pqul/EqPKW3Dm1w7FZXPHpIkN6VQ03LdY
+kSXOOpITg8cHESsHlvyKIZITaLDrNAPB4RHkRxyWhRpZWgEM35FasE6hIRTbszQ9
+jpuXcrG11L7HbITi599U8ZAo4qK9OgWfzJEsBdQKXBHEqCjiv4GvdXvgJyR2Eukp
+OIldtig78B5JgGKDLKjY
+=G+R6
+-----END PGP SIGNATURE-----
+
+--=_ALb-1vQm6P3YAYx12TU2SQ1--
+
+
+
+
+From X2Go-ML-1@baur-itcs.de Mon May 11 09:21:13 2015
+Received: (at 784565) by bugs.debian.org; 11 May 2015 09:21:13 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-9.4 required=4.0 tests=BAYES_00,DIGITS_LETTERS,
+	FOURLA,FVGT_m_MULTI_ODD,HAS_BUG_NUMBER,MONEY,PGPSIGNATURE,RCVD_IN_DNSWL_NONE,
+	RCVD_IN_MSPIKE_H2,STOCKLIKE autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 67; hammy, 149; neutral, 240; spammy,
+	1. spammytokens:0.997-1--jjng hammytokens:0.000-+--sk:iqecbae,
+	0.000-+--sk:iQEcBAE, 0.000-+--sha256, 0.000-+--SHA256, 0.000-+--H*UA:31.6.0
+Return-path: <X2Go-ML-1@baur-itcs.de>
+Received: from mout.kundenserver.de ([212.227.17.10])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <X2Go-ML-1@baur-itcs.de>)
+	id 1Yrjtg-0003AA-Jy
+	for 784565@bugs.debian.org; Mon, 11 May 2015 09:21:13 +0000
+Received: from [192.168.0.171] ([78.43.125.82]) by mrelayeu.kundenserver.de
+ (mreue102) with ESMTPSA (Nemesis) id 0MBke7-1Z2Qat2SRz-00AqUz; Mon, 11 May
+ 2015 11:20:48 +0200
+Message-ID: <5550746E.1040707@baur-itcs.de>
+Date: Mon, 11 May 2015 11:20:46 +0200
+From: Stefan Baur <X2Go-ML-1@baur-itcs.de>
+User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20100101 Thunderbird/31.6.0
+MIME-Version: 1.0
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>, 
+ "Francesco Poli (wintermute)" <invernomuto@paranoici.org>,
+ 784565@bugs.debian.org
+CC: opensource@gznianguan.com, Nito Martinez <nito.martinez@qindel.com>, 
+ dktrkranz@debian.org, x2go-dev@lists.x2go.org
+Subject: Re: [X2Go-Dev] [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are
+ derived from non-free code
+References: <20150511090748.Horde.Edus-FOfuc519TjISGi1vQ2@mail.das-netzwerkteam.de>
+In-Reply-To: <20150511090748.Horde.Edus-FOfuc519TjISGi1vQ2@mail.das-netzwerkteam.de>
+Content-Type: text/plain; charset=windows-1252
+Content-Transfer-Encoding: 8bit
+X-Provags-ID:  V03:K0:1hGpzbQ6YusgDW3LQNBHFEMw92BwlVIDUv6GGAN1bbqSykY6aoQ
+ ekoiYjWtMWz72yWg8Xd5/k/PEjXU7VxzZNBzxoyEx46ughI6kPZG/kS6r+aMsjf3KVXNi4U
+ da367A2ZowOeet1s6/LouBbblzzvjx7LF9SFO2TW4oakOyxhNCWEhVpveTV9FQPnavxZzhL
+ D5GN1YjxQGdnacFHIIuSQ==
+X-UI-Out-Filterresults: notjunk:1;
+
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+hi everyone,
+
+looking at the current homepage of DXPC, the following can be found in
+their changelog http://www.vigor.nu/dxpc/CHANGES:
+
+
+3.8.1 Release:
+
+[...]
+
+Changed license to BSD license.
+
+- -Stefan
+
+Am 11.05.2015 um 11:07 schrieb Mike Gabriel:
+> Hi Francesco, Cc:ing a couple of people/groups being affected by
+> the below.
+> 
+> On  Mi 06 Mai 2015 19:35:32 CEST, Francesco Poli (wintermute)
+> wrote:
+> 
+>> Package: nx-libs-lite Version: 3.5.0.27-1 Severity: serious 
+>> Justification: Policy 2.2.1
+>> 
+>> Hello and thanks for maintaining this package in Debian!
+>> 
+>> I noticed that the debian/copyright states:
+>> 
+>> [...] | Parts of this software are derived from DXPC project.
+>> These copyright | notices apply to original DXPC code: | |
+>> Redistribution and use in source and binary forms are permitted 
+>> provided |    that the above copyright notice and this paragraph
+>> are duplicated in all |    such forms. | |    THIS SOFTWARE IS
+>> PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED |
+>> WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES
+>> OF |    MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE. | |
+>> Copyright (c) 1995,1996 Brian Pane |    Copyright (c) 1996,1997
+>> Zachary Vonler and Brian Pane |    Copyright (c) 1999 Kevin Vigor
+>> and Brian Pane |    Copyright (c) 2000,2001 Gian Filippo Pinzari
+>> and Brian Pane [...]
+>> 
+>> This license lacks the permission to modify the DXPC code. Hence,
+>> the original DXPC code does not appear to comply with the DFSG.
+>> And the nx-libs-lite is in part derived from DXPC code.
+>> 
+>> This basically means that nx-libs-lite includes parts which are 
+>> non-free (as they are derived from non-modifiable code) and are
+>> also possibly legally undistributable (as they are
+>> non-modifiable, but actually modified). The combination with the
+>> rest of nx-libs-lite (which is GPL-licensed) may also be legally
+>> undistributable (since the license with no permission to modify
+>> is GPL-incompatible).
+>> 
+>> 
+>> If there's anything I misunderstood, please clarify.
+>> 
+>> Otherwise, please address this issue as soon as possible. The
+>> copyright owners for the original DXPC code should be contacted
+>> and persuaded to re-license under GPL-compatible terms.
+>> 
+>> Thanks for your time. Bye.
+> 
+> I/we will investigate this asap. Thanks for bringing this up.
+> 
+> Greets, Mike
+> 
+> 
+> _______________________________________________ x2go-dev mailing
+> list x2go-dev@lists.x2go.org 
+> http://lists.x2go.org/listinfo/x2go-dev
+> 
+
+
+- -- 
+BAUR-ITCS UG (haftungsbeschr�nkt)
+Gesch�ftsf�hrer: Stefan Baur
+Eichen�ckerweg 10, 89081 Ulm | Registergericht Ulm, HRB 724364
+Fon/Fax 0731 40 34 66-36/-35 | USt-IdNr.: DE268653243
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQEcBAEBCAAGBQJVUHRuAAoJEG7d9BjNvlEZsCYH/i0GArfIg0xNQ91srhMtMxVf
+NcaQ5uOJLLZ+e0WOcRMm5Kprg9f6uKQNFRo1dv9NCFNxjrpdR/5/LMmeSYxafIQA
+beoYbnuMMRBvcjoUN5ScGD/jjng/9VCiwviBVjUc6AhDebGjVone2OtaIXPoMELI
+ClKnDShC41qQpSUgEESUYHiIIptkkmSrIJS6Ostsby5rhT1mApv7ulBqVvADUKCX
+OtNZmG+O6Bvur63G2fBTrdQwZAed0+Q6/XlhfOkf5QNG4I9fd5KlrMDpSmO8w7Cm
+h4rVnveLS5+0afZXs9sImhNW4I7Ah8zh5sAUFNCGXEuO60XRRysUO4i1WjRgnZw=
+=sgsA
+-----END PGP SIGNATURE-----
+
+
+
+From mike.gabriel@das-netzwerkteam.de Mon May 11 09:26:40 2015
+Received: (at 784565) by bugs.debian.org; 11 May 2015 09:26:40 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 15; hammy, 150; neutral, 246; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1Yrjyx-0003n8-Sv
+	for 784565@bugs.debian.org; Mon, 11 May 2015 09:26:40 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id B938DE53;
+	Mon, 11 May 2015 11:26:37 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 564F73C20D;
+	Mon, 11 May 2015 11:26:37 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id zA86M1U+gj03; Mon, 11 May 2015 11:26:37 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id E81223BF5A;
+	Mon, 11 May 2015 11:26:36 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Mon, 11 May 2015 09:26:36 +0000
+Date: Mon, 11 May 2015 09:26:36 +0000
+Message-ID: <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: "Francesco Poli (wintermute)" <invernomuto@paranoici.org>,
+ 784565@bugs.debian.org
+Cc: x2go-dev@lists.x2go.org, nito.martinez@qindel.com,
+ opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+In-Reply-To: <20150506173532.7531.31389.reportbug@homebrew>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_8dL5yJABYXdTfUqhzQkNVg1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_8dL5yJABYXdTfUqhzQkNVg1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi Francesco,
+
+On  Mi 06 Mai 2015 19:35:32 CEST, Francesco Poli (wintermute) wrote:
+
+> Package: nx-libs-lite
+> Version: 3.5.0.27-1
+> Severity: serious
+> Justification: Policy 2.2.1
+>
+> Hello and thanks for maintaining this package in Debian!
+>
+> I noticed that the debian/copyright states:
+>
+> [...]
+> | Parts of this software are derived from DXPC project. These copyright
+> | notices apply to original DXPC code:
+> |
+> |    Redistribution and use in source and binary forms are permitted prov=
+ided
+> |    that the above copyright notice and this paragraph are duplicated in=
+ all
+> |    such forms.
+> |
+> |    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLI=
+ED
+> |    WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+> |    MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+> |
+> |    Copyright (c) 1995,1996 Brian Pane
+> |    Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
+> |    Copyright (c) 1999 Kevin Vigor and Brian Pane
+> |    Copyright (c) 2000,2001 Gian Filippo Pinzari and Brian Pane
+> [...]
+>
+> This license lacks the permission to modify the DXPC code.
+> Hence, the original DXPC code does not appear to comply with the
+> DFSG. And the nx-libs-lite is in part derived from DXPC code.
+>
+> This basically means that nx-libs-lite includes parts which are
+> non-free (as they are derived from non-modifiable code) and
+> are also possibly legally undistributable (as they are non-modifiable,
+> but actually modified). The combination with the rest of nx-libs-lite
+> (which is GPL-licensed) may also be legally undistributable (since
+> the license with no permission to modify is GPL-incompatible).
+>
+>
+> If there's anything I misunderstood, please clarify.
+>
+> Otherwise, please address this issue as soon as possible.
+> The copyright owners for the original DXPC code should be
+> contacted and persuaded to re-license under GPL-compatible
+> terms.
+>
+> Thanks for your time.
+> Bye.
+
+Please follow-up with reading [1].
+
+As it seems, dxpc has been long ago relicensed to BSD-2-clause (for=20=20
+v3.8.1=20in/around 2002).
+
+I have no exact clue, if NoMachine forked prior to that (if they quote=20=
+=20
+the=20old licensing terms, then probably they did).
+
+However, how do you see the situation considering that upstream=20=20
+changed=20to BSD-2-clause a long time ago. What approach do you propose=20=
+=20
+for=20nx-libs-lite to get the issue fully fixed?
+
+Mike
+
+[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=3D142028
+
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_8dL5yJABYXdTfUqhzQkNVg1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVUHXMAAoJEJr0azAldxsxls4P/RyFv6ghemJhfrHNbAUEDmNz
+kyY2Q4Jt6pIDXX3U3yThYCeyG1nVAwKJI2B/q7q/YWWdzea8RzTTXrj3DubYplOZ
+PatD30FhlKdL+rsohmLFrA5dHVcwFbJA4GqrR2Y8y6NSLEtifYE4EDIDKLqvX6Dy
+msvHyLl+3AXg2gR4Wmu9lOLC8MrPA3A7nwlw/wCa6kwf3i6FUsAB2nzUsj3yUX1f
+4iXzcZhjGCJli9otPLlYFjPuc0HjwBgoOx5tEOL1hgVYP+yiQCw24LOKwHTnDogZ
+ONio1VdS+VPUbhVTlBfYD29lSDO8pgBGk43325b7Bmo56Ica+HCr8TznMVASidvJ
+dbAXZQOMuHxBofP9sm89q2lIXjPmJFWspG76OEM8dAIMKo87gQNuOTNPuOK0Zj8T
+Ua+40fIc5/C7CyRgGO8wqb6dYjD4Q6HxbjSQJrlxsHdjKIozv+MXGV+if/bKSXM8
+tIAh9JzcwgYtRVlVQXCmpk+yP9DntWFs5WeOEGBqKZw+was5OSXSlpjukNn9us2a
+bWj0E84zMlIu61KVZ8ot14OMIzgUxzymIt/LzWHKiiSezb20S22LJGBaKLxbqplp
+9Gi8g9rEhjn5Pgpt9B3MlIWQTKhpAa71GCD9Okt9vhPsBiKE57fSjCYgQR83lhDy
+kbLoUbByjixBA+TXUYM8
+=NW/2
+-----END PGP SIGNATURE-----
+
+--=_8dL5yJABYXdTfUqhzQkNVg1--
+
+
+
+
+From invernomuto@paranoici.org Mon May 11 19:37:54 2015
+Received: (at 784565) by bugs.debian.org; 11 May 2015 19:37:54 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.5 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,HAS_BUG_NUMBER,MDO_CABLE_TV3,PGPSIGNATURE,
+	SPF_HELO_PASS,SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 9; hammy, 150; neutral, 119; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*UA:sk:x86_64-,
+	0.000-+--H*x:sk:x86_64-, 0.000-+--H*c:PGP-SHA256, 0.000-+--H*c:SignHturH,
+	0.000-+--H*c:pgp-signature
+Return-path: <invernomuto@paranoici.org>
+Received: from perdizione.investici.org ([94.23.50.208])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YrtWT-0004t9-Ty
+	for 784565@bugs.debian.org; Mon, 11 May 2015 19:37:54 +0000
+Received: from [94.23.50.208] (perdizione [94.23.50.208]) (Authenticated sender: invernomuto@paranoici.org) by localhost (Postfix) with ESMTPSA id 9C4DF120408;
+	Mon, 11 May 2015 19:37:46 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=paranoici.org;
+	s=stigmate; t=1431373066;
+	bh=vGWv2ZFJgWpWShHOYFcPN0r6i8IFunsxG5IJHqxpdbk=;
+	h=Date:From:To:Cc:Subject:In-Reply-To:References;
+	b=JQRMmMDPSZFkJ21FEn1TdsCco0YtUFBII0CsMLxdl3mxM5SzGN9flVttwlZ+5RrgR
+	 a7/u/VUVPzv0ZcdVKwrC+Nq6imwd5hzUj80C+e6KLZQoovz6shmhuIdKtga2OIl7lm
+	 cF0ONDqjdq0pI158Ws5hz0MiwJkzF6V5VbIEk3SY=
+Received: from frx by homebrew with local (Exim 4.85)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YrtVj-0001Cl-NV; Mon, 11 May 2015 21:37:07 +0200
+Date: Mon, 11 May 2015 21:36:59 +0200
+From: Francesco Poli <invernomuto@paranoici.org>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Cc: 784565@bugs.debian.org, x2go-dev@lists.x2go.org,
+ nito.martinez@qindel.com, opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+Message-Id: <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+In-Reply-To: <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	<20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+X-Mailer: Sylpheed 3.5.0beta1 (GTK+ 2.24.25; x86_64-pc-linux-gnu)
+Mime-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pgp-signature";
+ micalg="PGP-SHA256";
+ boundary="Signature=_Mon__11_May_2015_21_36_59_+0200_DweA9EbdD2ISBmUH"
+
+--Signature=_Mon__11_May_2015_21_36_59_+0200_DweA9EbdD2ISBmUH
+Content-Type: text/plain; charset=US-ASCII
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+On Mon, 11 May 2015 09:26:36 +0000 Mike Gabriel wrote:
+
+[...]
+> As it seems, dxpc has been long ago relicensed to BSD-2-clause (for =20
+> v3.8.1 in/around 2002).
+
+This is great news, indeed!
+
+>=20
+> I have no exact clue, if NoMachine forked prior to that (if they quote =20
+> the old licensing terms, then probably they did).
+
+Yep, it's plausible...
+
+>=20
+> However, how do you see the situation considering that upstream =20
+> changed to BSD-2-clause a long time ago. What approach do you propose =20
+> for nx-libs-lite to get the issue fully fixed?
+
+If the fork has been performed before the DXPC re-licensing (as it's
+likely), I see two possible strategies:
+
+ (A) someone gets in touch with DXPC copyright owners and asks them
+whether the re-licensing may be considered retroactive (applicable to
+older versions of DXPC); in case the answer is negative, DXPC copyright
+owners should be persuaded to make the re-licensing retroactive
+
+ (B) nx-libs-lite upstream developers re-fork from scratch, basing the
+new code on a BSD-licensed version of DXPC (I suspect this may turn out
+to be somewhat painful...)
+
+
+Obviously, the optimal solution is (A). I hope it may work...
+
+Thanks for your time and for your prompt and kind replies.
+
+
+--=20
+ http://www.inventati.org/frx/
+ There's not a second to spare! To the laboratory!
+..................................................... Francesco Poli .
+ GnuPG key fpr =3D=3D CA01 1147 9CD2 EFDF FB82  3925 3E1C 27E1 1F69 BFFE
+
+--Signature=_Mon__11_May_2015_21_36_59_+0200_DweA9EbdD2ISBmUH
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQIcBAEBCAAGBQJVUQTgAAoJED4cJ+Efab/+Mx4QAMLmPwqnPYyI0Bl6sZgxP3nA
+Yfrf7m2+swTrNz3M2xNepx1KoylRNlz2DiCuG7QWABNupSK60ACtIuAvWIAPSYNt
+wlHDRGiVrpCKBKzB4N3zjB0MN1VELhdWqrap8Yw5nnwohJ2jXoAUaqorwEba6YBg
+VK1BsGvlqcwSYt8eWt+ugpaRR43DbZTCpAvBn3t9DdYe8LwtlJDTCatbJfovlTJ9
+P19TNbwxiEoj8uWbmpOO/kLvvMed0avTEsvgAROQKF/dnWCnB1dh5QGd06IHdAY7
+KfnoZc4HUM8BB/ylWsaV13Cd8UA/2B2FKp3xbab3ry8gWeMe6dnk/pFa+pv6TGeT
+I+6VxWOMT/hc4AwBOl+R7yqp2AkcNO+KP2o5i04+yENcbgrGxyCQU2aVsHkJsVYi
+N5myXypSZY3tF6TnAm/UYP2GgiMCo0FXptwVoLiGSJkBw0tn13I25pYSqjYZlq4q
+4RQYuTEHEkV16tCdEdy+DSuI0GsABYUkY3a3A3TLj9LjiPPEDwLOxHjZlLbeyXP+
+xtmC3d82YvMmLXUiqItuhiBYjCRFq8piGGCDRX7wp1B+t6xHUcR8UV5O4s554iMX
++r2m1mLzM285PoKwP/Smd6BXU5RfhT4svmxvaMSSvADNo8X4ddNd2Hiq/Gib2ftH
+mYKFpBE7IMwQqfrOpAW5
+=Bt09
+-----END PGP SIGNATURE-----
+
+--Signature=_Mon__11_May_2015_21_36_59_+0200_DweA9EbdD2ISBmUH--
+
+
+
+From mike.gabriel@das-netzwerkteam.de Tue May 12 03:59:27 2015
+Received: (at 784565) by bugs.debian.org; 12 May 2015 03:59:27 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.4 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,MDO_CABLE_TV3,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 21; hammy, 150; neutral, 206; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1Ys1Lq-0000j4-Sf
+	for 784565@bugs.debian.org; Tue, 12 May 2015 03:59:27 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id B4F9BAA3;
+	Tue, 12 May 2015 05:59:21 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 299233C21D;
+	Tue, 12 May 2015 05:59:21 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id G2j6l6YtFs0q; Tue, 12 May 2015 05:59:21 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id C67023BF5A;
+	Tue, 12 May 2015 05:59:20 +0200 (CEST)
+Received: from p5B3B925B.dip0.t-ipconnect.de (p5B3B925B.dip0.t-ipconnect.de
+ [91.59.146.91]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Tue, 12 May 2015 03:59:20 +0000
+Date: Tue, 12 May 2015 03:59:20 +0000
+Message-ID: <20150512035920.Horde.JnI2DWx-AAFvzpbQFqakJw3@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Francesco Poli <invernomuto@paranoici.org>
+Cc: 784565@bugs.debian.org, x2go-dev@lists.x2go.org,
+ nito.martinez@qindel.com, opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+In-Reply-To: <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 91.59.146.91
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_kYZkQgyfaSLUTLVIkzgq8w1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_kYZkQgyfaSLUTLVIkzgq8w1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi Francesco,
+
+On  Mo 11 Mai 2015 21:36:59 CEST, Francesco Poli wrote:
+
+> On Mon, 11 May 2015 09:26:36 +0000 Mike Gabriel wrote:
+>
+> [...]
+>> As it seems, dxpc has been long ago relicensed to BSD-2-clause (for
+>> v3.8.1 in/around 2002).
+>
+> This is great news, indeed!
+>
+>>
+>> I have no exact clue, if NoMachine forked prior to that (if they quote
+>> the old licensing terms, then probably they did).
+>
+> Yep, it's plausible...
+>
+>>
+>> However, how do you see the situation considering that upstream
+>> changed to BSD-2-clause a long time ago. What approach do you propose
+>> for nx-libs-lite to get the issue fully fixed?
+>
+> If the fork has been performed before the DXPC re-licensing (as it's
+> likely), I see two possible strategies:
+>
+>  (A) someone gets in touch with DXPC copyright owners and asks them
+> whether the re-licensing may be considered retroactive (applicable to
+> older versions of DXPC); in case the answer is negative, DXPC copyright
+> owners should be persuaded to make the re-licensing retroactive
+
+This is the way to go, I will pull in Kevin Vigor (the upstream author=20=
+=20
+of=20DXPC) into this thread with my next email.
+
+>  (B) nx-libs-lite upstream developers re-fork from scratch, basing the
+> new code on a BSD-licensed version of DXPC (I suspect this may turn out
+> to be somewhat painful...)
+
+Yeah, indeed painful.
+
+> Obviously, the optimal solution is (A). I hope it may work...
+>
+> Thanks for your time and for your prompt and kind replies.
+
+Also, Michael DePaulo, one of the upstream NX maintainers noted that=20=20
+DXPC=20simply used a previous version of the BSD license, see [1]. The=20=
+=20
+weakness=20of that ancient license template is that modification is not=20=
+=20
+explictily=20allowed, but neither forbidden.
+
+I think, regarding the historical usage of the BSD license predecessor=20=
+=20
+and=20the switch to BSD-2-clause should be fine already (I am not a=20=20
+lawyer,=20though). I will contact DXPC upstream nonetheless and ask for=20=
+=20
+a=20statement.
+
+Greets,
+Mike
+
+[1] http://en.wikipedia.org/wiki/BSD_licenses#Previous_license
+
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_kYZkQgyfaSLUTLVIkzgq8w1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIbBAABAgAGBQJVUXqYAAoJEJr0azAldxsxYVAP+Pg4A2zg6TEs+vk/mknbLwV2
+dOv/tQiarKfb6JJRcm1j6rzGBhGzO4iwj/Uk8wmbFvIJgxs6mM93kfOPa0lJYM1N
+D0YcKPPsHqgxcyVW8pIyawhnW5IsIDSaugjsandx1hbfl+J5SBCAtSovhz5F+Fkf
+fs1wvgYcGKtWGNTxV5Qy48EnzSzAVz2r4GKBYUdRiCNpXtl/M8jJFIfm/cmJ7PJq
+ycY8Diu6x3mVvPdvap/0pOOY0uqg256XX7dcFJUtTNZoai4oGOuwR1o4g9jztyd/
+4JJ2E1MigAjGSYPpTnQGhORA86yDLQrk/NlLG/2/J8meG7Nsky6xmf3zBhuG/0G0
+3TZYQcoFrFS3EWQs0uKiGKGylchODCfXHZgF0y5NT5iqr4DMT51AlUeQl3MWhxf8
+j8OMjK86jsPMrSjL0l4uYbs+znMdlVpgjBSYsKoXg3tIc3WJpj77qyPUbfwO8hys
+5Q2j4lDaGV5NAnSmZ//p9lPwRu8oAMwSkrMkRTaJwLVhcmDzgoujZEpEPj64lIEy
+HD3p/5dSJF+RsYT6286JkWAZm+XvXeFpEqGZ7xAVsrYSY1qFm3g0se1oHxxcVWyN
+PEsQBOt8WXgYmtz7RLaBDbBQVMmeRMxbPCkC1xCHCU+Vq3y9dW/3TyOW4Oz1YoZR
+3YATO+YehUKVdM5teyg=
+=884K
+-----END PGP SIGNATURE-----
+
+--=_kYZkQgyfaSLUTLVIkzgq8w1--
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Tue May 12 04:46:43 2015
+Received: (at 784565) by bugs.debian.org; 12 May 2015 04:46:44 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.4 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,MDO_CABLE_TV3,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 27; hammy, 149; neutral, 375; spammy,
+	1. spammytokens:0.998-1--arctica hammytokens:0.000-+--IIRC,
+	0.000-+--H*c:pgp-signature, 0.000-+--H*c:protocol, 0.000-+--H*c:micalg,
+	0.000-+--H*c:signed
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1Ys25b-0004lf-4r
+	for 784565@bugs.debian.org; Tue, 12 May 2015 04:46:43 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 6AB7617F5;
+	Tue, 12 May 2015 06:46:40 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 71D923BC0D;
+	Tue, 12 May 2015 06:46:38 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id TYvbPGLabTH7; Tue, 12 May 2015 06:46:38 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 0669F3BA08;
+	Tue, 12 May 2015 06:46:38 +0200 (CEST)
+Received: from p5B3B925B.dip0.t-ipconnect.de (p5B3B925B.dip0.t-ipconnect.de
+ [91.59.146.91]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Tue, 12 May 2015 04:46:37 +0000
+Date: Tue, 12 May 2015 04:46:37 +0000
+Message-ID: <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Kevin Vigor <kevin@vigor.nu>
+Cc: 784565@bugs.debian.org, x2go-dev@lists.x2go.org,
+ nito.martinez@qindel.com, opensource@gznianguan.com, Francesco Poli
+ <invernomuto@paranoici.org>
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+In-Reply-To: <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 91.59.146.91
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_9zX_XixEpAdR4NT64zJguA1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_9zX_XixEpAdR4NT64zJguA1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Dear Kevin,
+
+(I Cc: several people involved in this, also the X2Go development=20=20
+mailing=20list...)
+
+[If you feel unconfortable with discussing the details / the impact of=20=
+=20
+the=20below in public, feel free to answer to me directly first with=20=20
+questions=20and concerns, before answering to all people who are listed=20=
+=20
+in=20Cc:.]
+
+Someone from the Debian legal team recently brought up a license issue=20=
+=20
+discovered=20in nx-libs 3.x series.
+
+TL;DR; Suggested by Francesco Poli from the Debian legal team: """
+(A) someone gets in touch with DXPC copyright owners and asks them
+whether the re-licensing [in 2002] may be considered retroactive=20=20
+(applicable=20to
+older versions of DXPC); in case the answer is negative, DXPC copyright
+owners should be persuaded to make the re-licensing retroactive
+"""
+
+The person contacting you about the above question is me. Mike=20=20
+Gabriel,=20Debian Developer and one of the current upstream maintainers=20=
+=20
+of=20nx-libs 3.x (previously also know as  "NX redistributed" for X2Go)=20=
+=20
+[1].
+
+This=20issue requires some time of reading from you and (hopefully) a=20=20
+public=20statement, that the original DXPC code can be considered as=20=20
+BSD-2-clause=20(the current license) also for released versions prior=20=20
+2002=20when the ancient BSD license template [2] was still shipped with=20=
+=20
+DXPC.
+
+For=20a complete follow-up, please check Debian bug #784565 [3].
+
+We are aware that NoMachine forked DXPC at some early stage around the=20=
+=20
+year=202000 and wrote their own commercial product around it. Obviously,=20=
+=20
+this=20fork happened before 2002 (i.e., before DXPC release 3.8.1), as=20=
+=20
+libxcomp3=20in NoMachine's NX ships the previously used BSD license=20=20
+template.=20I am not sure, if that fork was easy for you or actually a=20=
+=20
+nuisance.=20I may only guess at this point. I'd be happy to know more=20=20
+(maybe=20not in this mail thread, though).
+
+NoMachine has stopped publishing NXv3 updates a couple of years ago=20=20
+(2011=20IIRC), now. The maintenance has been moved into the hands of the=20=
+=20
+currently=20available FLOSS projects "X2Go", "Arctica Project" [NEW] and=20=
+=20
+"TheQVD".=20Some of us are running a business model on top of that=20=20
+(consultancy,=20support contracts, feature development contracts), some=20=
+=20
+of=20us spend a lot of their free time on improving / maintaining=20=20
+nx-libs=20(as we call NoMachine's NXv3 at the moment).
+
+To outline the impact of my mail clearly: If you say that it was not=20=20
+legal=20by NoMachine to fork DXPC at the given time (before 2002), then=20=
+=20
+all=20FLOSS remote desktop / remote application would be in real=20=20
+trouble,=20because then the core component of their software projects=20=20
+could=20not be considered as free (as in DFSG, Debian free software=20=20
+guidelines[4])=20anymore. Also the code changes originally performed by=20=
+=20
+NoMachine=20might have been illegal in the first place. All current=20=20
+maintenance=20activities and also planned future development on nx-libs=20=
+=20
+would=20become questionable.
+
+Thus, I hope you can chime in on this: Dear developers of nx-libs,=20=20
+please=20assume the BSD-2-license as retroactive and applicable to DXPC=20=
+=20
+version=20earlier than 3.8.1. As the copyright holder, I agree with=20=20
+modifications=20of code bases that originate before the change to=20=20
+BSD-2-clause=20license got introduced in 3.8.1 of DXPC.
+
+And... I will bring up that question later (but it is burning under my=20=
+=20
+nails)...=20Be sure: The nx-libs maintainers would be happy to have the=20=
+=20
+original=20DXPC author on the nx-libs developer team. But I will bring=20=
+=20
+up=20that question later (when this very issue is settled). ;-)
+
+Greets,
+Mike
+
+[1] https://github.com/ArcticaProject/nx-libs
+[2] http://en.wikipedia.org/wiki/BSD_licenses#Previous_license
+[3] http://bugs.debian.org/784565
+[4] http://de.wikipedia.org/wiki/Debian_Free_Software_Guidelines
+
+On  Mo 11 Mai 2015 21:36:59 CEST, Francesco Poli wrote:
+
+> On Mon, 11 May 2015 09:26:36 +0000 Mike Gabriel wrote:
+>
+> [...]
+>> As it seems, dxpc has been long ago relicensed to BSD-2-clause (for
+>> v3.8.1 in/around 2002).
+>
+> This is great news, indeed!
+>
+>>
+>> I have no exact clue, if NoMachine forked prior to that (if they quote
+>> the old licensing terms, then probably they did).
+>
+> Yep, it's plausible...
+>
+>>
+>> However, how do you see the situation considering that upstream
+>> changed to BSD-2-clause a long time ago. What approach do you propose
+>> for nx-libs-lite to get the issue fully fixed?
+>
+> If the fork has been performed before the DXPC re-licensing (as it's
+> likely), I see two possible strategies:
+>
+>  (A) someone gets in touch with DXPC copyright owners and asks them
+> whether the re-licensing may be considered retroactive (applicable to
+> older versions of DXPC); in case the answer is negative, DXPC copyright
+> owners should be persuaded to make the re-licensing retroactive
+>
+>  (B) nx-libs-lite upstream developers re-fork from scratch, basing the
+> new code on a BSD-licensed version of DXPC (I suspect this may turn out
+> to be somewhat painful...)
+>
+>
+> Obviously, the optimal solution is (A). I hope it may work...
+>
+> Thanks for your time and for your prompt and kind replies.
+
+
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_9zX_XixEpAdR4NT64zJguA1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVUYWtAAoJEJr0azAldxsxEMcP/0mjNHW4k/IiNjSbrm1j7pIQ
+k6yVqJ8cMW/71H0/VLuzS6roL02JAXMzToMzAcbPGqeV5rjhLDJNjcOuuADhb8HI
+Izisai5ABzHiclnITalVTsF4i5+MsTXI+6eNez9sv3Es8pwFuLkvAlqKsheO33mP
+dz83ZqDmCGKcCCbZmhbhGHdhScS8GMSyU7cBm6xu0TMh8rOtcECBG/+wfohVeR2I
+vy0GeYR0ZF0yIxcBGXYvjiocStjsxaqnD9QCt8JAfewVO3jY/Ye6DIEI92moS/Nz
+6iTA9GspZyYNqL7QsOraG2HF6TmIfK5xBaUjDrLH+HfKm2K6Dxp0wo6Y6VDY9mIi
+svCFCoIQ3RBihcsOp7k1v1eZl+WJJ2XXilQr3SrtlOiZAK0/FtbkUwhk4DLu5o3R
+CBHwy6F14szo8F4ChFGqqbOlODGJOiCONfOShRZQLgAgHciRirrgTKF4b25cspNU
+v7ag47K4WN3YNtkA5DO5Bj2NKAP8oWyvlTpO0uIuUZo/pj+7sHnWG8QSDJiyunVt
+3VxMLM4h3C02k+EtR2uvtKKqVFf+JgiwRGDhFx2ldUwWFg0+3IeWKuuTxRt6NcR+
+ZdDN2tR0PWpe4v+jsUqSD3YJNRoK1oyj9kMYriTkHTvhr/XcKr5KYNsWMC6nvqps
+JDhKCpypB1iR9N13NpeX
+=HDe/
+-----END PGP SIGNATURE-----
+
+--=_9zX_XixEpAdR4NT64zJguA1--
+
+
+
+
+From kevin@vigor.nu Tue May 12 15:07:38 2015
+Received: (at 784565) by bugs.debian.org; 12 May 2015 15:07:38 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-6.4 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,MDO_CABLE_TV3,SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 34; hammy, 150; neutral, 395; spammy,
+	0. spammytokens: hammytokens:0.000-+--IIRC, 0.000-+--H*f:sk:2015050,
+	0.000-+--H*UA:31.0, 0.000-+--H*u:31.0, 0.000-+--H*u:x86_64
+Return-path: <kevin@vigor.nu>
+Received: from gateway30.websitewelcome.com ([192.185.184.48])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YsBmT-0007o6-Qg
+	for 784565@bugs.debian.org; Tue, 12 May 2015 15:07:38 +0000
+Received: by gateway30.websitewelcome.com (Postfix, from userid 500)
+	id 69AEB573DA20; Tue, 12 May 2015 09:55:02 -0500 (CDT)
+Received: from gator4058.hostgator.com (gator4058.hostgator.com [192.185.4.69])
+	by gateway30.websitewelcome.com (Postfix) with ESMTP id 677E2573DA04
+	for <784565@bugs.debian.org>; Tue, 12 May 2015 09:55:02 -0500 (CDT)
+Received: from [63.158.132.10] (port=46206 helo=[10.50.3.84])
+	by gator4058.hostgator.com with esmtpsa (UNKNOWN:DHE-RSA-AES128-SHA:128)
+	(Exim 4.82)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YsBaH-0003xr-Ii; Tue, 12 May 2015 09:55:01 -0500
+Message-ID: <55521444.9090407@vigor.nu>
+Date: Tue, 12 May 2015 08:55:00 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Thunderbird/31.5.0
+MIME-Version: 1.0
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+CC: 784565@bugs.debian.org, x2go-dev@lists.x2go.org, 
+ nito.martinez@qindel.com, opensource@gznianguan.com, 
+ Francesco Poli <invernomuto@paranoici.org>
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew> <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de> <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org> <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+In-Reply-To: <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Transfer-Encoding: 7bit
+X-AntiAbuse: This header was added to track abuse, please include it with any abuse report
+X-AntiAbuse: Primary Hostname - gator4058.hostgator.com
+X-AntiAbuse: Original Domain - bugs.debian.org
+X-AntiAbuse: Originator/Caller UID/GID - [47 12] / [47 12]
+X-AntiAbuse: Sender Address Domain - vigor.nu
+X-BWhitelist: no
+X-Source-IP: 63.158.132.10
+X-Exim-ID: 1YsBaH-0003xr-Ii
+X-Source: 
+X-Source-Args: 
+X-Source-Dir: 
+X-Source-Sender: ([10.50.3.84]) [63.158.132.10]:46206
+X-Source-Auth: kevin@vigor.nu
+X-Email-Count: 2
+X-Source-Cap: a3ZpZ29yO2t2aWdvcjtnYXRvcjQwNTguaG9zdGdhdG9yLmNvbQ==
+X-Greylist: delayed 379 seconds by postgrey-1.34 at buxtehude; Tue, 12 May 2015 15:07:37 UTC
+
+Hi Mike, et al,
+
+    I am not the original author of dxpc, that being Brian Pane. However, I took over maintenance circa 1999 and am still the primary maintainer (though the project has effectively been dead for most of a decade now).
+
+    As you are aware, when I inherited the code, it was licensed under a variant of the BSD license that did not include the 'with modification' clause. To the best of my recollection, somebody from the FSF contacted me circa 2001 regarding this and as a result, subsequent releases were done under a standard 2-clause BSD license with the modification clause. Again, to the best of my recollection, I contacted Brian about this change and he offered no objection.
+
+    Further, I recall distinctly that NoMachine contacted me and explicitly asked permission before including DXPC code in NX, which I happily granted with no new conditions beyond the BSD license already in play.
+
+    It is possible, though by no means certain, that I could dig up ancient email to corroborate this account if necessary. However, I am more than willing to publicly state that I believe NoMachine's use of DXPC code to be both legal and ethical, and that my intent when changing the license to 2-clause BSD was simply to clarity the existing intent and that it ought therefore be considered retroactive.
+
+    Yours,
+       Kevin Vigor
+
+On 05/11/15 22:46, Mike Gabriel wrote:
+> Dear Kevin,
+>
+> (I Cc: several people involved in this, also the X2Go development mailing list...)
+>
+> [If you feel unconfortable with discussing the details / the impact of the below in public, feel free to answer to me directly first with questions and concerns, before answering to all people who are listed in Cc:.]
+>
+> Someone from the Debian legal team recently brought up a license issue discovered in nx-libs 3.x series.
+>
+> TL;DR; Suggested by Francesco Poli from the Debian legal team: """
+> (A) someone gets in touch with DXPC copyright owners and asks them
+> whether the re-licensing [in 2002] may be considered retroactive (applicable to
+> older versions of DXPC); in case the answer is negative, DXPC copyright
+> owners should be persuaded to make the re-licensing retroactive
+> """
+>
+> The person contacting you about the above question is me. Mike Gabriel, Debian Developer and one of the current upstream maintainers of nx-libs 3.x (previously also know as  "NX redistributed" for X2Go) [1].
+>
+> This issue requires some time of reading from you and (hopefully) a public statement, that the original DXPC code can be considered as BSD-2-clause (the current license) also for released versions prior 2002 when the ancient BSD license template [2] was still shipped with DXPC.
+>
+> For a complete follow-up, please check Debian bug #784565 [3].
+>
+> We are aware that NoMachine forked DXPC at some early stage around the year 2000 and wrote their own commercial product around it. Obviously, this fork happened before 2002 (i.e., before DXPC release 3.8.1), as libxcomp3 in NoMachine's NX ships the previously used BSD license template. I am not sure, if that fork was easy for you or actually a nuisance. I may only guess at this point. I'd be happy to know more (maybe not in this mail thread, though).
+>
+> NoMachine has stopped publishing NXv3 updates a couple of years ago (2011 IIRC), now. The maintenance has been moved into the hands of the currently available FLOSS projects "X2Go", "Arctica Project" [NEW] and "TheQVD". Some of us are running a business model on top of that (consultancy, support contracts, feature development contracts), some of us spend a lot of their free time on improving / maintaining nx-libs (as we call NoMachine's NXv3 at the moment).
+>
+> To outline the impact of my mail clearly: If you say that it was not legal by NoMachine to fork DXPC at the given time (before 2002), then all FLOSS remote desktop / remote application would be in real trouble, because then the core component of their software projects could not be considered as free (as in DFSG, Debian free software guidelines[4]) anymore. Also the code changes originally performed by NoMachine might have been illegal in the first place. All current maintenance activities and also planned future development on nx-libs would become questionable.
+>
+> Thus, I hope you can chime in on this: Dear developers of nx-libs, please assume the BSD-2-license as retroactive and applicable to DXPC version earlier than 3.8.1. As the copyright holder, I agree with modifications of code bases that originate before the change to BSD-2-clause license got introduced in 3.8.1 of DXPC.
+>
+> And... I will bring up that question later (but it is burning under my nails)... Be sure: The nx-libs maintainers would be happy to have the original DXPC author on the nx-libs developer team. But I will bring up that question later (when this very issue is settled). ;-)
+>
+> Greets,
+> Mike
+>
+> [1] https://github.com/ArcticaProject/nx-libs
+> [2] http://en.wikipedia.org/wiki/BSD_licenses#Previous_license
+> [3] http://bugs.debian.org/784565
+> [4] http://de.wikipedia.org/wiki/Debian_Free_Software_Guidelines
+>
+> On  Mo 11 Mai 2015 21:36:59 CEST, Francesco Poli wrote:
+>
+>> On Mon, 11 May 2015 09:26:36 +0000 Mike Gabriel wrote:
+>>
+>> [...]
+>>> As it seems, dxpc has been long ago relicensed to BSD-2-clause (for
+>>> v3.8.1 in/around 2002).
+>>
+>> This is great news, indeed!
+>>
+>>>
+>>> I have no exact clue, if NoMachine forked prior to that (if they quote
+>>> the old licensing terms, then probably they did).
+>>
+>> Yep, it's plausible...
+>>
+>>>
+>>> However, how do you see the situation considering that upstream
+>>> changed to BSD-2-clause a long time ago. What approach do you propose
+>>> for nx-libs-lite to get the issue fully fixed?
+>>
+>> If the fork has been performed before the DXPC re-licensing (as it's
+>> likely), I see two possible strategies:
+>>
+>>  (A) someone gets in touch with DXPC copyright owners and asks them
+>> whether the re-licensing may be considered retroactive (applicable to
+>> older versions of DXPC); in case the answer is negative, DXPC copyright
+>> owners should be persuaded to make the re-licensing retroactive
+>>
+>>  (B) nx-libs-lite upstream developers re-fork from scratch, basing the
+>> new code on a BSD-licensed version of DXPC (I suspect this may turn out
+>> to be somewhat painful...)
+>>
+>>
+>> Obviously, the optimal solution is (A). I hope it may work...
+>>
+>> Thanks for your time and for your prompt and kind replies.
+>
+>
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Tue May 12 15:42:13 2015
+Received: (at 784565) by bugs.debian.org; 12 May 2015 15:42:13 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-6.4 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,MDO_CABLE_TV3,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 28; hammy, 150; neutral, 444; spammy,
+	0. spammytokens: hammytokens:0.000-+--IIRC, 0.000-+--H*RU:sk:grimnir,
+	0.000-+--H*r:sk:grimnir, 0.000-+--H*RU:78.46.204.98,
+	0.000-+--H*RU:88.198.48.199
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YsCJx-0003Fj-12
+	for 784565@bugs.debian.org; Tue, 12 May 2015 15:42:13 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id AB2291F6
+	for <784565@bugs.debian.org>; Tue, 12 May 2015 17:42:08 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 0899C3BFDA
+	for <784565@bugs.debian.org>; Tue, 12 May 2015 17:42:08 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id tKjFu527nUiq for <784565@bugs.debian.org>;
+	Tue, 12 May 2015 17:42:07 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 558633C022
+	for <784565@bugs.debian.org>; Tue, 12 May 2015 17:42:07 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 1F4393BFDA
+	for <784565@bugs.debian.org>; Tue, 12 May 2015 17:42:07 +0200 (CEST)
+Received: from [10.215.43.89] (unknown [46.115.20.43])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPSA id 867C23BA87;
+	Tue, 12 May 2015 17:42:02 +0200 (CEST)
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Reply-To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Kevin Vigor <kevin@vigor.nu>
+Cc: 784565@bugs.debian.org, x2go-dev@lists.x2go.org, nito.martinez@qindel.com,  opensource@gznianguan.com, Francesco Poli <invernomuto@paranoici.org>
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+	from non-free code
+X-Mailer: Modest 3.2
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	 <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+	 <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+	 <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+	  <55521444.9090407@vigor.nu>
+In-Reply-To: <55521444.9090407@vigor.nu>
+Content-Type: text/plain; charset=utf-8
+Content-ID: <1431445315.4712.6.camel@Nokia-N900>
+Date: Tue, 12 May 2015 17:41:55 +0200
+Message-Id: <1431445315.4712.7.camel@Nokia-N900>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+Hi Kevin,
+
+thanks for your feedback. Let us wait for Francesco, our expert on license issues, and see what he thinks about your feedback.
+
+Thank you very much for providing info and sharing pieces of nx-libs's history.
+
+As you sent your reply to the Debian bug tracker already, this will public statement enough, I guess.
+
+Thanks a lot,
+Mike
+
+-- 
+
+DAS-NETZWERKTEAM
+mike gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976148
+
+GnuPG Key ID 0x25771B13
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+
+----- Original message -----
+> Hi Mike, et al,
+> 
+>         I am not the original author of dxpc, that being Brian Pane.
+> However, I took over maintenance circa 1999 and am still the primary
+> maintainer (though the project has effectively been dead for most of a
+> decade now).
+> 
+>         As you are aware, when I inherited the code, it was licensed under a
+> variant of the BSD license that did not include the 'with modification'
+> clause. To the best of my recollection, somebody from the FSF contacted
+> me circa 2001 regarding this and as a result, subsequent releases were
+> done under a standard 2-clause BSD license with the modification clause.
+> Again, to the best of my recollection, I contacted Brian about this
+> change and he offered no objection.
+> 
+>         Further, I recall distinctly that NoMachine contacted me and
+> explicitly asked permission before including DXPC code in NX, which I
+> happily granted with no new conditions beyond the BSD license already in
+> play.
+> 
+>         It is possible, though by no means certain, that I could dig up
+> ancient email to corroborate this account if necessary. However, I am
+> more than willing to publicly state that I believe NoMachine's use of
+> DXPC code to be both legal and ethical, and that my intent when changing
+> the license to 2-clause BSD was simply to clarity the existing intent
+> and that it ought therefore be considered retroactive.
+> 
+>         Yours,
+>               Kevin Vigor
+> 
+> On 05/11/15 22:46, Mike Gabriel wrote:
+> > Dear Kevin,
+> > 
+> > (I Cc: several people involved in this, also the X2Go development
+> > mailing list...)
+> > 
+> > [If you feel unconfortable with discussing the details / the impact of
+> > the below in public, feel free to answer to me directly first with
+> > questions and concerns, before answering to all people who are listed
+> > in Cc:.]
+> > 
+> > Someone from the Debian legal team recently brought up a license issue
+> > discovered in nx-libs 3.x series.
+> > 
+> > TL;DR; Suggested by Francesco Poli from the Debian legal team: """
+> > (A) someone gets in touch with DXPC copyright owners and asks them
+> > whether the re-licensing [in 2002] may be considered retroactive
+> > (applicable to older versions of DXPC); in case the answer is
+> > negative, DXPC copyright owners should be persuaded to make the
+> > re-licensing retroactive """
+> > 
+> > The person contacting you about the above question is me. Mike
+> > Gabriel, Debian Developer and one of the current upstream maintainers
+> > of nx-libs 3.x (previously also know as   "NX redistributed" for X2Go)
+> > [1].
+> > 
+> > This issue requires some time of reading from you and (hopefully) a
+> > public statement, that the original DXPC code can be considered as
+> > BSD-2-clause (the current license) also for released versions prior
+> > 2002 when the ancient BSD license template [2] was still shipped with
+> > DXPC.
+> > 
+> > For a complete follow-up, please check Debian bug #784565 [3].
+> > 
+> > We are aware that NoMachine forked DXPC at some early stage around the
+> > year 2000 and wrote their own commercial product around it. Obviously,
+> > this fork happened before 2002 (i.e., before DXPC release 3.8.1), as
+> > libxcomp3 in NoMachine's NX ships the previously used BSD license
+> > template. I am not sure, if that fork was easy for you or actually a
+> > nuisance. I may only guess at this point. I'd be happy to know more
+> > (maybe not in this mail thread, though).
+> > 
+> > NoMachine has stopped publishing NXv3 updates a couple of years ago
+> > (2011 IIRC), now. The maintenance has been moved into the hands of the
+> > currently available FLOSS projects "X2Go", "Arctica Project" [NEW] and
+> > "TheQVD". Some of us are running a business model on top of that
+> > (consultancy, support contracts, feature development contracts), some
+> > of us spend a lot of their free time on improving / maintaining
+> > nx-libs (as we call NoMachine's NXv3 at the moment).
+> > 
+> > To outline the impact of my mail clearly: If you say that it was not
+> > legal by NoMachine to fork DXPC at the given time (before 2002), then
+> > all FLOSS remote desktop / remote application would be in real
+> > trouble, because then the core component of their software projects
+> > could not be considered as free (as in DFSG, Debian free software
+> > guidelines[4]) anymore. Also the code changes originally performed by
+> > NoMachine might have been illegal in the first place. All current
+> > maintenance activities and also planned future development on nx-libs
+> > would become questionable.
+> > 
+> > Thus, I hope you can chime in on this: Dear developers of nx-libs,
+> > please assume the BSD-2-license as retroactive and applicable to DXPC
+> > version earlier than 3.8.1. As the copyright holder, I agree with
+> > modifications of code bases that originate before the change to
+> > BSD-2-clause license got introduced in 3.8.1 of DXPC.
+> > 
+> > And... I will bring up that question later (but it is burning under my
+> > nails)... Be sure: The nx-libs maintainers would be happy to have the
+> > original DXPC author on the nx-libs developer team. But I will bring
+> > up that question later (when this very issue is settled). ;-)
+> > 
+> > Greets,
+> > Mike
+> > 
+> > [1] https://github.com/ArcticaProject/nx-libs
+> > [2] http://en.wikipedia.org/wiki/BSD_licenses#Previous_license
+> > [3] http://bugs.debian.org/784565
+> > [4] http://de.wikipedia.org/wiki/Debian_Free_Software_Guidelines
+> > 
+> > On   Mo 11 Mai 2015 21:36:59 CEST, Francesco Poli wrote:
+> > 
+> > > On Mon, 11 May 2015 09:26:36 +0000 Mike Gabriel wrote:
+> > > 
+> > > [...]
+> > > > As it seems, dxpc has been long ago relicensed to BSD-2-clause (for
+> > > > v3.8.1 in/around 2002).
+> > > 
+> > > This is great news, indeed!
+> > > 
+> > > > 
+> > > > I have no exact clue, if NoMachine forked prior to that (if they
+> > > > quote the old licensing terms, then probably they did).
+> > > 
+> > > Yep, it's plausible...
+> > > 
+> > > > 
+> > > > However, how do you see the situation considering that upstream
+> > > > changed to BSD-2-clause a long time ago. What approach do you
+> > > > propose for nx-libs-lite to get the issue fully fixed?
+> > > 
+> > > If the fork has been performed before the DXPC re-licensing (as it's
+> > > likely), I see two possible strategies:
+> > > 
+> > > (A) someone gets in touch with DXPC copyright owners and asks them
+> > > whether the re-licensing may be considered retroactive (applicable to
+> > > older versions of DXPC); in case the answer is negative, DXPC
+> > > copyright owners should be persuaded to make the re-licensing
+> > > retroactive
+> > > 
+> > > (B) nx-libs-lite upstream developers re-fork from scratch, basing the
+> > > new code on a BSD-licensed version of DXPC (I suspect this may turn
+> > > out to be somewhat painful...)
+> > > 
+> > > 
+> > > Obviously, the optimal solution is (A). I hope it may work...
+> > > 
+> > > Thanks for your time and for your prompt and kind replies.
+> > 
+> > 
+> 
+
+
+
+
+From invernomuto@paranoici.org Tue May 12 21:42:01 2015
+Received: (at 784565) by bugs.debian.org; 12 May 2015 21:42:01 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-12.0 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,HAS_BUG_NUMBER,PGPSIGNATURE,SPF_HELO_PASS,
+	SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 15; hammy, 150; neutral, 119; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*UA:sk:x86_64-,
+	0.000-+--H*x:sk:x86_64-, 0.000-+--H*c:PGP-SHA256, 0.000-+--H*c:SignHturH,
+	0.000-+--H*c:pgp-signature
+Return-path: <invernomuto@paranoici.org>
+Received: from perdizione.investici.org ([94.23.50.208])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YsHw8-0008Hh-DT
+	for 784565@bugs.debian.org; Tue, 12 May 2015 21:42:01 +0000
+Received: from [94.23.50.208] (perdizione [94.23.50.208]) (Authenticated sender: invernomuto@paranoici.org) by localhost (Postfix) with ESMTPSA id 9E73512097E;
+	Tue, 12 May 2015 21:41:55 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=paranoici.org;
+	s=stigmate; t=1431466915;
+	bh=w0yVuJLtWq+0cj6zbjNb4THkJk0Xq3N9SMQ1+u0ZZnk=;
+	h=Date:From:To:Cc:Subject:In-Reply-To:References;
+	b=RRQcr33uMGnEaupGoWl0nXectE2hPbUghdie73/SnVp5Ax5QWxqK90ic5VPUE7RsN
+	 RsJ6HcYccQEzYLzm37W24u9eQZFa+Oc1CZaJBvFgOg9MAvh6tHaLUgOuFGkYXhn5R0
+	 Nlq5WHCpVKi9YvGfj/aAtfe84CJPt2HIKAqPXb5w=
+Received: from frx by homebrew with local (Exim 4.85)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YsHvP-00019Q-D1; Tue, 12 May 2015 23:41:15 +0200
+Date: Tue, 12 May 2015 23:40:48 +0200
+From: Francesco Poli <invernomuto@paranoici.org>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Cc: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org,
+ x2go-dev@lists.x2go.org, nito.martinez@qindel.com,
+ opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+Message-Id: <20150512234048.054319a449ffadcf87577425@paranoici.org>
+In-Reply-To: <1431445315.4712.7.camel@Nokia-N900>
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	<20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+	<20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+	<20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+	<55521444.9090407@vigor.nu>
+	<1431445315.4712.7.camel@Nokia-N900>
+X-Mailer: Sylpheed 3.5.0beta1 (GTK+ 2.24.25; x86_64-pc-linux-gnu)
+Mime-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pgp-signature";
+ micalg="PGP-SHA256";
+ boundary="Signature=_Tue__12_May_2015_23_40_48_+0200_KqpLAiCdvC+4zCCk"
+
+--Signature=_Tue__12_May_2015_23_40_48_+0200_KqpLAiCdvC+4zCCk
+Content-Type: text/plain; charset=US-ASCII
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+On Tue, 12 May 2015 17:41:55 +0200 Mike Gabriel wrote:
+
+> Hi Kevin,
+
+Hello Mike, hello Kevin, hello to all the other recipients.
+
+First of all, I wish to express my gratitude to Kevin for his prompt,
+kind and generous response.
+
+>=20
+> thanks for your feedback. Let us wait for Francesco, our expert on licens=
+e issues, and see what he thinks about your feedback.
+
+I think that this is an important first step to solve this issue for
+the best.
+Kevin Vigor is one of the copyright owners of the code that was forked
+before the re-licensing.
+We now know that he intended the re-licensing to be retroactive and
+this is really good.
+
+I think that now it would be useful to ascertain that the other
+copyright owners (Brian Pane, Zachary Vonler, Gian Filippo Pinzari) are
+also OK with this interpretation of the re-licensing operation.
+
+Maybe Kevin is able to dig the original conversations (assuming they
+were carried on by e-mail or similar archived means) or otherwise to
+get in touch with them and check? Or, alternatively, Kevin could help
+Mike to get in touch with them?
+
+I hope everything may be settled for the best soon.
+Thanks a lot to everyone involved.
+
+
+
+--=20
+ http://www.inventati.org/frx/
+ There's not a second to spare! To the laboratory!
+..................................................... Francesco Poli .
+ GnuPG key fpr =3D=3D CA01 1147 9CD2 EFDF FB82  3925 3E1C 27E1 1F69 BFFE
+
+--Signature=_Tue__12_May_2015_23_40_48_+0200_KqpLAiCdvC+4zCCk
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQIcBAEBCAAGBQJVUnNlAAoJED4cJ+Efab/+CBQP/33+SjLcIk2VZbjeeyCxhCAo
+kmgg9BDtqce1Dy22ONotywDNQ187suqlmkEa6yAAdglB0M3CYMFKSIsZHn2C0uGb
+B45HnzXE7PJd/j/WOXuCIvDe70iGJ7Ubk16DCjyRuKsF70cr2DcsbieiwZh8Wi4v
+GXNOxpm5Nv2bs1vQnRzYFc7GLWny3eCqcWF23XisqvxQecOHopoGWr9F6NuS5ymz
+NQ8Z7eanEPaqE86GYFIqJyt9Wcz+fM2r1d/IrNmYaTVBJPrqndQKnXJAViwYhtaM
+V8+CIKDuttcIYMto9dyE9+vr6wgtDyepVatQIHyVA2LpzR9jub8MGelXMdA7em3i
+/H3gz3H/tQti3T3HoHu+4CSAEWsXdtkHq2RWU9k3+HQuWB00z7WDr404xzs7k2Wg
+h6VR9c+VjV92KnMvDqWjE4VBYjrn6Ag5u/0Cf6HMx5RAGFNL8ROjOGbQSskfUogo
+GnWX2b8yLIe8ojg3AVowWV2oKVlWzsjZVHH9lp0M/lqGmnPVEJk0mh6DKbZPjK8O
+P2dpZ8IlSa18R2CvMWnf7HXKRR/s2ef7rUmBkT2sFnTwsT5PeDSU45/7ZuWbNIpw
+8/Y5q38c36Axeng1J0OCR8YX47dH0PubVnBzYEqoun3GucR1jifOiNzWLyM2ZxNe
+0JSSqn5ddFC8/iuGpFDI
+=ZqCl
+-----END PGP SIGNATURE-----
+
+--Signature=_Tue__12_May_2015_23_40_48_+0200_KqpLAiCdvC+4zCCk--
+
+
+
+From niels@thykier.net Wed May 13 16:04:21 2015
+Received: (at control) by bugs.debian.org; 13 May 2015 16:04:21 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-3.9 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,RCVD_IN_DNSWL_LOW,RCVD_IN_MSPIKE_H4,
+	RCVD_IN_MSPIKE_WL autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 6; hammy, 61; neutral, 18; spammy, 0.
+	spammytokens: hammytokens:0.000-+--H*u:devscripts, 0.000-+--H*u:bts,
+	0.000-+--H*UA:bts, 0.000-+--H*UA:devscripts, 0.000-+--H*MI:thykier
+Return-path: <niels@thykier.net>
+Received: from mailrelay11.public.one.com ([195.47.247.189])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <niels@thykier.net>)
+	id 1YsZ8u-0002Ch-RD
+	for control@bugs.debian.org; Wed, 13 May 2015 16:04:21 +0000
+X-HalOne-Cookie: 4652f81fa62fa9da4dd9249e7484054c41bc782d
+X-HalOne-ID: b22b9887-f989-11e4-950a-b82a72d06996
+DKIM-Signature: v=1; a=rsa-sha256; c=simple/simple;
+	d=thykier.net; s=20140924;
+	h=from:subject:date:message-id:to;
+	bh=EysymZxJFEX8N6fIBUIaFmFP7WdtVLf5PrmWzWVb22Y=;
+	b=Ur7nNbvtl3pu7O1YKIHwSM8MHIW+JPWJKM1GBE23FB4sLbENnBM2V0rmU5++qyolEv7hHAhvKkWFO
+	 lH4tbbHCyoYVdUE76nRT/1HEb5/X+pxjrsC1qTXWWXkekbuLNcDwIl0+WdVVEd5B4LYpW7igVWi4AH
+	 XncGXx/MNYDQvFiU=
+Received: from thykier.net (unknown [80.62.116.219])
+	by smtpfilter3.public.one.com (Halon Mail Gateway) with ESMTPSA
+	for <control@bugs.debian.org>; Wed, 13 May 2015 16:04:12 +0000 (GMT)
+Received: by thykier.net (Postfix, from userid 1000)
+	id 985EB4BB; Wed, 13 May 2015 18:04:10 +0200 (CEST)
+From: Niels Thykier <niels@thykier.net>
+To: control@bugs.debian.org
+Subject: tagging 784565
+Date: Wed, 13 May 2015 18:04:10 +0200
+User-Agent: devscripts bts/2.15.4
+Message-ID: <1431533050-371-bts-niels@thykier.net>
+Delivered-To: control@bugs.debian.org
+
+# distributable
+tags 784565 + jessie-ignore
+thanks
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Thu May 14 04:58:16 2015
+Received: (at 784565) by bugs.debian.org; 14 May 2015 04:58:16 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 22; hammy, 150; neutral, 339; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YslDr-0000NV-Ur
+	for 784565@bugs.debian.org; Thu, 14 May 2015 04:58:16 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id A03C82B5;
+	Thu, 14 May 2015 06:58:11 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id E89E93BD2E;
+	Thu, 14 May 2015 06:58:10 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id 5m6G8sqwjlfJ; Thu, 14 May 2015 06:58:10 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 5713E3BB3A;
+	Thu, 14 May 2015 06:58:10 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Thu, 14 May 2015 04:58:10 +0000
+Date: Thu, 14 May 2015 04:58:09 +0000
+Message-ID: <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Francesco Poli <invernomuto@paranoici.org>
+Cc: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org,
+ x2go-dev@lists.x2go.org, nito.martinez@qindel.com, opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are derived
+ from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+In-Reply-To: <20150512234048.054319a449ffadcf87577425@paranoici.org>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_SHoEHYV8bfary9lJHYP1lQ1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_SHoEHYV8bfary9lJHYP1lQ1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi all,
+
+there has been an off-list mail exchange between Francesco and Kevin=20=20
+(and=20me in Cc:) which I will quote at the end of this mail (as it was=20=
+=20
+not=20meant to be private and we should fully document the flow on this=20=
+=20
+issue).
+
+@Kevin:=20I will take you off this mail thread's Cc: field with my next=20=
+=20
+post.=20Feel free to follow-up via #784565 [1] on the Debian bug=20=20
+tracker.=20Thanks a lot for being so responsive and generous with=20=20
+providing=20information.
+
+On  Di 12 Mai 2015 23:40:48 CEST, Francesco Poli wrote:
+
+> On Tue, 12 May 2015 17:41:55 +0200 Mike Gabriel wrote:
+
+> I think that now it would be useful to ascertain that the other
+> copyright owners (Brian Pane, Zachary Vonler, Gian Filippo Pinzari) are
+> also OK with this interpretation of the re-licensing operation.
+
+As stated by Kevin, Gian Filippo worked/works on the NoMachine side. I=20=
+=20
+will=20include him in Cc:.
+
+For Brian Pane we also found and e-Mail address, for Zach Vonler, I=20=20
+will=20use the mail address provided in DXPC code (which might be=20=20
+outdated),=20but I think I actually have found his phone number on the=20=
+=20
+web,=20so if that mail address bounces I will give him a ring.
+
+> Maybe Kevin is able to dig the original conversations (assuming they
+> were carried on by e-mail or similar archived means) or otherwise to
+> get in touch with them and check? Or, alternatively, Kevin could help
+
+As stated in the forwarded messages below, Kevin was unable to dig out=20=
+=20
+any=20mails from backups. So we switch to plan B: contact Brian, Zach=20=20
+and=20Gian Filippo.
+
+> Mike to get in touch with them?
+
+I will do that.
+
+> I hope everything may be settled for the best soon.
+> Thanks a lot to everyone involved.
+
+/me, too.
+
+light+love
+Mike
+
+[1] http://bugs.debian.org/784565
+
+
+----- Weitergeleitete Nachricht von Kevin Vigor <kevin@vigor.nu> -----
+   Datum: Wed, 13 May 2015 09:01:27 -0600
+     Von: Kevin Vigor <kevin@vigor.nu>
+Betreff: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are=20=20
+derived=20from non-free code
+      An: Francesco Poli <invernomuto@paranoici.org>
+      Cc: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+
+On 05/12/15 15:40, Francesco Poli wrote:
+
+> Maybe Kevin is able to dig the original conversations (assuming they
+> were carried on by e-mail or similar archived means) or otherwise to
+> get in touch with them and check? Or, alternatively, Kevin could help
+> Mike to get in touch with them?
+
+I'm afraid I was not able to dig anything out of old backups last=20=20
+night.=20I still have a stack of CDs to look through, but don't hold=20=20
+your=20breath. Sorry about that.
+
+I have never had any contact with Zachary Vonler or Gian Filippo=20=20
+Pinzari,=20and have not spoken with Brian Pane in many years, so I have=20=
+=20
+no=20recent contact information for any of them. However, a quick google=20=
+=20
+turns=20up:
+
+https://www.linkedin.com/profile/view?id=3D728859
+http://www.brianp.net/contact/
+
+which is almost certainly the right Brian Pane (he was at CNet at the=20=20
+proper=20time).
+
+
+    Good luck,
+          Kevin
+
+----- Ende der weitergeleiteten Nachricht -----
+
+----- Weitergeleitete Nachricht von Francesco Poli=20=20
+<invernomuto@paranoici.org>=20-----
+   Datum: Wed, 13 May 2015 19:43:44 +0200
+     Von: Francesco Poli <invernomuto@paranoici.org>
+Betreff: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are=20=20
+derived=20from non-free code
+      An: Kevin Vigor <kevin@vigor.nu>
+      Cc: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+
+On Wed, 13 May 2015 09:01:27 -0600 Kevin Vigor wrote:
+
+> On 05/12/15 15:40, Francesco Poli wrote:
+>
+> > Maybe Kevin is able to dig the original conversations (assuming they
+> > were carried on by e-mail or similar archived means) or otherwise to
+> > get in touch with them and check? Or, alternatively, Kevin could help
+> > Mike to get in touch with them?
+>
+> I'm afraid I was not able to dig anything out of old backups last=20=20
+>=20night. I still have a stack of CDs to look through, but don't hold=20=
+=20
+>=20your breath. Sorry about that.
+
+Thanks a lot for searching: this is really appreciated, at least from
+my side.
+
+>
+> I have never had any contact with Zachary Vonler or Gian Filippo Pinzari,
+
+Then I wonder how it was possible to re-license DXPC in 2002...
+:-|
+
+> and have not spoken with Brian Pane in many years, so I have no recent
+contact information for any of them. However, a quick google turns up:
+>
+> https://www.linkedin.com/profile/view?id=3D728859
+> http://www.brianp.net/contact/
+>
+> which is almost certainly the right Brian Pane (he was at CNet at=20=20
+>=20the proper time).
+
+This could be really useful, thank you very much!
+
+Mike, I hope the search may go on from there: Brian should be asked
+about the retroactive nature of the re-licensing of DXPC and maybe he
+also knows how to get in touch with Zachary and/or Gian Filippo...
+
+
+P.S.: Kevin, any special reason why you dropped several addresses from
+the Cc list? Should this part of our conversation be kept private for
+the time being? Please clarify. Thanks!
+
+----- Ende der weitergeleiteten Nachricht -----
+
+----- Weitergeleitete Nachricht von Kevin Vigor <kevin@vigor.nu> -----
+   Datum: Wed, 13 May 2015 14:08:48 -0600
+     Von: Kevin Vigor <kevin@vigor.nu>
+Betreff: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are=20=20
+derived=20from non-free code
+      An: Francesco Poli <invernomuto@paranoici.org>
+      Cc: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+
+On 05/13/15 11:43, Francesco Poli wrote:
+> On Wed, 13 May 2015 09:01:27 -0600 Kevin Vigor wrote:
+
+>> I have never had any contact with Zachary Vonler or Gian Filippo Pinzari=
+,
+>
+> Then I wonder how it was possible to re-license DXPC in 2002...
+> :-|
+>
+
+I believe Gian worked on the NoMachine code; he has never contributed=20=20
+to=20DXPC directly.
+
+Zachary Vonler was allegedly the maintainer of DXPC for a while circa=20=20
+1999,=20but never responded to any email when I attempted to contact=20=20
+him,=20which is how I came to take over maintenance.
+
+
+> P.S.: Kevin, any special reason why you dropped several addresses from
+> the Cc list? Should this part of our conversation be kept private for
+> the time being? Please clarify. Thanks!
+
+No, I was just trying to keep from spamming email lists unnecessarily.=20=
+=20
+I=20do not consider any part of this conversation private.
+
+----- Ende der weitergeleiteten Nachricht -----
+
+----- Weitergeleitete Nachricht von Francesco Poli=20=20
+<invernomuto@paranoici.org>=20-----
+   Datum: Wed, 13 May 2015 22:50:32 +0200
+     Von: Francesco Poli <invernomuto@paranoici.org>
+Betreff: Re: [pkg-x2go-devel] Bug#784565: nx-libs-lite: parts are=20=20
+derived=20from non-free code
+      An: Kevin Vigor <kevin@vigor.nu>
+      Cc: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+
+On Wed, 13 May 2015 14:08:48 -0600 Kevin Vigor wrote:
+
+> On 05/13/15 11:43, Francesco Poli wrote:
+> > On Wed, 13 May 2015 09:01:27 -0600 Kevin Vigor wrote:
+>
+> >> I have never had any contact with Zachary Vonler or Gian Filippo Pinza=
+ri,
+> >
+> > Then I wonder how it was possible to re-license DXPC in 2002...
+> > :-|
+> >
+>
+> I believe Gian worked on the NoMachine code; he has never=20=20
+>=20contributed to DXPC directly.
+
+Good, then only Zachary has to be tracked down.
+
+>
+> Zachary Vonler was allegedly the maintainer of DXPC for a while=20=20
+>=20circa 1999, but never responded to any email when I attempted to=20=20
+>=20contact him, which is how I came to take over maintenance.
+
+Let's hope Brian is able to help Mike in getting in touch with
+Zachary...
+
+>
+>
+> > P.S.: Kevin, any special reason why you dropped several addresses from
+> > the Cc list? Should this part of our conversation be kept private for
+> > the time being? Please clarify. Thanks!
+>
+> No, I was just trying to keep from spamming email lists=20=20
+>=20unnecessarily. I do not consider any part of this conversation=20=20
+>=20private.
+>
+
+OK, thanks for clarifying.
+
+----- Ende der weitergeleiteten Nachricht -----
+
+--=20
+
+DAS-NETZWERKTEAM
+mike gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_SHoEHYV8bfary9lJHYP1lQ1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVVCthAAoJEJr0azAldxsx3KUP/2997X9KnhVEedREGxsuqvQn
+Dp5oGK2JPf0Z2MZui1FVehvakoHQD0MuhpVs7ZktnshwNvAgxyhW5esC617a9gsz
+jJvaJz0S0MPHfSM4Dz8Yg2t0u0DpueVZBpOeDOlt9W9ECXkpe2YPk5AOialHwTPX
+OP5KKfMSLEGFreUL7U0WeetC/To5zm54Ivx1a0wx2I+HdPJ0YXTxIC7JvUSNejFE
+0+yhK1thXf38juOeb2pxTvRQXcj1IoDMRSc0k7KHeNGmP1NF38fh1illPlBABG1u
+wa3hn+1uMe3+On8LJkDtIHtsXrR2RUuOP+0FbI4rTRo5SOeVFNRSl1ldp2ywl8rQ
+9WkK623cuurOydsHjj+fIlcb7GN/OgrTay8VRS3jUjy9tlQ7PCpF5W1m7kMPHrCP
+nh6/hUa6ep8qE+86dosQS4FxvOgSHOEpbNZ8ulEib/ClHr9wsnWpjxQtvRnZsBTl
+PAIXKvdiHUCgyfs4efSWYtR8QUJTYmPDrGr2V8jWAtzZOo6NSa09c2Yc2OxLRDpP
+HBGVSLUOrocvbb3wPAgnsogxtYCpzo/ga1Rnx2LdIfLNaTv62sek+nHqJzICqtcH
+SdMajeJTVksKQCmHqIQS7C2V44cDYizTe9exZIl75OKT6TDujuW/KZiPQK6VCCNv
+eEgOxmCOHlc8YLLz0dEP
+=N9IW
+-----END PGP SIGNATURE-----
+
+--=_SHoEHYV8bfary9lJHYP1lQ1--
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Thu May 14 05:55:46 2015
+Received: (at 784565) by bugs.debian.org; 14 May 2015 05:55:46 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 23; hammy, 150; neutral, 392; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1Ysm7W-0005fv-3I
+	for 784565@bugs.debian.org; Thu, 14 May 2015 05:55:46 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id BDB433282;
+	Thu, 14 May 2015 07:55:43 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 20DC03BD2E;
+	Thu, 14 May 2015 07:55:43 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id 3Dt4TKuxIMPh; Thu, 14 May 2015 07:55:43 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 871AB3B9EA;
+	Thu, 14 May 2015 07:55:42 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Thu, 14 May 2015 05:55:42 +0000
+Date: Thu, 14 May 2015 05:55:42 +0000
+Message-ID: <20150514055542.Horde.LWDaJ7sgQHr-LCJySXbtvQ3@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Zach Vonler <lightborn@mail.utexas.edu>, Brian Pane <brianp@brianp.net>,
+ Gian Filippo Pinzari <pinzari@nomachine.com>
+Cc: nito.martinez@qindel.com, x2go-dev@lists.x2go.org,
+ opensource@gznianguan.com, 784565@bugs.debian.org, Francesco Poli
+ <invernomuto@paranoici.org>
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+In-Reply-To: <20150512234048.054319a449ffadcf87577425@paranoici.org>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_whjzG6t3RqUoHnRlD0aGiA1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_whjzG6t3RqUoHnRlD0aGiA1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Dear Brian, dear Zachary, dear Gian Filippo,
+
+(Find a TL;DR; at the end of this mail...)
+
+I am contacting you on a licensing issue related to the DXPC code that=20=
+=20
+you=20worked on at the end of the nineties. I'd highly appreciate it if=20=
+=20
+you=20could take a little time to read this mail and get back to me,=20=20
+either=20privately or in public.
+[I have actually Cc:ed quite a number of people in this mail (thread).=20=
+=20
+All=20of them will be affected by the outcome of this license issue to=20=
+=20
+some=20lesser or greater extent. If you feel inconvenient with replying=20=
+=20
+to=20so many people you don't know, really don't hesitate to get back to=20=
+=20
+me=20in private first, so that we can sort things out. Thank you.]
+
+Before I continue, let me shortly introduce myself. My name is Mike=20=20
+Gabriel,=20I work for the Debian project [1.1, 1.2] (which brings forth=20=
+=20
+one=20of the major GNU/Linux distributions world-wide. I am also the=20=20
+upstream=20code maintainer of a software project called nx-libs [2]. The=20=
+=20
+nx-libs=20code has been derived from several of NoMachine's NXv3 [11]=20=20
+components=20(namely: nx-X11, nxagent, nxcomp, nxcompext and nxcompshad).
+
+A member of the Debian legal team [3] (Francesco Poli) made us (i.e.,=20=20
+the=20nx-libs developers, users, package maintainers) aware of an issue=20=
+=20
+[4]=20in the nx-libs component NXCOMP (which has been derived from DXPC=20=
+=20
+[5]).=20Please read Message #5 of the brought up issue on the Debian bug=20=
+=20
+tracker=20(#784565) [4] before you continue reading. Thanks.
+
+I will now jump into the below quoted mail and continue inline...
+
+On  Di 12 Mai 2015 23:40:48 CEST, Francesco Poli wrote:
+
+> On Tue, 12 May 2015 17:41:55 +0200 Mike Gabriel wrote:
+>
+>> Hi Kevin,
+>
+> Hello Mike, hello Kevin, hello to all the other recipients.
+>
+> First of all, I wish to express my gratitude to Kevin for his prompt,
+> kind and generous response.
+
+>> thanks for your feedback. Let us wait for Francesco, our expert on=20=20
+>>=20license issues, and see what he thinks about your feedback.
+>
+> I think that this is an important first step to solve this issue for
+> the best.
+> Kevin Vigor is one of the copyright owners of the code that was forked
+> before the re-licensing.
+> We now know that he intended the re-licensing to be retroactive and
+> this is really good.
+
+We are currently in the process of contacting all DXPC related=20=20
+copyright=20holders mentioned in the NXCOMP license file [6]. We already=20=
+=20
+received=20some feedback from Kevin Vigor [7], but we also need to=20=20
+address=20you (Brian, Zachary, Gian Filippo) with this. (The mail=20=20
+address=20I have from Zachary may be outdated, so any current contact=20=20
+address=20is highly welcome, in case the mail address being used will=20=20
+bounce=20back).
+
+At the moment, NXCOMP (and thus nx-libs, but also NoMachine's NXv3=20=20
+code)=20cannot be considered as fully free software, until this issue is=20=
+=20
+settled.=20The DXPC license before DXPC v3.8.1 was an ancient BSD style=20=
+=20
+license=20that failed in explicitly mentioning, that it is allowed to=20=20
+modify=20the DXPC code in derivative works. In 2002, DXPC 3.8.1 got=20=20
+released=20[12], using a more compliant license (BSD-2-clause). As Kevin=20=
+=20
+told=20us, this license change [8,9] was done after the FSF [10] had=20=20
+contacted=20the DXPC developers.
+
+However, the NXCOMP code in NXv3 got forked from DXPC before 2002, as=20=20
+it=20seems. So unfortunately, the modifications of DXPC as found in=20=20
+NoMachine's=20NXCOMP product are not compliant with the pre-3.8.1=20=20
+license=20of DXPC.
+
+> I think that now it would be useful to ascertain that the other
+> copyright owners (Brian Pane, Zachary Vonler, Gian Filippo Pinzari) are
+> also OK with this interpretation of the re-licensing operation.
+
+TL;DR; So here comes my actual question: are you (Brian Pane, Zachary=20=20
+Vonler,=20Gian Filippo Pinzari) ok with retroactively regarding=20=20
+pre-3.8.1=20code of DXPC (that you probably all worked on at that time)=20=
+=20
+as=20BSD-2-clause? Are you ok with others having taken or taking the=20=20
+pre-3.8.1=20DXPC code and distribute it in a modified form?
+
+A yes from all of you as DXPC copyright holders is essential for the=20=20
+continuation=20of nx-libs development under a free license. This may=20=20
+also=20possibly be an issue for NXv4 in case parts of it have been=20=20
+derived=20from DXPC.
+
+Thanks to all of you for taking your time.
+
+light+love
+Mike
+
+[1.1] http://www.debian.org
+[1.2] https://qa.debian.org/developer.php?login=3Dsunweaver%40debian.org
+[2] https://github.com/ArcticaProject/nx-libs
+[3] https://www.debian.org/legal/
+[4] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=3D784565#5
+[5] http://www.vigor.nu/dxpc/
+[6] https://github.com/ArcticaProject/nx-libs/blob/3.6.x/nxcomp/LICENSE#L32
+[7] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=3D784565#40
+[8] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=3D72020
+[9] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=3D142028
+[10] http://www.fsf.org/
+[11] https://www.nomachine.com/version-3
+[12] http://www.vigor.nu/dxpc/CHANGES
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_whjzG6t3RqUoHnRlD0aGiA1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVVDjeAAoJEJr0azAldxsx1JUP/RdzhmQ3HU+6x479AoGBTKxV
+onR3XPlq8Iw9f6dU0TjqlAHCOGeftJ+X7A3HamiTFsr5wUqlrTuKeYnVd4hTa08e
+ge9WIODczQfnoHm47siTjlMfQuHFIGDnHuJ+3GbvojMI7QXWrM9wgxGo2B/2UUQS
+tFlYPbvfAGhCyUVx/zLRFqDVzzdo+UCVoLLYKE1pkwjhpnGGamY1xd/KFjCgi0Vx
+f/Nx9w28EqmRFZCTmxghLngkTlQwrtBkSUAhLS3ntxV12RrrQQ2verXPWbW1DU9C
+3TZypNZSMc4O8etJ244YUk7wAvspUtJnXyvxoQ2Padw0ogGFayIdLtC8HStCy+Mx
+Q/FIND8+aGdYALNTbQfTCpJ1fmg06Id4hn96rdZOhpT80M3vTuY9HpIyf2dDCdHu
+OmHEjUKnMRgjPbVoIU5lz8s4X/ET7hzxb2psXSwscxI+qqlSrADzC98QB23djJii
+O9qPVB/HqJXwNNXlwiScrLC/q4ro0QgdurKmIDQq1zjdFXyBDEwMzxLNlVSJiEeG
+gMSiXD9lD8J1KBDp35P4wxmOcCSymILU11Lpvf5N22ID7cfk8x58+Fsik+RkQZcm
+94ll8p4XU0xOt8pgzGOVL4rLBsjcPGzuTjUoDsB8zmZLSgEgrISZNQC7pRhEXTRW
+3g7fQuF635IMObwgVJJB
+=c1td
+-----END PGP SIGNATURE-----
+
+--=_whjzG6t3RqUoHnRlD0aGiA1--
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Thu May 14 06:20:24 2015
+Received: (at 784565) by bugs.debian.org; 14 May 2015 06:20:24 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 15; hammy, 149; neutral, 94; spammy,
+	1. spammytokens:0.997-1--sk:austin. hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YsmVL-0008TY-AE
+	for 784565@bugs.debian.org; Thu, 14 May 2015 06:20:24 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id AA82B3282;
+	Thu, 14 May 2015 08:20:19 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id A8B823BD2E;
+	Thu, 14 May 2015 08:20:18 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id LyPILriO4mkm; Thu, 14 May 2015 08:20:18 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 4BB463BB3A;
+	Thu, 14 May 2015 08:20:18 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Thu, 14 May 2015 06:20:18 +0000
+Date: Thu, 14 May 2015 06:20:18 +0000
+Message-ID: <20150514062018.Horde.T6fBfDEHTv_IkVi4n506ew5@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Brian Pane <brianp@brianp.net>, Gian Filippo Pinzari
+ <pinzari@nomachine.com>
+Cc: opensource@gznianguan.com, 784565@bugs.debian.org,
+ nito.martinez@qindel.com, Francesco Poli <invernomuto@paranoici.org>,
+ x2go-dev@lists.x2go.org
+Subject: Re: [X2Go-Dev] [pkg-x2go-devel] Bug#784565: Bug#784565:
+ nx-libs-lite: parts are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+ <20150514055542.Horde.LWDaJ7sgQHr-LCJySXbtvQ3@mail.das-netzwerkteam.de>
+In-Reply-To: <20150514055542.Horde.LWDaJ7sgQHr-LCJySXbtvQ3@mail.das-netzwerkteam.de>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_FXxC2VoubfzELdkXQu84zQ1";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_FXxC2VoubfzELdkXQu84zQ1
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi again,
+
+On  Do 14 Mai 2015 07:55:42 CEST, Mike Gabriel wrote:
+
+> [...] (The mail address I have from Zachary may be outdated, so any=20=20
+>=20current contact address is highly welcome, in case the mail address=20=
+=20
+>=20being used will bounce back).
+
+As it seems, the publicly known mail address of Zachary Vonler at=20=20
+austin.utexas.edu=20is outdated.
+
+@Brian: if you happen to have a recent mail address of Zachary, could=20=20
+you=20please provide it to me privately? Thanks.
+
+Mike
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_FXxC2VoubfzELdkXQu84zQ1
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVVD6iAAoJEJr0azAldxsx4+8QAI9fbkDu0G/1NpC4+MDJ3HtH
+wzfUUIIoBAPTahr1ZGrGK4ZMH5+RvXtwX2OBTwRRgKlZOqsdU35bj2HKi01KNLGx
+9NXXnLz97CuTrXJrzis3C+pzCIpR6cR/SPhDdExdhjR8nawXcejfFhPUnbVvPvxY
+jYN43cYFScovk5f5bUtIAybVZZCpdRZwDRevD+1qTTs+WtDf/9PXL7CX9A7j7r6T
+XQIURSVQq/FVXcJHSdZcYZza/4JHIZbEQTeX3FaUK+zkdHlBbbmRwzN0YLP/XQiY
+06tQXFjgjqjjkoxTE5gQrlN3kyxNH2WpXj2eeAqQarkCOnKgiuFEYxhTCYnZHCmk
+WVYhb2/78VbRlRbDJH0jJ0KKNOi9fbXGcVa36IOgV2dLN+tnNorAQjHm7LkBDhyi
+c3EmzEPtDTmcb5XuPYwwbNGn2EE47UsTx3UjPFWAQVQ2LwMXoFb+iH+WWSQ8KW1b
+xKRDOtarACd06rbW/sKQVdzNytydvFkZZn//AHHA7KP7jmqhl/bub8EyEf9cCTVr
+92XB5bbI1rLfEo1D3FTUaCt1tUEumhgRzwlJteX5/vbpf0fJ3QcWMUQSQWYqbhEm
+LnlGOM44jZDtQ7QonezcB/+lQDu2/0Q7fZtgqtr9bxkJ5URr8/ByTI+E3K2bxdme
+jQAQL6yyRC5s419MIJTr
+=6/Dc
+-----END PGP SIGNATURE-----
+
+--=_FXxC2VoubfzELdkXQu84zQ1--
+
+
+
+
+From mike.gabriel@das-netzwerkteam.de Sat May 16 09:19:18 2015
+Received: (at 784565) by bugs.debian.org; 16 May 2015 09:19:18 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-10.9 required=4.0 tests=BAYES_00,DIGITS_LETTERS,
+	FOURLA,HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 31; hammy, 150; neutral, 208; spammy,
+	0. spammytokens: hammytokens:0.000-+--tarballs, 0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YtYFZ-0006BP-Mo
+	for 784565@bugs.debian.org; Sat, 16 May 2015 09:19:18 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 434CF3D4F;
+	Sat, 16 May 2015 11:19:13 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 9294C3BB55;
+	Sat, 16 May 2015 11:19:12 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id a-GW73-71I6N; Sat, 16 May 2015 11:19:12 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 224123BB3B;
+	Sat, 16 May 2015 11:19:12 +0200 (CEST)
+Received: from 176.4.79.4 ([176.4.79.4]) by mail.das-netzwerkteam.de (Horde
+ Framework) with HTTP; Sat, 16 May 2015 09:19:12 +0000
+Date: Sat, 16 May 2015 09:19:12 +0000
+Message-ID: <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: 784565@bugs.debian.org, Francesco Poli <invernomuto@paranoici.org>
+Cc: Kevin Vigor <kevin@vigor.nu>, nito.martinez@qindel.com,
+ x2go-dev@lists.x2go.org, opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+ <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+In-Reply-To: <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 176.4.79.4
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_n6jEwcfiXkrvf2B-ZGaJrw3";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_n6jEwcfiXkrvf2B-ZGaJrw3
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi all, esp. Kevin,
+
+On  Do 14 Mai 2015 06:58:09 CEST, Mike Gabriel wrote:
+
+I looked at dxpc releases (I obtained upstream tarballs from=20=20
+snapshot.debian.org).
+
+I=20currently have:
+
+"""
+[mike@minobo dxpc.nxrebase (upstream-nxrebase)]$ git log
+commit 0676a768a96383641a73a72ecd2e1083322e6abe
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:52:24 2015 +0200
+
+     Imported Upstream version 3.9.2
+
+commit 4ccf34b2c4763dfb01dceb8588b204b0d029cc3d
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:51:04 2015 +0200
+
+     Imported Upstream version 3.9.1
+
+commit dd8f60ce63c70ed605a2e1717feb7128e59fb8e6
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:49:19 2015 +0200
+
+     Imported Upstream version 3.9.0
+
+commit 01c990099aea802405f8d39c0b819ee1742c185c
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:32:06 2015 +0200
+
+     Imported Upstream version 3.8.2
+
+commit 48df60b3b946a08541ee48371634f074e875adda
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:31:57 2015 +0200
+
+     Imported Upstream version 3.8.0
+
+commit 11d81444d0f86a67f9b8483cbfa33343714b26e9
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:31:53 2015 +0200
+
+     Imported Upstream version 3.7.0
+
+commit e4f550abd4cd49ecc2381e717a55a9940087a376
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date:   Sat May 16 10:31:44 2015 +0200
+
+     Imported Upstream version 3.5.0
+"""
+
+> @Kevin: I will take you off this mail thread's Cc: field with my=20=20
+>=20next post. Feel free to follow-up via #784565 [1] on the Debian bug=20=
+=20
+>=20tracker. Thanks a lot for being so responsive and generous with=20=20
+>=20providing information.
+
+With this post I actually reincluded you because it becomes technical=20=20
+from=20here on and I probably will need your expertise on DXPC. Not sure=20=
+=20
+if=20you have time or prio or are willing to provide that. Would you be=20=
+=20
+open=20for answering technical questions on DXPC and esp. the changes=20=20
+between=203.7.0 and 3.8.1/3.8.2? I'd highly appreciate that.
+
+As I have not heard back neither from Brian Pane, Zachary Vonler nor=20=20
+Gian=20Filippo Pinzari (we had Ascension Day and maybe a prolonged=20=20
+weekend=20that people used for going on VAC), I will try looking at the=20=
+=20
+DXPC=20changes between 3.7.0 and 3.8.1. Obviously, NoMachine forked=20=20
+NXCOMP=20from DXPC some time between DXPC 3.7.0 and DXPC 3.8.0.
+
+Questions to Kevin:
+
+   o Is there any SVN upstream repo still online
+     (I saw it in one of the tarballs, that SVN was
+     used for 3.9.0).
+   o Do you have any tarballs documenting the
+     changes between 3.7.0 and 3.8.0? Do you also
+     have the 3.8.1 tarball?
+   o Did the 3.8.0 version of DXPC break proto
+     compatibility (i.e., you could not use client
+     3.7.0 and server 3.8.0 and vice versa with
+     each other)?
+
+Any help on this is appreciated. Thanks.
+
+Mike
+
+
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_n6jEwcfiXkrvf2B-ZGaJrw3
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVVwuPAAoJEJr0azAldxsxAqoQAI1IOApnU8WLZH+VT1GIgtvx
+XxuBALPeR8KobmGRfJd4bSzeIpAqw+JSGa0/XApTwjYbpsIUKnMrEfoHfS0wt4Tb
+ZmSiHL4XCYa6SCGOAbSe89QXNA8kS4ewQMSaPTZhGvoR6wIjdNfxXDN5aO6TkUlw
+qw786fMKYcj9htNnshlq264uSfkrMusFEw614dnfKEVnx8YrIUU5lNY9AInShO9S
+K0vy1vn53/Ie5Fec1FK0WUsT4xTu7NW80Ch0+IgopURIl9NmlomJVRwoDLbR47Ox
+6dFVGJ5VKmOt+oW2g4YAdti8YNhSYteyPgTAPMdtU4XqkHV5/RepCoV/6gr3/YR1
+To63WGpt2B+jl2d4OAPuWWdTRucB2QYsCz/jCvLKeLcg2ODHZJXhSzVYlIie0uFY
+SRvqM8qW+WyuYek2vZDneKvDB2eUqMhRb5dmSeod9UR+3RYTq+JrFUoDq65PONbM
+A0QZ+cG0EkQdxG/1V8yZoMRgxPOtb+AZcMIjC5NikWUsyIkGjMHNHSbJCboJBlyM
+DdyRCTxuM09cpzNxS7Ph0z0iSdQZAl2D7vPCAY1jwyLdu7Xra/p3aM6pqeYuIaWh
+OpoF/sRq08CjWmgVe7MdfkgxZQxW4qIdOeNYGUDIADzzj6cHdNV+WP13ISizeoyO
+u4cspyl/6lFu3TyMWkh8
+=fu9u
+-----END PGP SIGNATURE-----
+
+--=_n6jEwcfiXkrvf2B-ZGaJrw3--
+
+
+
+
+From zvonler@gmail.com Mon May 18 15:05:45 2015
+Received: (at 784565) by bugs.debian.org; 18 May 2015 15:05:46 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-5.3 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,FREEMAIL_FROM,HAS_BUG_NUMBER,HTML_MESSAGE,
+	MULTALT,RCVD_IN_DNSWL_LOW,RCVD_IN_MSPIKE_H3,RCVD_IN_MSPIKE_WL,SPF_PASS
+	autolearn=ham autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 14; hammy, 104; neutral, 41; spammy,
+	1. spammytokens:0.940-+--H*c:alternative
+	hammytokens:0.000-+--D*das-netzwerkteam.de, 0.000-+--sk:mikega,
+	0.000-+--sk:mike.ga, 0.000-+--U*mike.gabriel,
+	0.000-+--mike.gabriel@das-netzwerkteam.de
+Return-path: <zvonler@gmail.com>
+Received: from mail-ob0-f181.google.com ([209.85.214.181])
+	by buxtehude.debian.org with esmtps (TLS1.2:RSA_ARCFOUR_SHA1:128)
+	(Exim 4.80)
+	(envelope-from <zvonler@gmail.com>)
+	id 1YuMbx-0004SF-RZ
+	for 784565@bugs.debian.org; Mon, 18 May 2015 15:05:45 +0000
+Received: by obblk2 with SMTP id lk2so127830096obb.0
+        for <784565@bugs.debian.org>; Mon, 18 May 2015 08:05:39 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20120113;
+        h=mime-version:date:message-id:subject:from:to:content-type;
+        bh=nHgAzYNhWTJXAXb1d3jfmZVOFHEEaolqyRCNmCThusM=;
+        b=ilsboi8m+iXF7pVv2MVsvJqi8Es4/o3Awnfg5nSzWVB34kDB0g7zczoEfC4d9km/Bn
+         WDerLV30mJ+OfaRA5elHld2CsY9ByX2MuU73jj2kNenlEV15s7LdJxYsWiZeKM4AEeOw
+         gGF3oU3A/FfhVUrhoPjcGXiF7xjXh1kkPGjkmXFJgthTnyJQjrL6Kw6jfsqhQtbEpqnc
+         5hsWFCNR7O780T1pkf+MisASrWFXI3oolY4EV8/P6OeEWmmKd7L9h8YHPegOdFq543qZ
+         na9coEvmwpnReWORK79ycOgZa1DwiX1h2SvS+wgigQx8j9ZlJld5SpJFTcV3vSJxmICQ
+         i7Wg==
+MIME-Version: 1.0
+X-Received: by 10.202.89.131 with SMTP id n125mr19222614oib.91.1431961538959;
+ Mon, 18 May 2015 08:05:38 -0700 (PDT)
+Received: by 10.202.212.10 with HTTP; Mon, 18 May 2015 08:05:38 -0700 (PDT)
+Date: Mon, 18 May 2015 10:05:38 -0500
+Message-ID: <CAAnzQj-6Tgiar-GOxXx9FXU21cU4Be05Yo3zUSgr094sYXZP+w@mail.gmail.com>
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts are
+ derived from non-free code
+From: Zach Vonler <zvonler@gmail.com>
+To: 784565@bugs.debian.org
+Content-Type: multipart/alternative; boundary=001a113d381edcb3e205165c863b
+
+--001a113d381edcb3e205165c863b
+Content-Type: text/plain; charset=UTF-8
+
+On Thu, 14 May 2015 05:55:42 +0000 Mike Gabriel <
+mike.gabriel@das-netzwerkteam.de> wrote:
+
+>
+> TL;DR; So here comes my actual question: are you (Brian Pane, Zachary
+> Vonler, Gian Filippo Pinzari) ok with retroactively regarding
+> pre-3.8.1 code of DXPC (that you probably all worked on at that time)
+> as BSD-2-clause? Are you ok with others having taken or taking the
+> pre-3.8.1 DXPC code and distribute it in a modified form?
+>
+
+
+> A yes from all of you as DXPC copyright holders is essential for the
+> continuation of nx-libs development under a free license. This may
+> also possibly be an issue for NXv4 in case parts of it have been
+> derived from DXPC.
+
+
+Yes, I am fine with considering the license change to be retroactive to
+cover the time I was the maintainer.
+
+I have no objections to others distributing modified versions of that code.
+
+Zach
+
+--001a113d381edcb3e205165c863b
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">On Thu, 14 May 2015 05:55:42 +0000 Mike Gabriel &lt;<a hre=
+f=3D"mailto:mike.gabriel@das-netzwerkteam.de">mike.gabriel@das-netzwerkteam=
+.de</a>&gt; wrote:<br><div><blockquote class=3D"gmail_quote" style=3D"margi=
+n:0px 0px 0px 0.8ex;border-left-width:1px;border-left-color:rgb(204,204,204=
+);border-left-style:solid;padding-left:1ex"><br>TL;DR; So here comes my act=
+ual question: are you (Brian Pane, Zachary =C2=A0<br>Vonler, Gian Filippo P=
+inzari) ok with retroactively regarding =C2=A0<br>pre-3.8.1 code of DXPC (t=
+hat you probably all worked on at that time) =C2=A0<br>as BSD-2-clause? Are=
+ you ok with others having taken or taking the =C2=A0<br>pre-3.8.1 DXPC cod=
+e and distribute it in a modified form?<br></blockquote><div>=C2=A0</div><b=
+lockquote class=3D"gmail_quote" style=3D"margin:0px 0px 0px 0.8ex;border-le=
+ft-width:1px;border-left-color:rgb(204,204,204);border-left-style:solid;pad=
+ding-left:1ex">A yes from all of you as DXPC copyright holders is essential=
+ for the =C2=A0<br>continuation of nx-libs development under a free license=
+. This may =C2=A0<br>also possibly be an issue for NXv4 in case parts of it=
+ have been =C2=A0<br>derived from DXPC.</blockquote><div>=C2=A0</div></div>=
+<div>Yes, I am fine with considering the license change to be retroactive t=
+o cover the time I was the maintainer.</div><div><br></div><div>I have no o=
+bjections to others distributing modified versions of that code.</div><div>=
+<br></div><div>Zach</div></div>
+
+--001a113d381edcb3e205165c863b--
+
+
+
+From kevin@vigor.nu Mon May 18 21:26:12 2015
+Received: (at 784565) by bugs.debian.org; 18 May 2015 21:26:12 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-8.0 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,RCVD_IN_DNSWL_NONE,RCVD_IN_MSPIKE_H2,SPF_PASS autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 16; hammy, 150; neutral, 121; spammy,
+	0. spammytokens: hammytokens:0.000-+--tarballs, 0.000-+--H*f:sk:2015050,
+	0.000-+--3.9.0, 0.000-+--3.8.0, 0.000-+--H*UA:31.0
+Return-path: <kevin@vigor.nu>
+Received: from gateway13.websitewelcome.com ([69.56.148.12])
+	by buxtehude.debian.org with esmtps (TLS1.0:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuSY8-0004Mq-9I
+	for 784565@bugs.debian.org; Mon, 18 May 2015 21:26:12 +0000
+Received: by gateway13.websitewelcome.com (Postfix, from userid 5007)
+	id 248D59C09927E; Mon, 18 May 2015 15:38:28 -0500 (CDT)
+Received: from gator4058.hostgator.com (gator4058.hostgator.com [192.185.4.69])
+	by gateway13.websitewelcome.com (Postfix) with ESMTP id 1EB399C099246
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 15:38:28 -0500 (CDT)
+Received: from [63.158.132.10] (port=43192 helo=[10.50.3.84])
+	by gator4058.hostgator.com with esmtpsa (UNKNOWN:DHE-RSA-AES128-SHA:128)
+	(Exim 4.82)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuRnv-0001VU-8i; Mon, 18 May 2015 15:38:27 -0500
+Message-ID: <555A4DC1.2040900@vigor.nu>
+Date: Mon, 18 May 2015 14:38:25 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Thunderbird/31.5.0
+MIME-Version: 1.0
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>, 
+ 784565@bugs.debian.org, Francesco Poli <invernomuto@paranoici.org>
+CC: nito.martinez@qindel.com, x2go-dev@lists.x2go.org, 
+ opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew> <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de> <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org> <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de> <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900> <20150512234048.054319a449ffadcf87577425@paranoici.org> <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de> <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+In-Reply-To: <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Transfer-Encoding: 7bit
+X-AntiAbuse: This header was added to track abuse, please include it with any abuse report
+X-AntiAbuse: Primary Hostname - gator4058.hostgator.com
+X-AntiAbuse: Original Domain - bugs.debian.org
+X-AntiAbuse: Originator/Caller UID/GID - [47 12] / [47 12]
+X-AntiAbuse: Sender Address Domain - vigor.nu
+X-BWhitelist: no
+X-Source-IP: 63.158.132.10
+X-Exim-ID: 1YuRnv-0001VU-8i
+X-Source: 
+X-Source-Args: 
+X-Source-Dir: 
+X-Source-Sender: ([10.50.3.84]) [63.158.132.10]:43192
+X-Source-Auth: kevin@vigor.nu
+X-Email-Count: 2
+X-Source-Cap: a3ZpZ29yO2t2aWdvcjtnYXRvcjQwNTguaG9zdGdhdG9yLmNvbQ==
+X-Greylist: delayed 1495 seconds by postgrey-1.34 at buxtehude; Mon, 18 May 2015 21:26:12 UTC
+
+On 05/16/15 03:19, Mike Gabriel wrote:
+  As I have not heard back neither from Brian Pane, Zachary Vonler nor Gian Filippo Pinzari (we had Ascension Day and maybe a prolonged weekend that people used for going on VAC), I will try looking at the DXPC changes between 3.7.0 and 3.8.1. Obviously, NoMachine forked NXCOMP from DXPC some time between DXPC 3.7.0 and DXPC 3.8.0.
+>
+> Questions to Kevin:
+>
+>    o Is there any SVN upstream repo still online
+>      (I saw it in one of the tarballs, that SVN was
+>      used for 3.9.0).
+
+I'm afraid not. There was never an online repo available, and if I used one personally it is lost to the mists of time.
+
+>    o Do you have any tarballs documenting the
+>      changes between 3.7.0 and 3.8.0? Do you also
+>      have the 3.8.1 tarball?
+
+I have the source tarballs to each of those (including the 3.8.1 version). The 3.8.0 release includes a README-3.8.0 file which documents the changes between 3.7.0 and 3.8.0 reasonably well.
+
+As will be (unfortunately) obvious from examining the deltas between 3.7.0 (the last release by Brian and/or Zachary) and 3.8.0 (the first release by me), I inherited a significant majority of the code.
+
+>    o Did the 3.8.0 version of DXPC break proto
+>      compatibility (i.e., you could not use client
+>      3.7.0 and server 3.8.0 and vice versa with
+>      each other)?
+
+Yes, minor version number bumps were used to indicate compatibility. 3.8.x was incompatible with 3.7.x (and also with 3.9.x).
+
+
+
+
+From kevin@vigor.nu Mon May 18 21:34:50 2015
+Received: (at 784565) by bugs.debian.org; 18 May 2015 21:34:50 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-8.0 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,RCVD_IN_DNSWL_NONE,RCVD_IN_MSPIKE_H2,SPF_PASS autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 39; hammy, 146; neutral, 132; spammy,
+	4. spammytokens:0.999-1--tecnologies, 0.993-1--H*RU:67.18.68.12,
+	0.987-1--D*ascend.com, 0.987-1--H*r:34828 hammytokens:0.000-+--H*f:sk:2015050,
+	 0.000-+--3.8.0, 0.000-+--H*UA:31.0, 0.000-+--H*u:31.0,
+	0.000-+--H*f:sk:2015051
+Return-path: <kevin@vigor.nu>
+Received: from gateway15.websitewelcome.com ([67.18.68.12])
+	by buxtehude.debian.org with esmtps (TLS1.0:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuSgU-0005Jq-92
+	for 784565@bugs.debian.org; Mon, 18 May 2015 21:34:50 +0000
+Received: by gateway15.websitewelcome.com (Postfix, from userid 5007)
+	id 8BB94ED5E6912; Mon, 18 May 2015 16:11:44 -0500 (CDT)
+Received: from gator4058.hostgator.com (gator4058.hostgator.com [192.185.4.69])
+	by gateway15.websitewelcome.com (Postfix) with ESMTP id 84825ED5E68F2
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 16:11:44 -0500 (CDT)
+Received: from [63.158.132.10] (port=34828 helo=[10.50.3.84])
+	by gator4058.hostgator.com with esmtpsa (UNKNOWN:DHE-RSA-AES128-SHA:128)
+	(Exim 4.82)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuSK7-00005R-B6; Mon, 18 May 2015 16:11:43 -0500
+Message-ID: <555A558E.1020703@vigor.nu>
+Date: Mon, 18 May 2015 15:11:42 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Thunderbird/31.5.0
+MIME-Version: 1.0
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>, 
+ 784565@bugs.debian.org, Francesco Poli <invernomuto@paranoici.org>
+CC: nito.martinez@qindel.com, x2go-dev@lists.x2go.org, 
+ opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew> <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de> <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org> <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de> <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900> <20150512234048.054319a449ffadcf87577425@paranoici.org> <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de> <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+In-Reply-To: <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Transfer-Encoding: 7bit
+X-AntiAbuse: This header was added to track abuse, please include it with any abuse report
+X-AntiAbuse: Primary Hostname - gator4058.hostgator.com
+X-AntiAbuse: Original Domain - bugs.debian.org
+X-AntiAbuse: Originator/Caller UID/GID - [47 12] / [47 12]
+X-AntiAbuse: Sender Address Domain - vigor.nu
+X-BWhitelist: no
+X-Source-IP: 63.158.132.10
+X-Exim-ID: 1YuSK7-00005R-B6
+X-Source: 
+X-Source-Args: 
+X-Source-Dir: 
+X-Source-Sender: ([10.50.3.84]) [63.158.132.10]:34828
+X-Source-Auth: kevin@vigor.nu
+X-Email-Count: 2
+X-Source-Cap: a3ZpZ29yO2t2aWdvcjtnYXRvcjQwNTguaG9zdGdhdG9yLmNvbQ==
+X-Greylist: delayed 1383 seconds by postgrey-1.34 at buxtehude; Mon, 18 May 2015 21:34:50 UTC
+
+By the way, poking around the interwebs I find there is an archive of the old DXPC mailing list available at:
+
+http://marc.info/?l=dxpc&r=1&w=2
+
+I think you will find this of particular interest:
+
+
+http://marc.info/?l=dxpc&m=93093790813555&w=2
+
+
+List:       dxpc
+Subject:    Re: future tecnologies
+From:       Brian Pane <brianp () cnet ! com>
+Date:       1999-07-02 16:42:18
+[Download message RAW]
+
+Kevin Vigor <kvigor@eng.ascend.com> wrote:
+> On 01-Jul-99 dxpc@mcfeeley.cc.utexas.edu wrote:
+> > Speaking of licensing, are you putting your 3.8.0 changes to the dxpc
+> > code itself under GPL, or are they going to use the original dxpc's
+> > licensing?
+>
+> No, as you can probably guess, I am no fan of the GPL. For stuff on
+> this level, where my hacking is pretty simple and probably devoid of
+> commercial value, I'll just release my changes to the public domain and
+> give up even a copyright interest in them.
+>
+> Your and Zach's copyrights still stand, of course.
+>
+> I *think* that fact that we use the LZO library and API, but do not
+> directly incorporate the code, allows us to escape the clutch of the GPL
+> virus.
+>
+> btw, is there an original dxpc license? I haven't seen anything but a
+> copyright notice, which to my non-lawyerly mind translates as "free to
+> all the world as is, negotiate with copyright owner if modifying or
+> including in some other product".
+
+The copyright banner in the Readme is all the documentation there's ever
+been.  My intent was to allow _any_ distribution, use, and modification
+of the source, without imposing restrictions on the licensing style of
+any system into which others might incorporate the code.  We probably
+should start stating this clearly in the distributions.
+
+-brian
+
+[prev in list] [next in list] [prev in thread] [next in thread]
+
+
+
+From mike.gabriel@das-netzwerkteam.de Mon May 18 21:49:10 2015
+Received: (at 784565) by bugs.debian.org; 18 May 2015 21:49:10 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-6.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,T_RP_MATCHES_RCVD autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 35; hammy, 150; neutral, 281; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*RU:sk:grimnir,
+	0.000-+--H*r:sk:grimnir, 0.000-+--H*RU:78.46.204.98,
+	0.000-+--H*RU:88.198.48.199, 0.000-+--H*RU:sk:freya.d
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YuSuK-0007oj-Hh
+	for 784565@bugs.debian.org; Mon, 18 May 2015 21:49:10 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 253493049
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 23:49:04 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id ACC2E3BD6C
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 23:49:03 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id Hh79XOiBkYIp for <784565@bugs.debian.org>;
+	Mon, 18 May 2015 23:49:03 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 6CC483BC0D
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 23:49:03 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 2100C3BD6C
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 23:49:03 +0200 (CEST)
+Received: from [10.139.193.227] (unknown [176.0.38.193])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPSA id 453F63BB1E;
+	Mon, 18 May 2015 23:48:59 +0200 (CEST)
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Reply-To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org, Francesco Poli <invernomuto@paranoici.org>
+Cc: nito.martinez@qindel.com, x2go-dev@lists.x2go.org,  opensource@gznianguan.com, zvonler@gmail.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+	are derived from non-free code
+X-Mailer: Modest 3.2
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	 <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+	 <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+	 <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+	 <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+	 <20150512234048.054319a449ffadcf87577425@paranoici.org>
+	 <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+	 <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+	  <555A558E.1020703@vigor.nu>
+In-Reply-To: <555A558E.1020703@vigor.nu>
+Content-Type: text/plain; charset=utf-8
+Content-ID: <1431985731.1406.1.camel@Nokia-N900>
+Date: Mon, 18 May 2015 23:48:51 +0200
+Message-Id: <1431985731.1406.2.camel@Nokia-N900>
+Mime-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+Hi Kevin, hi Zach, hi Francesco, hi all,
+
+@Francesco, please review the recent posts and sum up what to do next.
+
+----- Original message -----
+> By the way, poking around the interwebs I find there is an archive of
+> the old DXPC mailing list available at:
+> 
+> http://marc.info/?l=dxpc&r=1&w=2
+> 
+> I think you will find this of particular interest:
+> 
+> 
+> http://marc.info/?l=dxpc&m=93093790813555&w=2
+
+
+> 
+> 
+> List:             dxpc
+> Subject:       Re: future tecnologies
+> From:             Brian Pane <brianp () cnet ! com>
+> Date:             1999-07-02 16:42:18
+> [Download message RAW]
+> 
+> Kevin Vigor <kvigor@eng.ascend.com> wrote:
+> > On 01-Jul-99 dxpc@mcfeeley.cc.utexas.edu wrote:
+> > > Speaking of licensing, are you putting your 3.8.0 changes to the dxpc
+> > > code itself under GPL, or are they going to use the original dxpc's
+> > > licensing?
+> > 
+> > No, as you can probably guess, I am no fan of the GPL. For stuff on
+> > this level, where my hacking is pretty simple and probably devoid of
+> > commercial value, I'll just release my changes to the public domain and
+> > give up even a copyright interest in them.
+> > 
+> > Your and Zach's copyrights still stand, of course.
+> > 
+> > I *think* that fact that we use the LZO library and API, but do not
+> > directly incorporate the code, allows us to escape the clutch of the
+> > GPL virus.
+> > 
+> > btw, is there an original dxpc license? I haven't seen anything but a
+> > copyright notice, which to my non-lawyerly mind translates as "free to
+> > all the world as is, negotiate with copyright owner if modifying or
+> > including in some other product".
+> 
+> The copyright banner in the Readme is all the documentation there's ever
+> been.   My intent was to allow _any_ distribution, use, and modification
+> of the source, without imposing restrictions on the licensing style of
+> any system into which others might incorporate the code.   We probably
+> should start stating this clearly in the distributions.
+> 
+> -brian
+> 
+> [prev in list] [next in list] [prev in thread] [next in thread]
+
+@Kevin: You are very awesome!
+
+@Francesco: that old post from Brian should be the statement we need, right? As Brian has not answered back, so far, does that post suffice?
+
+I also had a mail from Zach in my mailbox this morning. I managed to get hold of him via phone over the weekend. He posted his agreement to this Debian bug (as message #77) [1] earlier today. @Zach: thanks a lot for that!!!
+
+@Francesco: by looking at [2], I cannot see any hint for Gian Filippo Pinzari being a copyright holder of DXPC. This is stated in the NoMachine files at at least one place, but not in the latest DXPC upstream release. I am on my mobile right now, need to check old versions of DXPC, but if Gian Filippo Pinzari is not listed in the DXPC 3.7.0 release (where nxcomp obviously got forked from), then I think that we don't require his feedback, right?
+
+To my opinion, this issue can be settled. We have direct feedback from Kevin and Zach and Kevin dug out an old post from Brian stating the retroactive nature of the BSD-2-clause while Gian Filippo probably not being a real copyright holder of the original DXPC code. Right?
+
+light+love,
+Mike
+
+[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=77;att=0;bug=784565
+[2] http://www.vigor.nu/dxpc/README
+
+
+-- 
+
+DAS-NETZWERKTEAM
+mike gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976148
+
+GnuPG Key ID 0x25771B13
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+
+
+
+From invernomuto@paranoici.org Mon May 18 22:15:14 2015
+Received: (at 784565) by bugs.debian.org; 18 May 2015 22:15:14 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-12.0 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,HAS_BUG_NUMBER,PGPSIGNATURE,SPF_HELO_PASS,
+	SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 12; hammy, 150; neutral, 220; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*UA:sk:x86_64-,
+	0.000-+--H*x:sk:x86_64-, 0.000-+--H*c:PGP-SHA256, 0.000-+--H*c:SignHturH,
+	0.000-+--H*c:pgp-signature
+Return-path: <invernomuto@paranoici.org>
+Received: from latitanza.investici.org ([82.94.249.234])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YuTJa-0002xP-0G
+	for 784565@bugs.debian.org; Mon, 18 May 2015 22:15:14 +0000
+Received: from [82.94.249.234] (latitanza [82.94.249.234]) (Authenticated sender: invernomuto@paranoici.org) by localhost (Postfix) with ESMTPSA id 921B3120546;
+	Mon, 18 May 2015 22:15:05 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=paranoici.org;
+	s=stigmate; t=1431987305;
+	bh=RQEA/1bkAQ71T0PpK/7XelDXEZBLyoVavVl9tpWLzWY=;
+	h=Date:From:To:Cc:Subject:In-Reply-To:References;
+	b=sO+MOEv4mZZNK2g5Om9IC7Og5k2qPAvFepN+ei+3/jCixgNBbvaLuRpMgJw6l1yjD
+	 hpqRYIxtNgyVywgpuiFVACFBuDn1ksfdFrEPNAcgRl//Sert2aOjetbZcKi1VouhXi
+	 eexR8IP81C0C1UjzjeC7zEmF5V+wSyhVs9jKvKfg=
+Received: from frx by homebrew with local (Exim 4.85)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1YuTIi-0002Se-TN; Tue, 19 May 2015 00:14:20 +0200
+Date: Tue, 19 May 2015 00:14:08 +0200
+From: Francesco Poli <invernomuto@paranoici.org>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Cc: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org,
+ nito.martinez@qindel.com, x2go-dev@lists.x2go.org,
+ opensource@gznianguan.com, zvonler@gmail.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+Message-Id: <20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+In-Reply-To: <1431985731.1406.2.camel@Nokia-N900>
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	<20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+	<20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+	<20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+	<55521444.9090407@vigor.nu>
+	<1431445315.4712.7.camel@Nokia-N900>
+	<20150512234048.054319a449ffadcf87577425@paranoici.org>
+	<20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+	<20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+	<555A558E.1020703@vigor.nu>
+	<1431985731.1406.2.camel@Nokia-N900>
+X-Mailer: Sylpheed 3.5.0beta1 (GTK+ 2.24.25; x86_64-pc-linux-gnu)
+Mime-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pgp-signature";
+ micalg="PGP-SHA256";
+ boundary="Signature=_Tue__19_May_2015_00_14_08_+0200_Wl9eJ95DZcVokEvx"
+
+--Signature=_Tue__19_May_2015_00_14_08_+0200_Wl9eJ95DZcVokEvx
+Content-Type: text/plain; charset=US-ASCII
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+On Mon, 18 May 2015 23:48:51 +0200 Mike Gabriel wrote:
+
+[...]
+> @Francesco: that old post from Brian should be the statement we need,
+> right? As Brian has not answered back, so far, does that post suffice?
+
+Yes, I am under the impression that it may be considered as evidence
+that Brian had always meant to grant permission to modify, despite not
+being overly clear until DXPC version 3.8.1.
+In other words, it seems that the re-licensing was more intended to be
+a clarification, rather than a change of mind.
+
+>=20
+> I also had a mail from Zach in my mailbox this morning. I managed to
+> get hold of him via phone over the weekend. He posted his agreement
+> to this Debian bug (as message #77) [1] earlier today. @Zach: thanks
+> a lot for that!!!
+
+This is really great!
+
+>=20
+> @Francesco: by looking at [2], I cannot see any hint for Gian Filippo
+> Pinzari being a copyright holder of DXPC. This is stated in the
+> NoMachine files at at least one place, but not in the latest DXPC
+> upstream release. I am on my mobile right now, need to check old
+> versions of DXPC, but if Gian Filippo Pinzari is not listed in
+> the DXPC 3.7.0 release (where nxcomp obviously got forked from),
+> then I think that we don't require his feedback, right?
+
+If it is confirmed that Gian Filippo contributed to the forking of DXPC
+within the NoMachine project, but not directly to DXPC, then I think
+that he made his contributions available under the terms of the GPL v2
+of the NoMachine project.
+If this is the case, no feedback should be required from his side.
+
+>=20
+> To my opinion, this issue can be settled. We have direct feedback
+> from Kevin and Zach and Kevin dug out an old post from Brian stating
+> the retroactive nature of the BSD-2-clause while Gian Filippo probably
+> not being a real copyright holder of the original DXPC code. Right?
+
+Yes, I agree with this analysis.
+The only missing check is the one about Gian Filippo's involvement (as
+explained above).
+
+Thanks a lot to everyone involved in this license fixing effort!
+Bye.
+
+>=20
+> [1] https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D77;att=3D0;bug=3D=
+784565
+> [2] http://www.vigor.nu/dxpc/README
+
+
+
+--=20
+ http://www.inventati.org/frx/
+ There's not a second to spare! To the laboratory!
+..................................................... Francesco Poli .
+ GnuPG key fpr =3D=3D CA01 1147 9CD2 EFDF FB82  3925 3E1C 27E1 1F69 BFFE
+
+--Signature=_Tue__19_May_2015_00_14_08_+0200_Wl9eJ95DZcVokEvx
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQIcBAEBCAAGBQJVWmQ1AAoJED4cJ+Efab/+FowQALSZya0Xp8IXNA+d0gjQBLGQ
+7eDzaX+kPVKkbYdb7ZDlQF+ZVTwjOnqjf1dDLXWSHwcXYhFd3DeeFB11QfAKXptI
+GyzOt/vrh+w1K2zMb4rR9lxyUKIrKmVI6aOxyRTP7ojqkqqFvpF7ZVkDJZBFCSvx
+LXdAWTaz5NLIH5R4lzvTcTFYmC3JhBtf8m58l4jT3GC1pxoqlYQk0svWOrdlULQZ
+zh1dy6Sf0guwMuOH4pfreTKlNIizFj7BwanoN+tNvYG1sbQnyIwNRKUfG+v5/13P
+3tyjknNDTTE67T40qSv6pcZs46vqMTevL8E+s+wGfcvdKQ5Y2fPQ8Q9yxS6cVxH2
+DXsLV97RFCcdD+ys+7P9j7xYG0e38juu61sU42cNmrb5iU0woB3SJtFvABhioGZg
+TLFi/OxOT6ZTHcZtfwqozVyB1fOesqx3nvwCEE3pNuf58ErxRy1sIXwoChNL4+eo
+ET1kojXBXHER6W6EHno0yz600sJXHE8rco+fv5b5qGBHdLEJ0k80YXQI4FhJQT69
+I8FyASmNX4u6HvH6hRVm2BwE9WrZTUUQRb0m/pEfZVVroiRrqTl/ntvWchXvI2Tt
+IGfoDMtmVbSkh+2DQmsG9oDqiG1pCt3eNkLa1oftlQ7oIQem2MajCOS4QN20PMpU
+d/smtrrNvkmiWuQrjwDF
+=R0ou
+-----END PGP SIGNATURE-----
+
+--Signature=_Tue__19_May_2015_00_14_08_+0200_Wl9eJ95DZcVokEvx--
+
+
+
+From kevin@vigor.nu Tue May 19 01:41:18 2015
+Received: (at 784565) by bugs.debian.org; 19 May 2015 01:41:18 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-6.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 26; hammy, 131; neutral, 46; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*UA:31.6.0, 0.000-+--H*u:31.6.0,
+	0.000-+--H*f:sk:2015050, 0.000-+--H*UA:31.0, 0.000-+--H*u:31.0
+Return-path: <kevin@vigor.nu>
+Received: from gateway32.websitewelcome.com ([192.185.145.107])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuWX0-0002lG-Du
+	for 784565@bugs.debian.org; Tue, 19 May 2015 01:41:18 +0000
+Received: by gateway32.websitewelcome.com (Postfix, from userid 500)
+	id 311BBD143B8C; Mon, 18 May 2015 20:16:29 -0500 (CDT)
+Received: from gator4058.hostgator.com (gator4058.hostgator.com [192.185.4.69])
+	by gateway32.websitewelcome.com (Postfix) with ESMTP id 2F036D143B72
+	for <784565@bugs.debian.org>; Mon, 18 May 2015 20:16:29 -0500 (CDT)
+Received: from [98.202.128.111] (port=49655 helo=[192.168.7.118])
+	by gator4058.hostgator.com with esmtpsa (UNKNOWN:DHE-RSA-AES128-SHA:128)
+	(Exim 4.82)
+	(envelope-from <kevin@vigor.nu>)
+	id 1YuW8y-0004Tt-DX; Mon, 18 May 2015 20:16:28 -0500
+Message-ID: <555A8EE9.9000503@vigor.nu>
+Date: Mon, 18 May 2015 19:16:25 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20100101 Thunderbird/31.6.0
+MIME-Version: 1.0
+To: Francesco Poli <invernomuto@paranoici.org>, 
+ Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+CC: 784565@bugs.debian.org, nito.martinez@qindel.com, 
+ x2go-dev@lists.x2go.org, opensource@gznianguan.com, zvonler@gmail.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts
+ are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>	<20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>	<20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>	<20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>	<55521444.9090407@vigor.nu>	<1431445315.4712.7.camel@Nokia-N900>	<20150512234048.054319a449ffadcf87577425@paranoici.org>	<20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>	<20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>	<555A558E.1020703@vigor.nu>	<1431985731.1406.2.camel@Nokia-N900> <20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+In-Reply-To: <20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Transfer-Encoding: 7bit
+X-AntiAbuse: This header was added to track abuse, please include it with any abuse report
+X-AntiAbuse: Primary Hostname - gator4058.hostgator.com
+X-AntiAbuse: Original Domain - bugs.debian.org
+X-AntiAbuse: Originator/Caller UID/GID - [47 12] / [47 12]
+X-AntiAbuse: Sender Address Domain - vigor.nu
+X-BWhitelist: no
+X-Source-IP: 98.202.128.111
+X-Exim-ID: 1YuW8y-0004Tt-DX
+X-Source: 
+X-Source-Args: 
+X-Source-Dir: 
+X-Source-Sender: ([192.168.7.118]) [98.202.128.111]:49655
+X-Source-Auth: kevin@vigor.nu
+X-Email-Count: 3
+X-Source-Cap: a3ZpZ29yO2t2aWdvcjtnYXRvcjQwNTguaG9zdGdhdG9yLmNvbQ==
+X-Greylist: delayed 1487 seconds by postgrey-1.34 at buxtehude; Tue, 19 May 2015 01:41:18 UTC
+
+On 5/18/2015 4:14 PM, Francesco Poli wrote:
+> If it is confirmed that Gian Filippo contributed to the forking of 
+> DXPC within the NoMachine project, but not directly to DXPC, then I 
+> think that he made his contributions available under the terms of the 
+> GPL v2 of the NoMachine project. If this is the case, no feedback 
+> should be required from his side.
+I can confirm that Gian Fillippo never contributed directly to DXPC. 
+You'll note his name does not appear in the DXPC README, and never has.
+
+
+
+From mike.gabriel@das-netzwerkteam.de Tue May 19 08:15:28 2015
+Received: (at 784565) by bugs.debian.org; 19 May 2015 08:15:28 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 24; hammy, 150; neutral, 195; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YucgR-0008T9-K0
+	for 784565@bugs.debian.org; Tue, 19 May 2015 08:15:28 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 7D1773C96;
+	Tue, 19 May 2015 10:15:23 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id 08FEE3BFD5;
+	Tue, 19 May 2015 10:15:23 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id MW9pv+xO3WwY; Tue, 19 May 2015 10:15:22 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 97FCC3C2AA;
+	Tue, 19 May 2015 10:15:12 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Tue, 19 May 2015 08:15:12 +0000
+Date: Tue, 19 May 2015 08:15:12 +0000
+Message-ID: <20150519081512.Horde.36QI-nOdkbpWsXrDE4E8Yw1@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org, Francesco Poli
+ <invernomuto@paranoici.org>
+Cc: opensource@gznianguan.com, zvonler@gmail.com, nito.martinez@qindel.com,
+ x2go-dev@lists.x2go.org
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: Bug#784565:
+ nx-libs-lite: parts are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+ <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+ <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+ <555A558E.1020703@vigor.nu> <1431985731.1406.2.camel@Nokia-N900>
+ <20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+ <555A8EE9.9000503@vigor.nu>
+In-Reply-To: <555A8EE9.9000503@vigor.nu>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_AI4511z4pP7yPmTeeGgEoA6";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_AI4511z4pP7yPmTeeGgEoA6
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Hi Kevin, hi Frederico,
+
+On  Di 19 Mai 2015 03:16:25 CEST, Kevin Vigor wrote:
+
+> On 5/18/2015 4:14 PM, Francesco Poli wrote:
+>> If it is confirmed that Gian Filippo contributed to the forking of=20=20
+>>=20DXPC within the NoMachine project, but not directly to DXPC, then I=20=
+=20
+>>=20think that he made his contributions available under the terms of=20=
+=20
+>>=20the GPL v2 of the NoMachine project. If this is the case, no=20=20
+>>=20feedback should be required from his side.
+
+> I can confirm that Gian Fillippo never contributed directly to DXPC.=20=
+=20
+>=20You'll note his name does not appear in the DXPC README, and never=20=
+=20
+>=20has.
+
+@Kevin: This is again good news for sorting out this issue. Thanks a=20=20
+lot=20for your help, Kevin.
+
+@Frederico: I guess we are through then. Thanks for helping with=20=20
+clarifying=20the situation (and bringing it up in the first place).
+
+For fixing this issue (in terms of closing the bug), I propose this=20=20
+for=20downstream (i.e., Debian):
+
+   o copy bug_784565.mbox [1] into the debian/ folder of the=20=20
+nx-libs-lite=20package
+   o upload some latest release of nx-libs-lite 3.5.0.x to unstable
+   o update debian/copyright accordingly
+   o close this bug via debian/changelog
+
+For upstream, I propose this:
+
+   o copy bug_784565.mbox into the docs/ folder
+   o update copyright information in nxcomp/ subfolder
+   o provide some README or such that shortly explains our last weeks' proc=
+ess
+   o this will be for the upcoming 3.6.x release series of nx-libs
+
+   o this should also be backported to the 3.5.x release series
+
+Once the mbox file and README are upstreamed, I will drop that content=20=
+=20
+from=20the debian/ folder in the Debian package nx-libs-lite (as it will=20=
+=20
+be=20in the upstream tarball of nx-libs-lite).
+
+Feedback (esp. from Frederico), concerns, other suggestions?
+
+Greets,
+Mike
+
+
+[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?mbox=3Dyes;bug=3D784565
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_AI4511z4pP7yPmTeeGgEoA6
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVWvEQAAoJEJr0azAldxsxiZgP/1MhcK1h2or3zG3P9h3oOqFk
+rsknSn/0paY8HlzggWh5N4juLU9ET/VyO+xMCbVFDXb9jv5ryRI0MinPGwp6ujTl
+DxHAz5q5YrC/NYH9IU0PqL2Zja952xbjlVPgf64+iLT0kqFmY7L48bkxVXd4cKnJ
+flflATeaPTcVgIVcfFte2q/NJV7AAGjwb/tEOOMbqrRYOu1hKLozWnRSLZ/rdl5V
+OmktCjfAfw6Cvy4/IN6pCjG4uqFvsWvzjMofR53MLuy8cwQhtpvK9KPLCZlo9Efm
+KyrFNl866Egmc/HTLQkSaOJOKartANw+Ev7qsVi30OJOEWh9T1fDjnFvLn6hesKf
+9pAS/+mkuCUVNjLI/ATZAwY93bzBS+vo7fya2D/DxDk8FoLIe7XdI9GABdTE2U0H
+eyNLb/Lq485BEQEu9ThtvACZYH3F3UqA7OcFfLKyVw2lsOJV7SN3KCl76te4iNcf
+UlVzVr211lKhGTV9hLF3daKntu1H3jQku9zLK9ShJR6bYTpCAsGi2h2xzZm5PLDE
+9tbf+qUmDn3lp4uMaBtBdtq+yt47Wk95iS41x/qyvy0PK/RdnPxTpfdbriu4+1l2
+ij6Dq5bb7GckZDmpVjSsGSr4jjWtJ5QrnZbpv/u/v3+wliZL0c+CScrA+5I/qJeI
+eGXnQIwqcWE/2/AcAz2r
+=Q2/H
+-----END PGP SIGNATURE-----
+
+--=_AI4511z4pP7yPmTeeGgEoA6--
+
+
+
+
+From invernomuto@paranoici.org Wed May 20 18:04:34 2015
+Received: (at 784565) by bugs.debian.org; 20 May 2015 18:04:34 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-12.0 required=4.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,DKIM_VALID_AU,FOURLA,HAS_BUG_NUMBER,PGPSIGNATURE,SPF_HELO_PASS,
+	SPF_PASS autolearn=ham autolearn_force=no
+	version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 11; hammy, 150; neutral, 212; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*UA:sk:x86_64-,
+	0.000-+--H*x:sk:x86_64-, 0.000-+--H*c:PGP-SHA256, 0.000-+--H*c:SignHturH,
+	0.000-+--H*c:pgp-signature
+Return-path: <invernomuto@paranoici.org>
+Received: from latitanza.investici.org ([82.94.249.234])
+	by buxtehude.debian.org with esmtps (TLS1.2:DHE_RSA_AES_256_CBC_SHA256:256)
+	(Exim 4.80)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1Yv8M4-00011u-4i
+	for 784565@bugs.debian.org; Wed, 20 May 2015 18:04:34 +0000
+Received: from [82.94.249.234] (latitanza [82.94.249.234]) (Authenticated sender: invernomuto@paranoici.org) by localhost (Postfix) with ESMTPSA id C5F33121147;
+	Wed, 20 May 2015 18:04:24 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=paranoici.org;
+	s=stigmate; t=1432145064;
+	bh=kDc9DoBw4hJZuuDTXyurpbInn9fdFF6IfH4jMVGqQB4=;
+	h=Date:From:To:Cc:Subject:In-Reply-To:References;
+	b=frjvhV6NrKV9TyZSGeK6evsHeI9sAgoPOPboFwSAIij0bPp1G5rCLaVWFjD1RtFsK
+	 j+6I/XZ60KTIjiXaQGqqznF3jU2dQ/lzPkj1VYKa9Kmt1pw4UhJvU+mbyrO6cX2mSi
+	 52Wi1of3M+l/UT9DYKjXgzMRuWkYoAq4tmsOe9jY=
+Received: from frx by homebrew with local (Exim 4.85)
+	(envelope-from <invernomuto@paranoici.org>)
+	id 1Yv8LB-0001gi-7y; Wed, 20 May 2015 20:03:37 +0200
+Date: Wed, 20 May 2015 20:03:25 +0200
+From: Francesco Poli <invernomuto@paranoici.org>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Cc: Kevin Vigor <kevin@vigor.nu>, 784565@bugs.debian.org,
+ opensource@gznianguan.com, zvonler@gmail.com, nito.martinez@qindel.com,
+ x2go-dev@lists.x2go.org
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: Bug#784565:
+ nx-libs-lite: parts are derived from non-free code
+Message-Id: <20150520200325.6641876f5b4b2f483bdaea7d@paranoici.org>
+In-Reply-To: <20150519081512.Horde.36QI-nOdkbpWsXrDE4E8Yw1@mail.das-netzwerkteam.de>
+References: <20150506173532.7531.31389.reportbug@homebrew>
+	<20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+	<20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+	<20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+	<55521444.9090407@vigor.nu>
+	<1431445315.4712.7.camel@Nokia-N900>
+	<20150512234048.054319a449ffadcf87577425@paranoici.org>
+	<20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+	<20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+	<555A558E.1020703@vigor.nu>
+	<1431985731.1406.2.camel@Nokia-N900>
+	<20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+	<555A8EE9.9000503@vigor.nu>
+	<20150519081512.Horde.36QI-nOdkbpWsXrDE4E8Yw1@mail.das-netzwerkteam.de>
+X-Mailer: Sylpheed 3.5.0beta1 (GTK+ 2.24.25; x86_64-pc-linux-gnu)
+Mime-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pgp-signature";
+ micalg="PGP-SHA256";
+ boundary="Signature=_Wed__20_May_2015_20_03_25_+0200__3Vr7Ml7uHmX7EzV"
+
+--Signature=_Wed__20_May_2015_20_03_25_+0200__3Vr7Ml7uHmX7EzV
+Content-Type: text/plain; charset=US-ASCII
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+On Tue, 19 May 2015 08:15:12 +0000 Mike Gabriel wrote:
+
+[...]
+> @Frederico: I guess we are through then.
+
+Yes, it seems so (I'm assuming you meant to direct this question to
+me...).
+
+> Thanks for helping with =20
+> clarifying the situation (and bringing it up in the first place).
+
+You're welcome!
+Thanks to you and all the involved people for helping to solve this
+issue.
+
+>=20
+> For fixing this issue (in terms of closing the bug), I propose this =20
+> for downstream (i.e., Debian):
+>=20
+>    o copy bug_784565.mbox [1] into the debian/ folder of the =20
+> nx-libs-lite package
+
+Maybe the entire bug log is an overkill...
+I would include the relevant replies only. For instance:
+https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D40;mbox=3Dyes;bug=3D784=
+565
+https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D77;mbox=3Dyes;bug=3D784=
+565
+https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D87;mbox=3Dyes;bug=3D784=
+565
+https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D102;mbox=3Dyes;bug=3D78=
+4565
+
+>    o upload some latest release of nx-libs-lite 3.5.0.x to unstable
+>    o update debian/copyright accordingly
+
+In the debian/copyright file the license for the original DXPC code
+should be replaced with the 2-clause BSD license (currently adopted for
+DXPC) with a comment saying something like:
+
+  The original DXPC code used to be available under a license which
+  failed to explicitly grant the permission to modify, but was later
+  retroactively re-licensed under the 2-clause BSD license (see
+  debian/bug_784565_*.mbox for the copyright owners' statements; see
+  <https://bugs.debian.org/784565> for more details)
+
+Moreover, the copyright notice of Gian Filippo Pinzari should be
+documented in some more appropriate part of the debian/copyright file,
+associated with the NoMachine license (GPL v2 or later).
+
+>    o close this bug via debian/changelog
+>=20
+> For upstream, I propose this:
+>=20
+>    o copy bug_784565.mbox into the docs/ folder
+
+Again, I would not include the entire bug log, but only the relevant
+messages (see above)...
+
+>    o update copyright information in nxcomp/ subfolder
+>    o provide some README or such that shortly explains our last weeks' pr=
+ocess
+>    o this will be for the upcoming 3.6.x release series of nx-libs
+>=20
+>    o this should also be backported to the 3.5.x release series
+
+
+Thanks to everyone involved!
+Bye.
+
+--=20
+ http://www.inventati.org/frx/
+ There's not a second to spare! To the laboratory!
+..................................................... Francesco Poli .
+ GnuPG key fpr =3D=3D CA01 1147 9CD2 EFDF FB82  3925 3E1C 27E1 1F69 BFFE
+
+--Signature=_Wed__20_May_2015_20_03_25_+0200__3Vr7Ml7uHmX7EzV
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQIcBAEBCAAGBQJVXMxyAAoJED4cJ+Efab/+yUsP/RWzC9NoVGF7UnEIEpJODu0u
+hVkX1zjpJ+iMByHVlatR90ulKwkvVb4d354YJqyI0VM2wUtif6XBoroB0K3i6vZE
+DsxugBlzhnH8jgpPVKbOyBKshpKKZsUbvDdEXM20ZkfI4xwokymiSdHOKoHH4ZHS
+WN9q+i6OezfWvZSKQ+VCbe7QiQABAcB+zCdVvUWevhNqMDKdhsDC03Ju+5YZQbse
+QbgYSazZvJouLPamivquh8nBdjGpPxqAJGrlUu3SR5slJxRojRvl2cl/CDFEQEQR
+gbLMnnr2nj1hF4JI2WaWCSX90NrGTfGxCN4IdNd7tmjtkg5lB+KFx63YjHbLmUl/
+k87XAyXxSWyGvc7M2xyIXBQQrHtRxtK0rdN+e7ht9PcXYyxUtQzr7vfPwvI+B2GV
+M23ZUoyV1rFp5JymbUL4Vk6pq/hLnv9FzwOySNVcj6Pt8eT+BcoSbwOI1AMq1P1S
+wCs/PhEGBA3TDWERXF0Fb7x24NEf7EdjmzKTGGdXTCfSkacxkGzsMaRpWb0D6IaV
+tSI6CmBQ9uOdkbiNDhGX4esosyJZJQ9GrnWX9d/lTs9wXUHHykvnYRbDzpkChZdI
+ICqc+IxnPmX6HU2kyq2ZAzfhx/drqLizcv0gQlyY6APjRu3EQ3tapR9kYB6BcuGU
+cMLlO0549ekk8/s3Zk0i
+=9Hew
+-----END PGP SIGNATURE-----
+
+--Signature=_Wed__20_May_2015_20_03_25_+0200__3Vr7Ml7uHmX7EzV--
+
+
+
+From mike.gabriel@das-netzwerkteam.de Thu May 21 09:35:35 2015
+Received: (at 784565) by bugs.debian.org; 21 May 2015 09:35:35 +0000
+X-Spam-Checker-Version: SpamAssassin 3.4.0-bugs.debian.org_2005_01_02
+	(2014-02-07) on buxtehude.debian.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-11.9 required=4.0 tests=BAYES_00,FOURLA,
+	HAS_BUG_NUMBER,PGPSIGNATURE,T_RP_MATCHES_RCVD autolearn=ham
+	autolearn_force=no version=3.4.0-bugs.debian.org_2005_01_02
+X-Spam-Bayes: score:0.0000 Tokens: new, 15; hammy, 150; neutral, 222; spammy,
+	0. spammytokens: hammytokens:0.000-+--H*c:pgp-signature,
+	0.000-+--H*c:protocol, 0.000-+--H*c:micalg, 0.000-+--H*c:signed,
+	0.000-+--H*RU:sk:grimnir
+Return-path: <mike.gabriel@das-netzwerkteam.de>
+Received: from freya.das-netzwerkteam.de ([88.198.48.199])
+	by buxtehude.debian.org with esmtps (TLS1.1:DHE_RSA_AES_256_CBC_SHA1:256)
+	(Exim 4.80)
+	(envelope-from <mike.gabriel@das-netzwerkteam.de>)
+	id 1YvMt4-0006Ry-Ri
+	for 784565@bugs.debian.org; Thu, 21 May 2015 09:35:35 +0000
+Received: from grimnir.das-netzwerkteam.de (grimnir.das-netzwerkteam.de [78.46.204.98])
+	by freya.das-netzwerkteam.de (Postfix) with ESMTPS id 89FD21F2;
+	Thu, 21 May 2015 11:35:31 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTP id C86AC3BAE9;
+	Thu, 21 May 2015 11:35:30 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at grimnir.das-netzwerkteam.de
+Received: from grimnir.das-netzwerkteam.de ([127.0.0.1])
+	by localhost (grimnir.das-netzwerkteam.de [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id GqfEjOoeH2CA; Thu, 21 May 2015 11:35:30 +0200 (CEST)
+Received: from grimnir.das-netzwerkteam.de (localhost [127.0.0.1])
+	by grimnir.das-netzwerkteam.de (Postfix) with ESMTPS id 615DC3BAB2;
+	Thu, 21 May 2015 11:35:30 +0200 (CEST)
+Received: from bifrost.das-netzwerkteam.de (bifrost.das-netzwerkteam.de
+ [178.62.101.154]) by mail.das-netzwerkteam.de (Horde Framework) with HTTP;
+ Thu, 21 May 2015 09:35:30 +0000
+Date: Thu, 21 May 2015 09:35:30 +0000
+Message-ID: <20150521093530.Horde.Oeys0xv-mTUN5U5IZtdeLA1@mail.das-netzwerkteam.de>
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+To: Francesco Poli <invernomuto@paranoici.org>, 784565@bugs.debian.org
+Cc: nito.martinez@qindel.com, opensource@gznianguan.com
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: Bug#784565:
+ Bug#784565: nx-libs-lite: parts are derived from non-free code
+References: <20150506173532.7531.31389.reportbug@homebrew>
+ <20150511092636.Horde.oj6sHKnvQDt85T3EW1WhVA1@mail.das-netzwerkteam.de>
+ <20150511213659.34dce0505c493c1e23d2c3ee@paranoici.org>
+ <20150512044637.Horde.8WHdvRpU7GS9Szy323gv_Q2@mail.das-netzwerkteam.de>
+ <55521444.9090407@vigor.nu> <1431445315.4712.7.camel@Nokia-N900>
+ <20150512234048.054319a449ffadcf87577425@paranoici.org>
+ <20150514045809.Horde.-3NIZzBnA5V5B6a721F2kg2@mail.das-netzwerkteam.de>
+ <20150516091912.Horde.W_1Szu5msccGYo-Ndwv3cg1@mail.das-netzwerkteam.de>
+ <555A558E.1020703@vigor.nu> <1431985731.1406.2.camel@Nokia-N900>
+ <20150519001408.8e5452a098db48d6867af6cb@paranoici.org>
+ <555A8EE9.9000503@vigor.nu>
+ <20150519081512.Horde.36QI-nOdkbpWsXrDE4E8Yw1@mail.das-netzwerkteam.de>
+ <20150520200325.6641876f5b4b2f483bdaea7d@paranoici.org>
+In-Reply-To: <20150520200325.6641876f5b4b2f483bdaea7d@paranoici.org>
+User-Agent: Internet Messaging Program (IMP) H5 (6.2.2)
+Accept-Language: de,en
+Organization: DAS-NETZWERKTEAM
+X-Originating-IP: 178.62.101.154
+X-Remote-Browser: Mozilla/5.0 (X11; Linux x86_64; rv:32.0) Gecko/20100101
+ Firefox/32.0 Iceweasel/32.0
+Content-Type: multipart/signed; boundary="=_5hM8_j7kivGPCYTZql9Fug5";
+ protocol="application/pgp-signature"; micalg=pgp-sha1
+MIME-Version: 1.0
+
+This message is in MIME format and has been PGP signed.
+
+--=_5hM8_j7kivGPCYTZql9Fug5
+Content-Type: text/plain; charset=us-ascii; format=flowed; DelSp=Yes
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+Control: forwarded -1 https://github.com/ArcticaProject/nx-libs/issues/30
+
+Hi Francesco,
+
+On  Mi 20 Mai 2015 20:03:25 CEST, Francesco Poli wrote:
+
+> On Tue, 19 May 2015 08:15:12 +0000 Mike Gabriel wrote:
+>
+> [...]
+>> @Frederico: I guess we are through then.
+>
+> Yes, it seems so (I'm assuming you meant to direct this question to
+> me...).
+
+Yes. :-)
+
+>> For fixing this issue (in terms of closing the bug), I propose this
+>> for downstream (i.e., Debian):
+>>
+>>    o copy bug_784565.mbox [1] into the debian/ folder of the
+>> nx-libs-lite package
+>
+> Maybe the entire bug log is an overkill...
+> I would include the relevant replies only. For instance:
+> https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D40;mbox=3Dyes;bug=3D7=
+84565
+> https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D77;mbox=3Dyes;bug=3D7=
+84565
+> https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D87;mbox=3Dyes;bug=3D7=
+84565
+> https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=3D102;mbox=3Dyes;bug=3D=
+784565
+
+ACK.
+
+>>    o upload some latest release of nx-libs-lite 3.5.0.x to unstable
+>>    o update debian/copyright accordingly
+>
+> In the debian/copyright file the license for the original DXPC code
+> should be replaced with the 2-clause BSD license (currently adopted for
+> DXPC) with a comment saying something like:
+>
+>   The original DXPC code used to be available under a license which
+>   failed to explicitly grant the permission to modify, but was later
+>   retroactively re-licensed under the 2-clause BSD license (see
+>   debian/bug_784565_*.mbox for the copyright owners' statements; see
+>   <https://bugs.debian.org/784565> for more details)
+>
+> Moreover, the copyright notice of Gian Filippo Pinzari should be
+> documented in some more appropriate part of the debian/copyright file,
+> associated with the NoMachine license (GPL v2 or later).
+>
+>>    o close this bug via debian/changelog
+>>
+>> For upstream, I propose this:
+>>
+>>    o copy bug_784565.mbox into the docs/ folder
+>
+> Again, I would not include the entire bug log, but only the relevant
+> messages (see above)...
+>
+>>    o update copyright information in nxcomp/ subfolder
+>>    o provide some README or such that shortly explains our last=20=20
+>>=20weeks' process
+>>    o this will be for the upcoming 3.6.x release series of nx-libs
+>>
+>>    o this should also be backported to the 3.5.x release series
+
+Doing all the above now.
+
+Thanks to all,
+Mike
+
+--=20
+
+DAS-NETZWERKTEAM
+mike=20gabriel, herweg 7, 24357 fleckeby
+fon: +49 (1520) 1976 148
+
+GnuPG Key ID 0x25771B31
+mail: mike.gabriel@das-netzwerkteam.de, http://das-netzwerkteam.de
+
+freeBusy:
+https://mail.das-netzwerkteam.de/freebusy/m.gabriel%40das-netzwerkteam.de.x=
+fb
+
+--=_5hM8_j7kivGPCYTZql9Fug5
+Content-Type: application/pgp-signature
+Content-Description: Digitale PGP-Signatur
+Content-Disposition: inline
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAABAgAGBQJVXabiAAoJEJr0azAldxsxd4cP/in26lIPvdANMyDaqq3zQOMh
+n/Q+oZK5SYnHQP7vaS4mOWjTw5tCbfcUMcKwu1KpbgpUGOl9e1c/oKGxR3j5GWh3
+XiqQhPWEMf64OsM4vW5prJFrx0VNqfxykMWbGzQfs6Dz9ihJ6+HzVudOk3bfHwj2
+GahCflRo7xA1hJjwz5cIX1/WJaAF25TVSQ43jVpPu0pnAYOWvhOAZMpTJTZqRbgT
+peuFaiKE+NOb4C/WO9mkuO3wlEBZ5Ef/RinKQDlbV5/CZElEs1f42A4t5q909EVi
+U2PpaEis8BJAIKetl8g/bPoHh9u6X3tbeOKJlZBo5l2SMyLUG0sYsoAyhJKJtIvk
+gwdGdO71A7HLEJ6DfvE8vYXUPy9JEOQ6hhL2qeZOtJG2DZ2Qcoll9eK5scg2YutW
+ZXHRTYcCQeS4PQpvQPlCR5LuFTJeNBwJ0cWgtfXYPIrPMyeEZj/VP+Ypm82hBT+I
+JFjo80QjOEJ7uEM1wmn8nD0rbbP/NVf6ot/UcwlejC/XaYIlWDW5FrXf18UbGsvu
+VzaHkLbhbGUYedwsb50Uu6Nn4IX8IEcF3zbwnqmB5IlbPYV0UokjgtnKEIQbdmF4
+fQ5xe5u/p2aZTnQwt39vey2W/RxJVOHRjVVrYGv0eqgda8TYOWzI3UIjSYGfuLcU
+kDRest50Qfy4tmilPx3z
+=Cf5/
+-----END PGP SIGNATURE-----
+
+--=_5hM8_j7kivGPCYTZql9Fug5--
+
+
+
+

--- a/nxcomp/LICENSE
+++ b/nxcomp/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2001, 2010 NoMachine - http://www.nomachine.com/.
+Copyright (c) 2001,2010 NoMachine - http://www.nomachine.com/.
+Copyright (c) 2000,2003 Gian Filippo Pinzari
 
 NXCOMP library and NX extensions to X are copyright of NoMachine.
 Redistribution and use of this software is allowed according to the
@@ -18,6 +19,8 @@ along with this program; if not, you can request a copy to NoMachine
 or write to the Free Software Foundation, Inc., 59 Temple Place, Suite
 330, Boston, MA  02111-1307 USA
 
+==============================================================================
+
 Parts of this software are derived from DXPC project. These copyright
 notices apply to original DXPC code:
 
@@ -29,9 +32,59 @@ THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
-Copyright (c) 1995,1996 Brian Pane
+Copyright (c) 1995,1996,2000,2006 Brian Pane
 Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
 Copyright (c) 1999 Kevin Vigor and Brian Pane
-Copyright (c) 2000,2006 Gian Filippo Pinzari and Brian Pane
+<crossed-out>Copyright (c) 2000,2006 Gian Filippo Pinzari and Brian Pane</crossed-out>
 
 All rights reserved.
+
+==============================================================================
+
+Update 2015-05-21 on the nature of the original DXPC license: The
+original DXPC code used to be available under a license which failed to
+explicitly grant the permission to modify, but was later retroactively
+re-licensed under the 2-clause BSD license (see
+README.on-retroactive-DXPC-license for the copyright owners' statements;
+see <https://bugs.debian.org/784565> for more details).
+
+In the course of discussion, it also became evident that Gian Filippo
+Pinzari never participated in any of the official DXPC releases, but
+rather worked on the forked code on the NoMachine side. Thus, we
+crossed-out his name in the above copyright notice and moved him to the
+top list of copyright holders associated with the GPL-2 re-licensing done
+by NoMachine.
+
+Thus, the version of DXPC where NXCOMP got forked from (most likely some
+DXPC version between release 3.7.0 and release 3.8.0) can be considered
+as BSD-2-clause, as quoted below:
+
+Copyright (c) 1995,1996 Brian Pane
+Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
+Copyright (c) 1999-2002 Kevin Vigor and Brian Pane
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/nxcomp/Misc.cpp
+++ b/nxcomp/Misc.cpp
@@ -384,9 +384,9 @@ static const char CopyrightInfo[] =
 Copyright (c) 2001, 2010 NoMachine, http://www.nomachine.com/.\n\
 \n\
 NXCOMP, NX protocol compression and NX extensions to this software \n\
-are copyright of NoMachine. Redistribution and use of the present\n\
-software is allowed according to terms specified in the file LICENSE\n\
-which comes in the source distribution.\n\
+are copyright of NoMachine. Redistribution (modified or unmodified) and
+use of the present\n\ software is allowed according to terms specified in
+the file LICENSE\n\ which comes in the source distribution.\n\
 \n\
 Check http://www.nomachine.com/licensing.html for applicability.\n\
 \n\

--- a/nxcomp/README.on-retroactive-DXPC-license
+++ b/nxcomp/README.on-retroactive-DXPC-license
@@ -1,0 +1,269 @@
+On DXPC retroactive relicensing as BSD-2-clause
+===============================================
+
+TL;DR; In May 2015, all versions of DXPC released before version 3.8.1 (sometime
+in 2002) have retroactively been re-licensed by all previous maintainers
+of DXPC as BSD-2-clause.
+
+This README file gives an overview of the discussion thread that lead to
+the retroactive re-licensing of DXPC.
+
+For the full discussion, see doc/DXPC_re-licensed::debbug_784565.mbox in
+this source project or #784565 on the Debian bug tracker [1].
+
+light+love,
+20150521, Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+
+[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=784565
+
+------------------------------------------------------------------------------
+
+STEP 1
+======
+
+In May 2015, a serious license issue around the nxcomp code shipped in
+this source project was raised and solved on the Debian bug tracker (thanks to
+Francesco Poli and many others): http://bugs.debian.org/784565
+
+"""
+From: "Francesco Poli \(wintermute\)" <invernomuto@paranoici.org>
+To: Debian Bug Tracking System <submit@bugs.debian.org>
+Date: Wed, 06 May 2015 19:35:32 +0200
+
+I noticed that the debian/copyright states:
+
+[...]
+| Parts of this software are derived from DXPC project. These copyright
+| notices apply to original DXPC code:
+|
+|    Redistribution and use in source and binary forms are permitted provided
+|    that the above copyright notice and this paragraph are duplicated in all
+|    such forms.
+|
+|    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+|    WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+|    MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+|
+|    Copyright (c) 1995,1996 Brian Pane
+|    Copyright (c) 1996,1997 Zachary Vonler and Brian Pane
+|    Copyright (c) 1999 Kevin Vigor and Brian Pane
+|    Copyright (c) 2000,2001 Gian Filippo Pinzari and Brian Pane
+[...]
+
+This license lacks the permission to modify the DXPC code.
+Hence, the original DXPC code does not appear to comply with the
+DFSG. And the nx-libs-lite is in part derived from DXPC code.
+
+This basically means that nx-libs-lite includes parts which are
+non-free (as they are derived from non-modifiable code) and
+are also possibly legally undistributable (as they are non-modifiable,
+but actually modified). The combination with the rest of nx-libs-lite
+(which is GPL-licensed) may also be legally undistributable (since
+the license with no permission to modify is GPL-incompatible).
+
+
+If there's anything I misunderstood, please clarify.
+
+Otherwise, please address this issue as soon as possible.
+The copyright owners for the original DXPC code should be
+contacted and persuaded to re-license under GPL-compatible
+terms.
+"""
+The issue has been settled by asking all recent maintainers (i.e.,
+copyright holders) of DXPC, to agree on considering the BSD-2-clause
+license (as introduced in DXPC 3.8.1) retro-actively as the license of
+all pre-3.8.1 DXPC releases.
+"""
+
+STEP 2:
+=======
+
+Kevin Vigor, the (at that time being) latest known maintainer of DXPC
+replied back immediately and provided the info given below. He also
+stated that he agrees to applying BSD-2-clause retroactively to all
+pre-3.8.1 releases of DXPC.
+
+"""
+From: Kevin Vigor <kevin@vigor.nu>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+CC: 784565@bugs.debian.org, [...]
+Subject: Re: Bug#784565: nx-libs-lite: parts are derived from non-free code
+
+Hi Mike, et al,
+
+   I am not the original author of dxpc, that being Brian Pane. However,
+   I took over maintenance circa 1999 and am still the primary maintainer
+   (though the project has effectively been dead for most of a decade
+   now).
+
+   As you are aware, when I inherited the code, it was licensed under a
+   variant of the BSD license that did not include the 'with
+   modification' clause. To the best of my recollection, somebody from
+   the FSF contacted me circa 2001 regarding this and as a result,
+   subsequent releases were done under a standard 2-clause BSD license
+   with the modification clause. Again, to the best of my recollection, I
+   contacted Brian about this change and he offered no objection.
+
+   Further, I recall distinctly that NoMachine contacted me and
+   explicitly asked permission before including DXPC code in NX, which I
+   happily granted with no new conditions beyond the BSD license already
+   in play.
+
+   It is possible, though by no means certain, that I could dig up
+   ancient email to corroborate this account if necessary. However, I am
+   more than willing to publicly state that I believe NoMachine's use of
+   DXPC code to be both legal and ethical, and that my intent when
+   changing the license to 2-clause BSD was simply to clarity the
+   existing intent and that it ought therefore be considered retroactive.
+
+   Yours,
+      Kevin Vigor
+
+[...]
+"""
+
+STEP 3:
+-------
+
+We were not able to dig out any recent mail address of Zachary Volner,
+another of the DXPC copyright holders, but a phone number.
+
+On Friday, May 15th, I (Mike Gabriel) called that phone number and left a
+message on - hopefully - Zach's voicebox, asking him to mail me, so I
+could explain everything. He mailed back and later on posted the below
+statement to the Debian BTS, also expressing his agreement to the
+retroactive re-licensing of DXPC.
+
+"""
+Date: Mon, 18 May 2015 10:05:38 -0500
+Subject: Re: Bug#784565: nx-libs-lite: parts are derived from non-free code
+From: Zach Vonler <zvonler@gmail.com>
+To: 784565@bugs.debian.org
+
+On Thu, 14 May 2015 05:55:42 +0000 Mike Gabriel <
+mike.gabriel@das-netzwerkteam.de> wrote:
+
+>
+> TL;DR; So here comes my actual question: are you (Brian Pane, Zachary
+> Vonler, Gian Filippo Pinzari) ok with retroactively regarding
+> pre-3.8.1 code of DXPC (that you probably all worked on at that time)
+> as BSD-2-clause? Are you ok with others having taken or taking the
+> pre-3.8.1 DXPC code and distribute it in a modified form?
+>
+
+
+> A yes from all of you as DXPC copyright holders is essential for the
+> continuation of nx-libs development under a free license. This may
+> also possibly be an issue for NXv4 in case parts of it have been
+> derived from DXPC.
+
+
+Yes, I am fine with considering the license change to be retroactive to
+cover the time I was the maintainer.
+
+I have no objections to others distributing modified versions of that code.
+
+Zach
+"""
+
+STEP 4:
+-------
+
+By 18th May 2015, Brian Pane had not mailed back to us. Hoping he is well
+and alive. Giving my personal gratitude to him for his work on DXPC back
+in the nighties.
+
+However, Kevin found an old archive of the DXPC mailing lists, esp. a
+post by Brian expressing openness to modifications of all DXPC code
+versions.
+
+We refer to this regarding his consent on the re-licensing.
+
+"""
+Date: Mon, 18 May 2015 15:11:42 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+To: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>,  784565@bugs.debian.org, Francesco Poli <invernomuto@paranoici.org>
+CC: [...]
+Subject: Re: Bug#784565: nx-libs-lite: parts are derived from non-free code
+
+By the way, poking around the interwebs I find there is an archive of the old DXPC mailing list available at:
+
+http://marc.info/?l=dxpc&r=1&w=2
+
+I think you will find this of particular interest:
+
+
+http://marc.info/?l=dxpc&m=93093790813555&w=2
+
+
+List:       dxpc
+Subject:    Re: future tecnologies
+From:       Brian Pane <brianp () cnet ! com>
+Date:       1999-07-02 16:42:18
+[Download message RAW]
+
+Kevin Vigor <kvigor@eng.ascend.com> wrote:
+> On 01-Jul-99 dxpc@mcfeeley.cc.utexas.edu wrote:
+> > Speaking of licensing, are you putting your 3.8.0 changes to the dxpc
+> > code itself under GPL, or are they going to use the original dxpc's
+> > licensing?
+>
+> No, as you can probably guess, I am no fan of the GPL. For stuff on
+> this level, where my hacking is pretty simple and probably devoid of
+> commercial value, I'll just release my changes to the public domain and
+> give up even a copyright interest in them.
+>
+> Your and Zach's copyrights still stand, of course.
+>
+> I *think* that fact that we use the LZO library and API, but do not
+> directly incorporate the code, allows us to escape the clutch of the GPL
+> virus.
+>
+> btw, is there an original dxpc license? I haven't seen anything but a
+> copyright notice, which to my non-lawyerly mind translates as "free to
+> all the world as is, negotiate with copyright owner if modifying or
+> including in some other product".
+
+The copyright banner in the Readme is all the documentation there's ever
+been.  My intent was to allow _any_ distribution, use, and modification
+of the source, without imposing restrictions on the licensing style of
+any system into which others might incorporate the code.  We probably
+should start stating this clearly in the distributions.
+
+-brian
+
+[prev in list] [next in list] [prev in thread] [next in thread]
+"""
+
+STEP 5:
+-------
+
+Last but not least, Kevin informed us that Gian Filippo Pinzari never
+contributed any code to any of the official DPXC releases. So we assumed
+that his copyrights on the code stem from the time where he - under the
+NoMachine umbrella - worked on the code and should probably be associated
+with the GPL-2 re-licensing of the code later on done by NoMachine
+(which we did in the LICENSE file).
+
+It also appears, that there has been an incongruity between the copyright
+statement in nxcomp/Misc.cpp and nxcomp/LICENSE for Gian Filippo Pinzari.
+We used the copyright years (2000,2003) from nxcomp/Misc.cpp instead of
+those originally given in nxcomp/LICENSE (2000,2006).
+
+"""
+Date: Mon, 18 May 2015 19:16:25 -0600
+From: Kevin Vigor <kevin@vigor.nu>
+To: Francesco Poli <invernomuto@paranoici.org>,
+ Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+CC: 784565@bugs.debian.org, [...]
+Subject: Re: [pkg-x2go-devel] Bug#784565: Bug#784565: nx-libs-lite: parts are derived from non-free code
+
+On 5/18/2015 4:14 PM, Francesco Poli wrote:
+> If it is confirmed that Gian Filippo contributed to the forking of
+> DXPC within the NoMachine project, but not directly to DXPC, then I
+> think that he made his contributions available under the terms of the
+> GPL v2 of the NoMachine project. If this is the case, no feedback
+> should be required from his side.
+I can confirm that Gian Fillippo never contributed directly to DXPC.
+You'll note his name does not appear in the DXPC README, and never has.
+"""


### PR DESCRIPTION
- Update nxcomp/LICENSE.
- Add nxcomp/README.on-retroactive-DXPC-license, giving a
  short overview of the flow of discussions
- Add "modified or unmodified" to the license information
  printed out to stdout in nxcomp/Misc.cpp
- Fix copyright year (2006->2003) for Gian Filippo Pinzari
  (and move him to the GPL-2 section).
- Add the complete .mbox file of Debian bug #748565.
