### PR TITLE
Xext CVE Fixes

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
@@ -1423,6 +1423,7 @@ SProcXvQueryExtension(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryExtensionReq);
+  REQUEST_SIZE_MATCH(xvQueryExtensionReq);
   swaps(&stuff->length, n);
   return ProcXvQueryExtension(client);
 }
@@ -1432,6 +1433,7 @@ SProcXvQueryAdaptors(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryAdaptorsReq);
+  REQUEST_SIZE_MATCH(xvQueryAdaptorsReq);
   swaps(&stuff->length, n);
   swapl(&stuff->window, n);
   return ProcXvQueryAdaptors(client);
@@ -1442,6 +1444,7 @@ SProcXvQueryEncodings(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryEncodingsReq);
+  REQUEST_SIZE_MATCH(xvQueryEncodingsReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   return ProcXvQueryEncodings(client);
@@ -1452,6 +1455,7 @@ SProcXvGrabPort(ClientPtr client)
 {
   register char n;
   REQUEST(xvGrabPortReq);
+  REQUEST_SIZE_MATCH(xvGrabPortReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->time, n);
@@ -1463,6 +1467,7 @@ SProcXvUngrabPort(ClientPtr client)
 {
   register char n;
   REQUEST(xvUngrabPortReq);
+  REQUEST_SIZE_MATCH(xvUngrabPortReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->time, n);
@@ -1474,6 +1479,7 @@ SProcXvPutVideo(ClientPtr client)
 {
   register char n;
   REQUEST(xvPutVideoReq);
+  REQUEST_SIZE_MATCH(xvPutVideoReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1494,6 +1500,7 @@ SProcXvPutStill(ClientPtr client)
 {
   register char n;
   REQUEST(xvPutStillReq);
+  REQUEST_SIZE_MATCH(xvPutStillReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1514,6 +1521,7 @@ SProcXvGetVideo(ClientPtr client)
 {
   register char n;
   REQUEST(xvGetVideoReq);
+  REQUEST_SIZE_MATCH(xvGetVideoReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1534,6 +1542,7 @@ SProcXvGetStill(ClientPtr client)
 {
   register char n;
   REQUEST(xvGetStillReq);
+  REQUEST_SIZE_MATCH(xvGetStillReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1554,6 +1563,7 @@ SProcXvPutImage(ClientPtr client)
 {
   register char n;
   REQUEST(xvPutImageReq);
+  REQUEST_AT_LEAST_SIZE(xvPutImageReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1578,6 +1588,7 @@ SProcXvShmPutImage(ClientPtr client)
 {
   register char n;
   REQUEST(xvShmPutImageReq);
+  REQUEST_SIZE_MATCH(xvShmPutImageReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1605,6 +1616,7 @@ SProcXvSelectVideoNotify(ClientPtr client)
 {
   register char n;
   REQUEST(xvSelectVideoNotifyReq);
+  REQUEST_SIZE_MATCH(xvSelectVideoNotifyReq);
   swaps(&stuff->length, n);
   swapl(&stuff->drawable, n);
   return ProcXvSelectVideoNotify(client);
@@ -1615,6 +1627,7 @@ SProcXvSelectPortNotify(ClientPtr client)
 {
   register char n;
   REQUEST(xvSelectPortNotifyReq);
+  REQUEST_SIZE_MATCH(xvSelectPortNotifyReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   return ProcXvSelectPortNotify(client);
@@ -1625,6 +1638,7 @@ SProcXvStopVideo(ClientPtr client)
 {
   register char n;
   REQUEST(xvStopVideoReq);
+  REQUEST_SIZE_MATCH(xvStopVideoReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->drawable, n);
@@ -1636,6 +1650,7 @@ SProcXvSetPortAttribute(ClientPtr client)
 {
   register char n;
   REQUEST(xvSetPortAttributeReq);
+  REQUEST_SIZE_MATCH(xvSetPortAttributeReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->attribute, n);
@@ -1647,6 +1662,7 @@ SProcXvGetPortAttribute(ClientPtr client)
 {
   register char n;
   REQUEST(xvGetPortAttributeReq);
+  REQUEST_SIZE_MATCH(xvGetPortAttributeReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swapl(&stuff->attribute, n);
@@ -1658,6 +1674,7 @@ SProcXvQueryBestSize(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryBestSizeReq);
+  REQUEST_SIZE_MATCH(xvQueryBestSizeReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   swaps(&stuff->vid_w, n);
@@ -1672,6 +1689,7 @@ SProcXvQueryPortAttributes(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryPortAttributesReq);
+  REQUEST_SIZE_MATCH(xvQueryPortAttributesReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   return ProcXvQueryPortAttributes(client);
@@ -1682,6 +1700,7 @@ SProcXvQueryImageAttributes(ClientPtr client)
 {
   register char n;
   REQUEST(xvQueryImageAttributesReq);
+  REQUEST_SIZE_MATCH(xvQueryImageAttributesReq);
   swaps(&stuff->length, n);
   swapl(&stuff->id, n);
   swaps(&stuff->width, n);
@@ -1694,6 +1713,7 @@ SProcXvListImageFormats(ClientPtr client)
 {
   register char n;
   REQUEST(xvListImageFormatsReq);
+  REQUEST_SIZE_MATCH(xvListImageFormatsReq);
   swaps(&stuff->length, n);
   swapl(&stuff->port, n);
   return ProcXvListImageFormats(client);


### PR DESCRIPTION
This is one of the PRs to address #29.

I did a test build on Ubuntu 14.04 64-bit. It passed.

However, I am trying to find an application that uses the Xvideo extension to test this for regressions. I suppose I need to find an application that is linked (`ldd` command) against `/usr/lib/x86_64-linux-gnu/libXv.so`, but neither VLC nor Totem are. Neither are Firefox or Google Chrome (which both support HTML5 video.)
