### PR TITLE
Apply misc patches to duplicate XRender code

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/NXpicturestr.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXpicturestr.h
@@ -369,7 +369,13 @@ typedef struct _PictureScreen {
     int				nfilterAliases;
 
     ChangePictureTransformProcPtr   ChangePictureTransform;
+
+    /**
+     * Called immediately after a picture's transform is changed through the
+     * SetPictureFilter request.  Not called for source-only pictures.
+     */
     ChangePictureFilterProcPtr	ChangePictureFilter;
+
     DestroyPictureFilterProcPtr	DestroyPictureFilter;
 
     TrapezoidsProcPtr		Trapezoids;


### PR DESCRIPTION
This PR split off from #35 

This PR also depends on the outcome of PR #37. Once we have removed all the duplicate code that we possibly can remove, we need to apply any previous non-CVE patches/commits to the remaining duplicate code.

commit 0d56c45 was:
nx-X11: handle source pictures (those without a Drawable surface) gracefully.
