### PR TITLE
Replace "pointer" by "void *"

### DIFF
--- a/nx-X11/extras/Mesa/src/mesa/drivers/x11/xm_span.c
+++ b/nx-X11/extras/Mesa/src/mesa/drivers/x11/xm_span.c
@@ -115,7 +115,7 @@ static unsigned long read_pixel( XMesaDisplay *dpy,
       XMesaDestroyImage( pixel );
    }
 #else
-   (*dpy->GetImage)(d, x, y, 1, 1, ZPixmap, ~0L, (pointer)&p);
+   (*dpy->GetImage)(d, x, y, 1, 1, ZPixmap, ~0L, (void *)&p);
 #endif
    return p;
 }
@@ -3834,7 +3834,7 @@ get_row_ci(GLcontext *ctx, struct gl_renderbuffer *rb,
 #else
       (*xmesa->display->GetImage)(xrb->drawable,
 				  x, y, n, 1, ZPixmap,
-				  ~0L, (pointer)index);
+				  ~0L, (void *)index);
 #endif
    }
    else if (xrb->ximage) {
@@ -3869,7 +3869,7 @@ get_row_rgba(GLcontext *ctx, struct gl_renderbuffer *rb,
       error = (!span->data);
       (*xmesa->display->GetImage)(xrb->drawable,
 				  x, YFLIP(xrb, y), n, 1, ZPixmap,
-				  ~0L, (pointer)span->data);
+				  ~0L, (void *)span->data);
 #else
       int k;
       y = YFLIP(xrb, y);

--- a/nx-X11/include/Xdefs.h
+++ b/nx-X11/include/Xdefs.h
@@ -103,8 +103,8 @@ typedef FSID AccContext;
 typedef struct timeval **OSTimePtr;
 
 
-typedef void (* BlockHandlerProcPtr)(pointer /* blockData */,
+typedef void (* BlockHandlerProcPtr)(void * /* blockData */,
 				     OSTimePtr /* pTimeout */,
-				     pointer /* pReadmask */);
+				     void * /* pReadmask */);
 
 #endif

--- a/nx-X11/include/extensions/XKBsrv.h
+++ b/nx-X11/include/extensions/XKBsrv.h
@@ -294,7 +294,7 @@ extern char *	XkbModelUsed,*XkbLayoutUsed,*XkbVariantUsed,*XkbOptionsUsed;
 extern Bool	noXkbExtension;
 extern Bool	XkbWantRulesProp;
 
-extern pointer	XkbLastRepeatEvent;
+extern void *	XkbLastRepeatEvent;
 
 extern CARD32	xkbDebugFlags;
 extern CARD32	xkbDebugCtrls;
@@ -336,7 +336,7 @@ extern	int	DeviceButtonPress,DeviceButtonRelease;
 #define	IsKeypadKey(s)		XkbKSIsKeypad(s)
 
 #define	Status		int
-#define	XPointer	pointer
+#define	XPointer	void *
 #define	Display		struct _XDisplay
 
 #ifndef True
@@ -715,7 +715,7 @@ extern	void XkbHandleBell(
        BOOL		/* eventOnly */,
        DeviceIntPtr	/* kbd */,
        CARD8		/* percent */,
-       pointer 		/* ctrl */,
+       void * 		/* ctrl */,
        CARD8		/* class */,
        Atom		/* name */,
        WindowPtr	/* pWin */,

--- a/nx-X11/include/extensions/lbxopts.h
+++ b/nx-X11/include/extensions/lbxopts.h
@@ -96,8 +96,8 @@ struct iovec {
 typedef void *LbxStreamCompHandle;
 
 typedef struct _LbxStreamOpts {
-    LbxStreamCompHandle	(*streamCompInit)(int fd, pointer arg);
-    pointer		streamCompArg;
+    LbxStreamCompHandle	(*streamCompInit)(int fd, void * arg);
+    void *		streamCompArg;
     int			(*streamCompStuffInput)(
 			    int fd,
 			    unsigned char *buf,

--- a/nx-X11/include/extensions/syncstr.h
+++ b/nx-X11/include/extensions/syncstr.h
@@ -396,11 +396,11 @@ typedef struct _SysCounterInfo {
     CARD64	bracket_less;
     SyncCounterType counterType;  /* how can this counter change */
     void        (*QueryValue)(
-			      pointer /*pCounter*/,
+			      void * /*pCounter*/,
 			      CARD64 * /*freshvalue*/
 );
     void	(*BracketValues)(
-				 pointer /*pCounter*/,
+				 void * /*pCounter*/,
 				 CARD64 * /*lessthan*/,
 				 CARD64 * /*greaterthan*/
 );
@@ -465,16 +465,16 @@ typedef union {
 } SyncAwaitUnion;
 
 
-extern pointer SyncCreateSystemCounter(
+extern void * SyncCreateSystemCounter(
     char *	/* name */,
     CARD64  	/* inital_value */,
     CARD64  	/* resolution */,
     SyncCounterType /* change characterization */,
     void        (* /*QueryValue*/ ) (
-        pointer /* pCounter */,
+        void * /* pCounter */,
         CARD64 * /* pValue_return */), /* XXX prototype */
     void        (* /*BracketValues*/) (
-        pointer /* pCounter */, 
+        void * /* pCounter */,
         CARD64 * /* pbracket_less */,
         CARD64 * /* pbracket_greater */)
 );
@@ -485,7 +485,7 @@ extern void SyncChangeCounter(
 );
 
 extern void SyncDestroySystemCounter(
-    pointer pCounter
+    void * pCounter
 );
 extern void InitServertime(void);
 

--- a/nx-X11/include/extensions/xtrapproto.h
+++ b/nx-X11/include/extensions/xtrapproto.h
@@ -44,7 +44,7 @@ SOFTWARE.
 # define Bool int
 #endif
 /* xtrapdi.c */
-int XETrapDestroyEnv (pointer value , XID id );
+int XETrapDestroyEnv (void * value , XID id );
 void XETrapCloseDown ( ExtensionEntry *extEntry );
 Bool XETrapRedirectDevices (void );
 void DEC_XTRAPInit (void );

--- a/nx-X11/programs/Xserver/GL/glx/glxcmds.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxcmds.c
@@ -229,7 +229,7 @@ int DoCreateContext(__GLXclientState *cl, GLXContextID gcId,
     /*
     ** Register this context as a resource.
     */
-    if (!AddResource(gcId, __glXContextRes, (pointer)glxc)) {
+    if (!AddResource(gcId, __glXContextRes, (void *)glxc)) {
 	if (!isDirect) {
 	    (*glxc->gc->exports.destroyContext)((__GLcontext *)glxc->gc);
         }
@@ -1760,7 +1760,7 @@ static int __glXBindSwapBarrierSGIX(__GLXclientState *cl, GLbyte *pc)
             if (ret == Success) {
                 if (barrier)
                     /* add source for cleanup when drawable is gone */
-                    AddResource(drawable, __glXSwapBarrierRes, (pointer)screen);
+                    AddResource(drawable, __glXSwapBarrierRes, (void *)screen);
                 else
                     /* delete source */
                     FreeResourceByType(drawable, __glXSwapBarrierRes, FALSE);

--- a/nx-X11/programs/Xserver/GL/glx/glxext.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxext.c
@@ -417,7 +417,7 @@ static int __glXDispatch(ClientPtr client)
 	** with the client so we will be notified when the client dies.
 	*/
 	XID xid = FakeClientID(client->index);
-	if (!AddResource( xid, __glXClientRes, (pointer)(long)client->index)) {
+	if (!AddResource( xid, __glXClientRes, (void *)(long)client->index)) {
 	    return BadAlloc;
 	}
 	ResetClientState(client->index);
@@ -471,7 +471,7 @@ static int __glXSwapDispatch(ClientPtr client)
 	** with the client so we will be notified when the client dies.
 	*/
 	XID xid = FakeClientID(client->index);
-	if (!AddResource( xid, __glXClientRes, (pointer)(long)client->index)) {
+	if (!AddResource( xid, __glXClientRes, (void *)(long)client->index)) {
 	    return BadAlloc;
 	}
 	ResetClientState(client->index);

--- a/nx-X11/programs/Xserver/GL/glxmodule.c
+++ b/nx-X11/programs/Xserver/GL/glxmodule.c
@@ -1236,11 +1236,11 @@ static XF86ModuleVersionInfo VersRec =
 
 XF86ModuleData glxModuleData = { &VersRec, glxSetup, NULL };
 
-static pointer
-glxSetup(pointer module, pointer opts, int *errmaj, int *errmin)
+static void *
+glxSetup(void * module, void * opts, int *errmaj, int *errmin)
 {
     static Bool setupDone = FALSE;
-    pointer GLcore  = NULL;
+    void * GLcore  = NULL;
 #ifdef GLX_USE_SGI_SI
     char GLcoreName[] = "GL";
 #else

--- a/nx-X11/programs/Xserver/GL/mesa/GLcore/GLcoremodule.c
+++ b/nx-X11/programs/Xserver/GL/mesa/GLcore/GLcoremodule.c
@@ -56,9 +56,9 @@ static XF86ModuleVersionInfo VersRec =
 
 XF86ModuleData GLcoreModuleData = { &VersRec, GLcoreSetup, NULL };
 
-static pointer
-GLcoreSetup(pointer module, pointer opts, int *errmaj, int *errmin)
+static void *
+GLcoreSetup(void * module, void * opts, int *errmaj, int *errmin)
 {
     /* Need a non-NULL return value to indicate success */
-    return (pointer)1;
+    return (void *)1;
 }

--- a/nx-X11/programs/Xserver/XTrap/xf86XTrapModule.c
+++ b/nx-X11/programs/Xserver/XTrap/xf86XTrapModule.c
@@ -41,11 +41,11 @@ static XF86ModuleVersionInfo xtrapVersRec =
 
 XF86ModuleData xtrapModuleData = { &xtrapVersRec, xtrapSetup, NULL };
 
-static pointer
-xtrapSetup(pointer module, pointer opts, int *errmaj, int *errmin) {
+static void *
+xtrapSetup(void * module, void * opts, int *errmaj, int *errmin) {
     LoadExtension(&xtrapExt, FALSE);
     /* Need a non-NULL return value to indicate success */
-    return (pointer)1;
+    return (void *)1;
 }
 
 #endif /* XFree86LOADER */

--- a/nx-X11/programs/Xserver/XTrap/xtrapdi.c
+++ b/nx-X11/programs/Xserver/XTrap/xtrapdi.c
@@ -195,7 +195,7 @@ static void GetSendColorPlanesRep (ClientPtr client , xResourceReq *req );
  *      client would be reset here.
  *
  */
-int XETrapDestroyEnv(pointer value, XID id)
+int XETrapDestroyEnv(void * value, XID id)
 {
     xXTrapReq request;
     XETrapEnv *penv = XETenv[(long)value];
@@ -251,7 +251,7 @@ void XETrapCloseDown(ExtensionEntry *extEntry)
     {
         if (XETenv[i] != NULL)
         {
-            XETrapDestroyEnv((pointer)i,0L);
+            XETrapDestroyEnv((void *)i,0L);
         }
     }
     ignore_grabs = False;
@@ -508,7 +508,7 @@ int XETrapCreateEnv(ClientPtr client)
         penv->protocol = 31;    /* default to backwards compatibility */
         /* prep for client's departure (for memory dealloc, cleanup) */
         AddResource(FakeClientID(client->index),XETrapType,
-            (pointer)(long)(client->index));
+            (void *)(long)(client->index));
         if (XETrapRedirectDevices() == False)
         {
             status = XETrapErrorBase + BadDevices;

--- a/nx-X11/programs/Xserver/Xext/appgroup.c
+++ b/nx-X11/programs/Xserver/Xext/appgroup.c
@@ -92,7 +92,7 @@ extern int connBlockScreenStart;
 
 static 
 int XagAppGroupFree(
-    pointer what,
+    void * what,
     XID id) /* unused */
 {
     int i;
@@ -126,8 +126,8 @@ int XagAppGroupFree(
 /* static */
 void XagClientStateChange(
     CallbackListPtr* pcbl,
-    pointer nulldata,
-    pointer calldata)
+    void * nulldata,
+    void * calldata)
 {
     SecurityAuthorizationPtr pAuth;
     NewClientInfoRec* pci = (NewClientInfoRec*) calldata;
@@ -262,7 +262,7 @@ void XagResetProc(
 {
     DeleteCallback (&ClientStateCallback, XagClientStateChange, NULL);
     XagCallbackRefCount = 0;
-    while (appGrpList) XagAppGroupFree ((pointer) appGrpList, 0);
+    while (appGrpList) XagAppGroupFree ((void *) appGrpList, 0);
 }
 
 static 
@@ -476,7 +476,7 @@ int ProcXagCreate (
 	return BadAlloc;
     ret = AttrValidate (client, stuff->attrib_mask, pAppGrp);
     if (ret != Success) {
-	XagAppGroupFree ((pointer)pAppGrp, (XID)0);
+	XagAppGroupFree ((void *)pAppGrp, (XID)0);
 	return ret;
     }
     if (pAppGrp->single_screen) {
@@ -484,7 +484,7 @@ int ProcXagCreate (
 	if (!pAppGrp->ConnectionInfo)
 	    return BadAlloc;
     }
-    if (!AddResource (stuff->app_group, RT_APPGROUP, (pointer)pAppGrp))
+    if (!AddResource (stuff->app_group, RT_APPGROUP, (void *)pAppGrp))
 	return BadAlloc;
     if (XagCallbackRefCount++ == 0)
 	(void) AddCallback (&ClientStateCallback, XagClientStateChange, NULL);
@@ -824,6 +824,6 @@ void XagCallClientStateChange(
 	NewClientInfoRec clientinfo;
 
 	clientinfo.client = client;
-	XagClientStateChange (NULL, NULL, (pointer)&clientinfo);
+	XagClientStateChange (NULL, NULL, (void *)&clientinfo);
     }
 }

--- a/nx-X11/programs/Xserver/Xext/appgroup.h
+++ b/nx-X11/programs/Xserver/Xext/appgroup.h
@@ -2,8 +2,8 @@
 
 void XagClientStateChange(
     CallbackListPtr* pcbl,
-    pointer nulldata,
-    pointer calldata);
+    void * nulldata,
+    void * calldata);
 int ProcXagCreate (
     register ClientPtr client);
 int ProcXagDestroy(

--- a/nx-X11/programs/Xserver/Xext/extmod/modinit.c
+++ b/nx-X11/programs/Xserver/Xext/extmod/modinit.c
@@ -232,8 +232,8 @@ static XF86ModuleVersionInfo VersRec =
  */
 XF86ModuleData extmodModuleData = { &VersRec, extmodSetup, NULL };
 
-static pointer
-extmodSetup(pointer module, pointer opts, int *errmaj, int *errmin)
+static void *
+extmodSetup(void * module, void * opts, int *errmaj, int *errmin)
 {
     int i;
 
@@ -244,7 +244,7 @@ extmodSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 	    char *s;
 	    s = (char *)xalloc(strlen(extensionModules[i].name) + 5);
 	    if (s) {
-		pointer o;
+		void * o;
 		strcpy(s, "omit");
 		strcat(s, extensionModules[i].name);
 		o = xf86FindOption(opts, s);
@@ -258,7 +258,7 @@ extmodSetup(pointer module, pointer opts, int *errmaj, int *errmin)
 	LoadExtension(&extensionModules[i], FALSE);
     }
     /* Need a non-NULL return */
-    return (pointer)1;
+    return (void *)1;
 }
 
 #endif /* XFree86LOADER */

--- a/nx-X11/programs/Xserver/Xext/mbuf.c
+++ b/nx-X11/programs/Xserver/Xext/mbuf.c
@@ -107,7 +107,7 @@ static int		EventSelectForMultibuffer(
  */
 RESTYPE			MultibufferDrawableResType;
 static int		MultibufferDrawableDelete (
-				pointer /* value */,
+				void * /* value */,
 				XID /* id */
 				);
 /*
@@ -117,7 +117,7 @@ static int		MultibufferDrawableDelete (
  */
 static RESTYPE		MultibufferResType;
 static int		MultibufferDelete (
-				pointer /* value */,
+				void * /* value */,
 				XID /* id */
 				);
 
@@ -127,7 +127,7 @@ static int		MultibufferDelete (
  */
 static RESTYPE		MultibuffersResType;
 static int		MultibuffersDelete (
-				pointer /* value */,
+				void * /* value */,
 				XID /* id */
 				);
 
@@ -137,7 +137,7 @@ static int		MultibuffersDelete (
  */
 static RESTYPE		OtherClientResType;
 static int		OtherClientDelete (
-				pointer /* value */,
+				void * /* value */,
 				XID /* id */
 				);
 
@@ -229,7 +229,7 @@ MultibufferExtensionInit()
 		xfree (screenInfo.screens[j]->devPrivates[MultibufferScreenIndex].ptr);
 	    return;
 	}
-	pScreen->devPrivates[MultibufferScreenIndex].ptr = (pointer) pMultibufferScreen;
+	pScreen->devPrivates[MultibufferScreenIndex].ptr = (void *) pMultibufferScreen;
 	/*
  	 * wrap PositionWindow to resize the pixmap when the window
 	 * changes size
@@ -312,7 +312,7 @@ SetupBackgroundPainter (pWin, pGC)
     WindowPtr	pWin;
     GCPtr	pGC;
 {
-    pointer	    gcvalues[4];
+    void	    *gcvalues[4];
     int		    ts_x_origin, ts_y_origin;
     PixUnion	    background;
     int		    backgroundState;
@@ -337,21 +337,21 @@ SetupBackgroundPainter (pWin, pGC)
     switch (backgroundState)
     {
     case BackgroundPixel:
-	gcvalues[0] = (pointer) background.pixel;
-	gcvalues[1] = (pointer) FillSolid;
+	gcvalues[0] = (void *) background.pixel;
+	gcvalues[1] = (void *) FillSolid;
 	gcmask = GCForeground|GCFillStyle;
 	break;
 
     case BackgroundPixmap:
-	gcvalues[0] = (pointer) FillTiled;
-	gcvalues[1] = (pointer) background.pixmap;
-	gcvalues[2] = (pointer)(long) ts_x_origin;
-	gcvalues[3] = (pointer)(long) ts_y_origin;
+	gcvalues[0] = (void *) FillTiled;
+	gcvalues[1] = (void *) background.pixmap;
+	gcvalues[2] = (void *)(long) ts_x_origin;
+	gcvalues[3] = (void *)(long) ts_y_origin;
 	gcmask = GCFillStyle|GCTile|GCTileStipXOrigin|GCTileStipYOrigin;
 	break;
 
     default:
-	gcvalues[0] = (pointer) GXnoop;
+	gcvalues[0] = (void *) GXnoop;
 	gcmask = GCFunction;
     }
     DoChangeGC(pGC, gcmask, (XID *)gcvalues, TRUE);
@@ -381,7 +381,7 @@ CreateImageBuffers (pWin, nbuf, ids, action, hint)
     pMultibuffers->pWindow = pWin;
     pMultibuffers->buffers = (MultibufferPtr) (pMultibuffers + 1);
     pMultibuffers->refcnt = pMultibuffers->numMultibuffer = 0;
-    if (!AddResource (pWin->drawable.id, MultibuffersResType, (pointer) pMultibuffers))
+    if (!AddResource (pWin->drawable.id, MultibuffersResType, (void *) pMultibuffers))
 	return BadAlloc;
     width = pWin->drawable.width;
     height = pWin->drawable.height;
@@ -407,12 +407,12 @@ CreateImageBuffers (pWin, nbuf, ids, action, hint)
 	pMultibuffer->side = MultibufferSideMono;
 	pMultibuffer->clobber = MultibufferUnclobbered;
 	pMultibuffer->pMultibuffers = pMultibuffers;
-	if (!AddResource (ids[i], MultibufferResType, (pointer) pMultibuffer))
+	if (!AddResource (ids[i], MultibufferResType, (void *) pMultibuffer))
 	    break;
 	pMultibuffer->pPixmap = (*pScreen->CreatePixmap) (pScreen, width, height, depth);
 	if (!pMultibuffer->pPixmap)
 	    break;
-	if (!AddResource (ids[i], MultibufferDrawableResType, (pointer) pMultibuffer->pPixmap))
+	if (!AddResource (ids[i], MultibufferDrawableResType, (void *) pMultibuffer->pPixmap))
 	{
 	    FreeResource (ids[i], MultibufferResType);
 	    (*pScreen->DestroyPixmap) (pMultibuffer->pPixmap);
@@ -439,7 +439,7 @@ CreateImageBuffers (pWin, nbuf, ids, action, hint)
     pMultibuffers->lastUpdate.milliseconds = 0;
     pMultibuffers->width = width;
     pMultibuffers->height = height;
-    pWin->devPrivates[MultibufferWindowIndex].ptr = (pointer) pMultibuffers;
+    pWin->devPrivates[MultibufferWindowIndex].ptr = (void *) pMultibuffers;
     if (pClearGC) FreeScratchGC(pClearGC);
     return Success;
 }
@@ -693,7 +693,7 @@ ProcGetMBufferAttributes (client)
 		   (char *)&rep);
     WriteToClient (client, (int)(pMultibuffers->numMultibuffer * sizeof (XID)),
 		   (char *)ids);
-    DEALLOCATE_LOCAL((pointer) ids);
+    DEALLOCATE_LOCAL((void *) ids);
     return client->noClientException;
 }
 
@@ -842,9 +842,9 @@ ProcGetBufferInfo (client)
 	    k++;
 	}
     }
-    WriteToClient (client, sizeof (xMbufGetBufferInfoReply), (pointer) &rep);
-    WriteToClient (client, (int) nInfo * sizeof (xMbufBufferInfo), (pointer) pInfo);
-    DEALLOCATE_LOCAL ((pointer) pInfo);
+    WriteToClient (client, sizeof (xMbufGetBufferInfoReply), (void *) &rep);
+    WriteToClient (client, (int) nInfo * sizeof (xMbufBufferInfo), (void *) pInfo);
+    DEALLOCATE_LOCAL ((void *) pInfo);
     return client->noClientException;
 }
 
@@ -1463,7 +1463,7 @@ AliasMultibuffer (pMultibuffers, i)
 	pMultibuffer = &pMultibuffers->buffers[pMultibuffers->displayedMultibuffer];
 	ChangeResourceValue (pMultibuffer->pPixmap->drawable.id,
 			     MultibufferDrawableResType,
- 			     (pointer) pMultibuffer->pPixmap);
+			     (void *) pMultibuffer->pPixmap);
     }
     /*
      * make the new association
@@ -1471,7 +1471,7 @@ AliasMultibuffer (pMultibuffers, i)
     pMultibuffer = &pMultibuffers->buffers[i];
     ChangeResourceValue (pMultibuffer->pPixmap->drawable.id,
 			 MultibufferDrawableResType,
-			 (pointer) pMultibuffers->pWindow);
+			 (void *) pMultibuffers->pWindow);
     pMultibuffers->displayedMultibuffer = i;
 }
 
@@ -1608,7 +1608,7 @@ MultibufferPositionWindow (pWin, x, y)
 	{
 	    ChangeResourceValue (pPixmap->drawable.id,
 				 MultibufferDrawableResType,
-				 (pointer) pPixmap);
+				 (void *) pPixmap);
 	}
     }
     FreeScratchGC (pGC);
@@ -1619,7 +1619,7 @@ MultibufferPositionWindow (pWin, x, y)
 /*ARGSUSED*/
 static int
 MultibufferDrawableDelete (value, id)
-    pointer	value;
+    void	*value;
     XID		id;
 {
     DrawablePtr	pDrawable = (DrawablePtr)value;
@@ -1645,7 +1645,7 @@ MultibufferDrawableDelete (value, id)
 /*ARGSUSED*/
 static int
 MultibufferDelete (value, id)
-    pointer	value;
+    void	*value;
     XID		id;
 {
     MultibufferPtr	pMultibuffer = (MultibufferPtr)value;
@@ -1665,7 +1665,7 @@ MultibufferDelete (value, id)
 /*ARGSUSED*/
 static int
 MultibuffersDelete (value, id)
-    pointer	value;
+    void	*value;
     XID		id;
 {
     MultibuffersPtr	pMultibuffers = (MultibuffersPtr)value;
@@ -1682,7 +1682,7 @@ MultibuffersDelete (value, id)
 /* Resource delete func for OtherClientResType */
 static int
 OtherClientDelete (value, id)
-    pointer	value;
+    void	*value;
     XID		id;
 {
     MultibufferPtr	pMultibuffer = (MultibufferPtr)value;
@@ -1745,7 +1745,7 @@ EventSelectForMultibuffer (pMultibuffer, client, mask)
 		return BadAlloc;
 	    other->mask = mask;
 	    other->resource = FakeClientID (client->index);
-	    if (!AddResource (other->resource, OtherClientResType, (pointer) pMultibuffer))
+	    if (!AddResource (other->resource, OtherClientResType, (void *) pMultibuffer))
 	    {
 		xfree (other);
 		return BadAlloc;

--- a/nx-X11/programs/Xserver/Xext/mbufbf.c
+++ b/nx-X11/programs/Xserver/Xext/mbufbf.c
@@ -230,7 +230,7 @@ bufMultibufferInit(pScreen, pMBScreen)
     if (!pMBPriv)
 	return (FALSE);
 
-    pMBScreen->devPrivate.ptr = (pointer) pMBPriv;
+    pMBScreen->devPrivate.ptr = (void *) pMBPriv;
     pMBPriv->frameBuffer  = bufFrameBuffer[pScreen->myNum];
     pMBPriv->selectPlane = bufselectPlane[pScreen->myNum];
 
@@ -374,7 +374,7 @@ bufCreateImageBuffers (pWin, nbuf, ids, action, hint)
     pMBScreen = MB_SCREEN_PRIV(pScreen);
     pMBWindow = MB_WINDOW_PRIV(pWin);
 
-    pMBWindow->devPrivate.ptr = (pointer) REGION_CREATE(pScreen, 0,0);
+    pMBWindow->devPrivate.ptr = (void *) REGION_CREATE(pScreen, 0,0);
     if (!pMBWindow->devPrivate.ptr)
 	return(0);
     REGION_COPY(pScreen, (RegionPtr) pMBWindow->devPrivate.ptr,
@@ -389,7 +389,7 @@ bufCreateImageBuffers (pWin, nbuf, ids, action, hint)
 	    break;
 
 	if (!AddResource (ids[i], MultibufferDrawableResType,
-			  (pointer) pMBBuffer->pDrawable))
+			  (void *) pMBBuffer->pDrawable))
 	{
 	    bufDestroyBuffer((BufferPtr) pMBBuffer->pDrawable);
 	    break;

--- a/nx-X11/programs/Xserver/Xext/mbufpx.c
+++ b/nx-X11/programs/Xserver/Xext/mbufpx.c
@@ -124,7 +124,7 @@ pixMultibufferInit(pScreen, pMBScreen)
 	xfree(pInfo);
 	return (FALSE);
     }
-    pMBScreen->devPrivate.ptr = (pointer) pMBPriv;
+    pMBScreen->devPrivate.ptr = (void *) pMBPriv;
     pMBPriv->PositionWindow = NULL;
     pMBPriv->funcsWrapped = 0;
 
@@ -162,7 +162,7 @@ pixCreateImageBuffers (pWin, nbuf, ids, action, hint)
 	    break;
 
 	if (!AddResource (ids[i], MultibufferDrawableResType,
-			  (pointer) pMBBuffer->pDrawable))
+			  (void *) pMBBuffer->pDrawable))
 	{
 	    (*pScreen->DestroyPixmap) ((PixmapPtr) pMBBuffer->pDrawable);
 	    break;
@@ -570,7 +570,7 @@ pixPositionWindow (pWin, x, y)
 	{
 	    ChangeResourceValue (pPixmap->drawable.id,
 				 MultibufferDrawableResType,
-				 (pointer) pPixmap);
+				 (void *) pPixmap);
 	}
     }
     FreeScratchGC (pGC);

--- a/nx-X11/programs/Xserver/Xext/panoramiX.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiX.c
@@ -133,7 +133,7 @@ static void XineramaValidateGC(GCPtr, unsigned long, DrawablePtr);
 static void XineramaChangeGC(GCPtr, unsigned long);
 static void XineramaCopyGC(GCPtr, unsigned long, GCPtr);
 static void XineramaDestroyGC(GCPtr);
-static void XineramaChangeClip(GCPtr, int, pointer, int);
+static void XineramaChangeClip(GCPtr, int, void *, int);
 static void XineramaDestroyClip(GCPtr);
 static void XineramaCopyClip(GCPtr, GCPtr);
 
@@ -165,7 +165,7 @@ XineramaCloseScreen (int i, ScreenPtr pScreen)
     if (pScreen->myNum == 0)
 	REGION_UNINIT(pScreen, &PanoramiXScreenRegion);
 
-    xfree ((pointer) pScreenPriv);
+    xfree ((void *) pScreenPriv);
 
     return (*pScreen->CloseScreen) (i, pScreen);
 }
@@ -308,7 +308,7 @@ static void
 XineramaChangeClip (
     GCPtr   pGC,
     int		type,
-    pointer	pvalue,
+    void	*pvalue,
     int		nrects 
 ){
     Xinerama_GC_FUNC_PROLOGUE (pGC);
@@ -335,7 +335,7 @@ XineramaDestroyClip(GCPtr pGC)
 
 
 int
-XineramaDeleteResource(pointer data, XID id)
+XineramaDeleteResource(void * data, XID id)
 {
     xfree(data);
     return 1;
@@ -343,7 +343,7 @@ XineramaDeleteResource(pointer data, XID id)
 
 
 static Bool 
-XineramaFindIDOnAnyScreen(pointer resource, XID id, pointer privdata)
+XineramaFindIDOnAnyScreen(void * resource, XID id, void * privdata)
 {
     PanoramiXRes *res = (PanoramiXRes*)resource;
     int j;
@@ -368,7 +368,7 @@ typedef struct {
 
 
 static Bool 
-XineramaFindIDByScrnum(pointer resource, XID id, pointer privdata)
+XineramaFindIDByScrnum(void * resource, XID id, void * privdata)
 {
     PanoramiXRes *res = (PanoramiXRes*)resource;
     PanoramiXSearchData *data = (PanoramiXSearchData*)privdata;
@@ -541,7 +541,7 @@ void PanoramiXExtensionInit(int argc, char *argv[])
 
 	   pScreenPriv = xalloc(sizeof(PanoramiXScreenRec));
 	   pScreen->devPrivates[PanoramiXScreenIndex].ptr = 
-						(pointer)pScreenPriv;
+						(void *)pScreenPriv;
 	   if(!pScreenPriv) {
 		noPanoramiXExtension = TRUE;
 		return;
@@ -747,9 +747,9 @@ Bool PanoramiXCreateConnectionBlock(void)
     root->mmHeight *= height_mult;
 
     while(ConnectionCallbackList) {
-	pointer tmp;
+	void *tmp;
 
-	tmp = (pointer)ConnectionCallbackList;
+	tmp = (void *)ConnectionCallbackList;
 	(*ConnectionCallbackList->func)();
 	ConnectionCallbackList = ConnectionCallbackList->next;
 	xfree(tmp);

--- a/nx-X11/programs/Xserver/Xext/panoramiXsrv.h
+++ b/nx-X11/programs/Xserver/Xext/panoramiXsrv.h
@@ -22,7 +22,7 @@ extern PanoramiXRes * PanoramiXFindIDByScrnum(RESTYPE, XID, int);
 extern PanoramiXRes * PanoramiXFindIDOnAnyScreen(RESTYPE, XID);
 extern WindowPtr PanoramiXChangeWindow(int, WindowPtr);
 extern Bool XineramaRegisterConnectionBlockCallback(void (*func)(void));
-extern int XineramaDeleteResource(pointer, XID);
+extern int XineramaDeleteResource(void *, XID);
 
 extern void XineramaReinitData(ScreenPtr);
 

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -139,7 +139,7 @@ typedef struct _ScreenSaverEvent {
 } ScreenSaverEventRec;
 
 static int ScreenSaverFreeEvents(
-    pointer /* value */,
+    void * /* value */,
     XID /* id */
 );
 
@@ -179,7 +179,7 @@ typedef struct _ScreenSaverAttr {
 } ScreenSaverAttrRec, *ScreenSaverAttrPtr;
 
 static int ScreenSaverFreeAttr (
-    pointer /* value */,
+    void * /* value */,
     XID /* id */
 );
 
@@ -213,7 +213,7 @@ MakeScreenPrivate (
 static int ScreenPrivateIndex;
 
 #define GetScreenPrivate(s) ((ScreenSaverScreenPrivatePtr)(s)->devPrivates[ScreenPrivateIndex].ptr)
-#define SetScreenPrivate(s,v) ((s)->devPrivates[ScreenPrivateIndex].ptr = (pointer) v);
+#define SetScreenPrivate(s,v) ((s)->devPrivates[ScreenPrivateIndex].ptr = (void *) v);
 #define SetupScreen(s)	ScreenSaverScreenPrivatePtr pPriv = (s ? GetScreenPrivate(s) : NULL)
 
 #define New(t)	((t *) xalloc (sizeof (t)))
@@ -356,7 +356,7 @@ setEventMask (pScreen, client, mask)
     	    pEv->client = client;
     	    pEv->screen = pScreen;
     	    pEv->resource = FakeClientID (client->index);
-	    if (!AddResource (pEv->resource, EventType, (pointer) pEv))
+	    if (!AddResource (pEv->resource, EventType, (void *) pEv))
 		return FALSE;
     	}
 	pEv->mask = mask;
@@ -390,7 +390,7 @@ FreeScreenAttr (pAttr)
 
 static int
 ScreenSaverFreeEvents (value, id)
-    pointer value;
+    void * value;
     XID id;
 {
     ScreenSaverEventPtr	pOld = (ScreenSaverEventPtr)value;
@@ -413,7 +413,7 @@ ScreenSaverFreeEvents (value, id)
 
 static int
 ScreenSaverFreeAttr (value, id)
-    pointer value;
+    void * value;
     XID id;
 {
     ScreenSaverAttrPtr	pOldAttr = (ScreenSaverAttrPtr)value;
@@ -1163,7 +1163,7 @@ ScreenSaverSetAttributes (ClientPtr client)
 	FreeScreenAttr (pPriv->attr);
     pPriv->attr = pAttr;
     pAttr->resource = FakeClientID (client->index);
-    if (!AddResource (pAttr->resource, AttrType, (pointer) pAttr))
+    if (!AddResource (pAttr->resource, AttrType, (void *) pAttr))
 	return BadAlloc;
     return Success;
 PatchUp:

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -288,7 +288,7 @@ SecurityAudit(char *format, ...)
 
 static int
 SecurityDeleteAuthorization(
-    pointer value,
+    void * value,
     XID id)
 {
     SecurityAuthorizationPtr pAuth = (SecurityAuthorizationPtr)value;
@@ -347,7 +347,7 @@ SecurityDeleteAuthorization(
 /* resource delete function for RTEventClient */
 static int
 SecurityDeleteAuthorizationEventClient(
-    pointer value,
+    void * value,
     XID id)
 {
     OtherClientsPtr pEventClient, prev = NULL;
@@ -432,7 +432,7 @@ static CARD32
 SecurityAuthorizationExpired(
     OsTimerPtr timer,
     CARD32 time,
-    pointer pval)
+    void * pval)
 {
     SecurityAuthorizationPtr pAuth = (SecurityAuthorizationPtr)pval;
 
@@ -538,7 +538,7 @@ SecurityEventSelectForAuthorization(
     pEventClient->resource = FakeClientID(client->index);
     pEventClient->next = pAuth->eventClients;
     if (!AddResource(pEventClient->resource, RTEventClient,
-		     (pointer)pAuth))
+		     (void *)pAuth))
     {
 	xfree(pEventClient);
 	return BadAlloc;
@@ -624,7 +624,7 @@ ProcSecurityGenerateAuthorization(
 	    SecurityValidateGroupInfoRec vgi;
 	    vgi.group = group;
 	    vgi.valid = FALSE;
-	    CallCallbacks(&SecurityValidateGroupCallback, (pointer)&vgi);
+	    CallCallbacks(&SecurityValidateGroupCallback, (void *)&vgi);
 
 	    /* if nobody said they recognized it, it's an error */
 
@@ -1065,7 +1065,7 @@ SecurityCheckDeviceAccess(client, dev, fromRequest)
  *	resource access.
  */
 
-static pointer
+static void *
 SecurityAuditResourceIDAccess(
     ClientPtr client,
     XID id)
@@ -1119,13 +1119,13 @@ SecurityAuditResourceIDAccess(
  *	Disallowed resource accesses are audited.
  */
 
-static pointer
+static void *
 SecurityCheckResourceIDAccess(
     ClientPtr client,
     XID id,
     RESTYPE rtype,
     Mask access_mode,
-    pointer rval)
+    void * rval)
 {
     int cid = CLIENT_ID(id);
     int reqtype = ((xReq *)client->requestBuffer)->reqType;
@@ -1288,8 +1288,8 @@ SecurityCheckResourceIDAccess(
 static void
 SecurityClientStateCallback(
     CallbackListPtr *pcbl,
-    pointer nulldata,
-    pointer calldata)
+    void * nulldata,
+    void * calldata)
 {
     NewClientInfoRec *pci = (NewClientInfoRec *)calldata;
     ClientPtr client = pci->client;
@@ -1445,7 +1445,7 @@ SecurityCensorImage(client, pVisibleRegion, widthBytesLine, pDraw, x, y, w, h,
 
 	pPix = GetScratchPixmapHeader(pDraw->pScreen, w, h,
 		    depth, bitsPerPixel,
-		    widthBytesLine, (pointer)pBuf);
+		    widthBytesLine, (void *)pBuf);
 	if (!pPix)
 	{
 	    failed = TRUE;

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -58,11 +58,11 @@ typedef	RegionPtr (*CreateDftPtr)(
 	);
 
 static int ShapeFreeClient(
-	pointer /* data */,
+	void * /* data */,
 	XID /* id */
 	);
 static int ShapeFreeEvents(
-	pointer /* data */,
+	void * /* data */,
 	XID /* id */
 	);
 static void ShapeResetProc(
@@ -774,7 +774,7 @@ ProcShapeQueryExtents (client)
 /*ARGSUSED*/
 static int
 ShapeFreeClient (data, id)
-    pointer	    data;
+    void	    *data;
     XID		    id;
 {
     ShapeEventPtr   pShapeEvent;
@@ -796,14 +796,14 @@ ShapeFreeClient (data, id)
 	    	*pHead = pShapeEvent->next;
 	}
     }
-    xfree ((pointer) pShapeEvent);
+    xfree ((void *) pShapeEvent);
     return 1;
 }
 
 /*ARGSUSED*/
 static int
 ShapeFreeEvents (data, id)
-    pointer	    data;
+    void	    *data;
     XID		    id;
 {
     ShapeEventPtr   *pHead, pCur, pNext;
@@ -812,9 +812,9 @@ ShapeFreeEvents (data, id)
     for (pCur = *pHead; pCur; pCur = pNext) {
 	pNext = pCur->next;
 	FreeResource (pCur->clientResource, ClientType);
-	xfree ((pointer) pCur);
+	xfree ((void *) pCur);
     }
-    xfree ((pointer) pHead);
+    xfree ((void *) pHead);
     return 1;
 }
 
@@ -861,7 +861,7 @@ ProcShapeSelectInput (client)
      	 */
    	clientResource = FakeClientID (client->index);
     	pNewShapeEvent->clientResource = clientResource;
-    	if (!AddResource (clientResource, ClientType, (pointer)pNewShapeEvent))
+	if (!AddResource (clientResource, ClientType, (void *)pNewShapeEvent))
 	    return BadAlloc;
     	/*
      	 * create a resource to contain a pointer to the list
@@ -873,7 +873,7 @@ ProcShapeSelectInput (client)
     	{
 	    pHead = (ShapeEventPtr *) xalloc (sizeof (ShapeEventPtr));
 	    if (!pHead ||
-	    	!AddResource (pWin->drawable.id, EventType, (pointer)pHead))
+		!AddResource (pWin->drawable.id, EventType, (void *)pHead))
 	    {
 	    	FreeResource (clientResource, RT_NONE);
 	    	return BadAlloc;

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -86,7 +86,7 @@ static void miShmPutImage(XSHM_PUT_IMAGE_ARGS);
 static void fbShmPutImage(XSHM_PUT_IMAGE_ARGS);
 static PixmapPtr fbShmCreatePixmap(XSHM_CREATE_PIXMAP_ARGS);
 static int ShmDetachSegment(
-    pointer		/* value */,
+    void *		/* value */,
     XID			/* shmseg */
     );
 static void ShmResetProc(
@@ -309,7 +309,7 @@ ShmDestroyPixmap (PixmapPtr pPixmap)
 #else
 	char	*base = (char *) pPixmap->devPrivate.ptr;
 	
-	if (base != (pointer) (pPixmap + 1))
+	if (base != (void *) (pPixmap + 1))
 	{
 	    for (shmdesc = Shmsegs; shmdesc; shmdesc = shmdesc->next)
 	    {
@@ -321,7 +321,7 @@ ShmDestroyPixmap (PixmapPtr pPixmap)
 	    shmdesc = 0;
 #endif
 	if (shmdesc)
-	    ShmDetachSegment ((pointer) shmdesc, pPixmap->drawable.id);
+	    ShmDetachSegment ((void *) shmdesc, pPixmap->drawable.id);
     }
     
     pScreen->DestroyPixmap = destroyPixmap[pScreen->myNum];
@@ -465,7 +465,7 @@ ProcShmAttach(client)
 	shmdesc->next = Shmsegs;
 	Shmsegs = shmdesc;
     }
-    if (!AddResource(stuff->shmseg, ShmSegType, (pointer)shmdesc))
+    if (!AddResource(stuff->shmseg, ShmSegType, (void *)shmdesc))
 	return BadAlloc;
     return(client->noClientException);
 }
@@ -473,7 +473,7 @@ ProcShmAttach(client)
 /*ARGSUSED*/
 static int
 ShmDetachSegment(value, shmseg)
-    pointer value; /* must conform to DeleteType */
+    void * value; /* must conform to DeleteType */
     XID shmseg;
 {
     ShmDescPtr shmdesc = (ShmDescPtr)value;
@@ -548,7 +548,7 @@ fbShmPutImage(dst, pGC, depth, format, w, h, sx, sy, sw, sh, dx, dy, data)
 	PixmapPtr pPixmap;
 
 	pPixmap = GetScratchPixmapHeader(dst->pScreen, w, h, depth,
-		BitsPerPixel(depth), PixmapBytePad(w, depth), (pointer)data);
+		BitsPerPixel(depth), PixmapBytePad(w, depth), (void *)data);
 	if (!pPixmap)
 	    return;
 	if (format == XYBitmap)
@@ -794,12 +794,12 @@ CreatePmap:
 
 	if (pMap) {
 #ifdef PIXPRIV
-            pMap->devPrivates[shmPixmapPrivate].ptr = (pointer) shmdesc;
+            pMap->devPrivates[shmPixmapPrivate].ptr = (void *) shmdesc;
 #endif
             shmdesc->refcnt++;
 	    pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	    pMap->drawable.id = newPix->info[j].id;
-	    if (!AddResource(newPix->info[j].id, RT_PIXMAP, (pointer)pMap)) {
+	    if (!AddResource(newPix->info[j].id, RT_PIXMAP, (void *)pMap)) {
 		(*pScreen->DestroyPixmap)(pMap);
 		result = BadAlloc;
 		break;
@@ -1062,7 +1062,7 @@ fbShmCreatePixmap (pScreen, width, height, depth, addr)
 	return NullPixmap;
 
     if (!(*pScreen->ModifyPixmapHeader)(pPixmap, width, height, depth,
-	    BitsPerPixel(depth), PixmapBytePad(width, depth), (pointer)addr)) {
+	    BitsPerPixel(depth), PixmapBytePad(width, depth), (void *)addr)) {
 	(*pScreen->DestroyPixmap)(pPixmap);
 	return NullPixmap;
     }
@@ -1129,12 +1129,12 @@ CreatePmap:
     if (pMap)
     {
 #ifdef PIXPRIV
-	pMap->devPrivates[shmPixmapPrivate].ptr = (pointer) shmdesc;
+	pMap->devPrivates[shmPixmapPrivate].ptr = (void *) shmdesc;
 #endif
 	shmdesc->refcnt++;
 	pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	pMap->drawable.id = stuff->pid;
-	if (AddResource(stuff->pid, RT_PIXMAP, (pointer)pMap))
+	if (AddResource(stuff->pid, RT_PIXMAP, (void *)pMap))
 	{
 	    return(client->noClientException);
 	}

--- a/nx-X11/programs/Xserver/Xext/sleepuntil.c
+++ b/nx-X11/programs/Xserver/Xext/sleepuntil.c
@@ -49,10 +49,10 @@ typedef struct _Sertafied {
     XID			id;
     void		(*notifyFunc)(
 			ClientPtr /* client */,
-			pointer /* closure */
+			void * /* closure */
 			);
 
-    pointer		closure;
+    void		*closure;
 } SertafiedRec, *SertafiedPtr;
 
 static SertafiedPtr pPending;
@@ -62,21 +62,21 @@ static int	    SertafiedGeneration;
 
 static void	    ClientAwaken(
     ClientPtr /* client */,
-    pointer /* closure */
+    void * /* closure */
 );
 static int	    SertafiedDelete(
-    pointer /* value */,
+    void * /* value */,
     XID /* id */
 );
 static void	    SertafiedBlockHandler(
-    pointer /* data */,
+    void * /* data */,
     OSTimePtr /* wt */,
-    pointer /* LastSelectMask */
+    void * /* LastSelectMask */
 );
 static void	    SertafiedWakeupHandler(
-    pointer /* data */,
+    void * /* data */,
     int /* i */,
-    pointer /* LastSelectMask */
+    void * /* LastSelectMask */
 );
 
 int
@@ -85,8 +85,8 @@ ClientSleepUntil (client, revive, notifyFunc, closure)
     TimeStamp	*revive;
     void	(*notifyFunc)(
         ClientPtr /* client */,
-        pointer   /* closure */);
-    pointer	closure;
+        void *   /* closure */);
+    void	*closure;
 {
     SertafiedPtr	pRequest, pReq, pPrev;
 
@@ -109,7 +109,7 @@ ClientSleepUntil (client, revive, notifyFunc, closure)
     {
 	if (!RegisterBlockAndWakeupHandlers (SertafiedBlockHandler,
 					     SertafiedWakeupHandler,
-					     (pointer) 0))
+					     (void *) 0))
 	{
 	    xfree (pRequest);
 	    return FALSE;
@@ -117,7 +117,7 @@ ClientSleepUntil (client, revive, notifyFunc, closure)
 	BlockHandlerRegistered = TRUE;
     }
     pRequest->notifyFunc = 0;
-    if (!AddResource (pRequest->id, SertafiedResType, (pointer) pRequest))
+    if (!AddResource (pRequest->id, SertafiedResType, (void *) pRequest))
 	return FALSE;
     if (!notifyFunc)
 	notifyFunc = ClientAwaken;
@@ -142,7 +142,7 @@ ClientSleepUntil (client, revive, notifyFunc, closure)
 static void
 ClientAwaken (client, closure)
     ClientPtr	client;
-    pointer	closure;
+    void	*closure;
 {
     if (!client->clientGone)
 	AttendClient (client);
@@ -151,7 +151,7 @@ ClientAwaken (client, closure)
 
 static int
 SertafiedDelete (value, id)
-    pointer value;
+    void * value;
     XID id;
 {
     SertafiedPtr	pRequest = (SertafiedPtr)value;
@@ -175,9 +175,9 @@ SertafiedDelete (value, id)
 
 static void
 SertafiedBlockHandler (data, wt, LastSelectMask)
-    pointer	    data;		/* unused */
+    void	    *data;		/* unused */
     OSTimePtr	    wt;			/* wait time */
-    pointer	    LastSelectMask;
+    void	    *LastSelectMask;
 {
     SertafiedPtr	    pReq, pNext;
     unsigned long	    delay;
@@ -211,9 +211,9 @@ SertafiedBlockHandler (data, wt, LastSelectMask)
 
 static void
 SertafiedWakeupHandler (data, i, LastSelectMask)
-    pointer	    data;
+    void *	    data;
     int		    i;
-    pointer	    LastSelectMask;
+    void *	    LastSelectMask;
 {
     SertafiedPtr	pReq, pNext;
     TimeStamp		now;
@@ -233,7 +233,7 @@ SertafiedWakeupHandler (data, i, LastSelectMask)
     {
 	RemoveBlockAndWakeupHandlers (SertafiedBlockHandler,
 				      SertafiedWakeupHandler,
-				      (pointer) 0);
+				      (void *) 0);
 	BlockHandlerRegistered = FALSE;
     }
 }

--- a/nx-X11/programs/Xserver/Xext/sleepuntil.h
+++ b/nx-X11/programs/Xserver/Xext/sleepuntil.h
@@ -39,9 +39,9 @@ extern int ClientSleepUntil(
     TimeStamp *revive,
     void (*notifyFunc)(
 	ClientPtr /* client */,
-	pointer   /* closure */
+	void *   /* closure */
 	),
-    pointer Closure
+    void * Closure
 );
 
 #endif

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -103,40 +103,40 @@ static SyncCounter **SysCounterList = NULL;
 
 static int
 FreeAlarm(
-    pointer /* addr */,
+    void * /* addr */,
     XID /* id */
 );
 
 static int
 FreeAlarmClient(
-    pointer /* value */,
+    void * /* value */,
     XID /* id */
 );
 
 static int
 FreeAwait(
-    pointer /* addr */,
+    void * /* addr */,
     XID /* id */
 );
 
 static void
 ServertimeBracketValues(
-    pointer /* pCounter */,
+    void * /* pCounter */,
     CARD64 * /* pbracket_less */,
     CARD64 * /* pbracket_greater */
 );
 
 static void
 ServertimeQueryValue(
-    pointer /* pCounter */,
+    void * /* pCounter */,
     CARD64 * /* pValue_return */
 );
 
 static void
 ServertimeWakeupHandler(
-    pointer /* env */,
+    void * /* env */,
     int /* rc */,
-    pointer /* LastSelectMask */
+    void * /* LastSelectMask */
 );
 
 static int 
@@ -161,9 +161,9 @@ SCounterNotifyEvent(
 
 static void
 ServertimeBlockHandler(
-    pointer  /* env */,
+    void *  /* env */,
     struct timeval ** /* wt */,
-    pointer  /* LastSelectMask */
+    void *  /* LastSelectMask */
 );
 
 static int
@@ -449,7 +449,7 @@ SyncInitTrigger(client, pTrigger, counter, changes)
 
     if (IsSystemCounter(pCounter))
     {
-	(*pCounter->pSysCounterInfo->QueryValue) ((pointer) pCounter,
+	(*pCounter->pSysCounterInfo->QueryValue) ((void *) pCounter,
 						  &pCounter->value);
     }
 
@@ -1016,9 +1016,9 @@ SyncCreateCounter(client, id, initialvalue)
     if (!(pCounter = (SyncCounter *) xalloc(sizeof(SyncCounter))))
 	return (SyncCounter *)NULL;
 
-    if (!AddResource(id, RTCounter, (pointer) pCounter))
+    if (!AddResource(id, RTCounter, (void *) pCounter))
     {
-	xfree((pointer) pCounter);
+	xfree((void *) pCounter);
 	return (SyncCounter *)NULL;
     }
 
@@ -1032,7 +1032,7 @@ SyncCreateCounter(client, id, initialvalue)
 }
 
 static int FreeCounter(
-    pointer /*env*/,
+    void * /*env*/,
     XID     /*id*/
 );
 
@@ -1040,7 +1040,7 @@ static int FreeCounter(
  * ***** System Counter utilities
  */
 
-pointer 
+void *
 SyncCreateSystemCounter(name, initial, resolution, counterType,
 			QueryValue, BracketValues)
     char           *name;
@@ -1048,10 +1048,10 @@ SyncCreateSystemCounter(name, initial, resolution, counterType,
     CARD64          resolution;
     SyncCounterType counterType;
     void            (*QueryValue) (
-        pointer /* pCounter */, 
+        void * /* pCounter */, 
         CARD64 * /* pValue_return */);
     void            (*BracketValues) (
-        pointer /* pCounter */,
+        void * /* pCounter */,
         CARD64 * /* pbracket_less */,
         CARD64 * /* pbracket_greater */);
 {
@@ -1060,7 +1060,7 @@ SyncCreateSystemCounter(name, initial, resolution, counterType,
     SysCounterList = (SyncCounter **)xrealloc(SysCounterList,
 			    (SyncNumSystemCounters+1)*sizeof(SyncCounter *));
     if (!SysCounterList)
-	return (pointer)NULL;
+	return (void *)NULL;
 
     /* this function may be called before SYNC has been initialized, so we
      * have to make sure RTCounter is created.
@@ -1070,7 +1070,7 @@ SyncCreateSystemCounter(name, initial, resolution, counterType,
 	RTCounter = CreateNewResourceType(FreeCounter);
 	if (RTCounter == 0)
 	{
-	    return (pointer)NULL;
+	    return (void *)NULL;
 	}
     }
 
@@ -1084,7 +1084,7 @@ SyncCreateSystemCounter(name, initial, resolution, counterType,
 	if (!psci)
 	{
 	    FreeResource(pCounter->id, RT_NONE);
-	    return (pointer) pCounter;
+	    return (void *) pCounter;
 	}
 	pCounter->pSysCounterInfo = psci;
 	psci->name = name;
@@ -1096,12 +1096,12 @@ SyncCreateSystemCounter(name, initial, resolution, counterType,
 	XSyncMinValue(&psci->bracket_less);
 	SysCounterList[SyncNumSystemCounters++] = pCounter;
     }
-    return (pointer) pCounter;
+    return (void *) pCounter;
 }
 
 void
 SyncDestroySystemCounter(pSysCounter)
-    pointer pSysCounter;
+    void * pSysCounter;
 {
     SyncCounter *pCounter = (SyncCounter *)pSysCounter;
     FreeResource(pCounter->id, RT_NONE);
@@ -1186,7 +1186,7 @@ SyncComputeBracketValues(pCounter, startOver)
 
     if (pnewgtval || pnewltval)
     {
-	(*psci->BracketValues)((pointer)pCounter, pnewltval, pnewgtval);
+	(*psci->BracketValues)((void *)pCounter, pnewltval, pnewgtval);
     }
 }
 
@@ -1197,7 +1197,7 @@ SyncComputeBracketValues(pCounter, startOver)
 /* ARGSUSED */
 static int
 FreeAlarm(addr, id)
-    pointer         addr;
+    void            *addr;
     XID             id;
 {
     SyncAlarm      *pAlarm = (SyncAlarm *) addr;
@@ -1224,7 +1224,7 @@ FreeAlarm(addr, id)
 /* ARGSUSED */
 static int
 FreeCounter(env, id)
-    pointer         env;
+    void            *env;
     XID             id;
 {
     SyncCounter     *pCounter = (SyncCounter *) env;
@@ -1276,7 +1276,7 @@ FreeCounter(env, id)
 /* ARGSUSED */
 static int
 FreeAwait(addr, id)
-    pointer         addr;
+    void            *addr;
     XID             id;
 {
     SyncAwaitUnion *pAwaitUnion = (SyncAwaitUnion *) addr;
@@ -1304,7 +1304,7 @@ FreeAwait(addr, id)
 /* loosely based on dix/events.c/OtherClientGone */
 static int
 FreeAlarmClient(value, id)
-    pointer value; /* must conform to DeleteType */
+    void * value; /* must conform to DeleteType */
     XID   id;
 {
     SyncAlarm *pAlarm = (SyncAlarm *)value;
@@ -1778,7 +1778,7 @@ ProcSyncQueryCounter(client)
 
     if (IsSystemCounter(pCounter))
     {
-	(*pCounter->pSysCounterInfo->QueryValue) ((pointer) pCounter,
+	(*pCounter->pSysCounterInfo->QueryValue) ((void *) pCounter,
 						  &pCounter->value);
     }
 
@@ -2406,7 +2406,7 @@ SyncExtensionInit(INITARGS)
 
 
 
-static pointer ServertimeCounter;
+static void * ServertimeCounter;
 static XSyncValue Now;
 static XSyncValue *pnext_time;
 
@@ -2424,9 +2424,9 @@ static XSyncValue *pnext_time;
  */
 /*ARGSUSED*/
 static void ServertimeBlockHandler(env, wt, LastSelectMask)
-pointer env;
+void * env;
 struct timeval **wt;
-pointer LastSelectMask;
+void * LastSelectMask;
 {
     XSyncValue delay;
     unsigned long timeout;
@@ -2455,9 +2455,9 @@ pointer LastSelectMask;
  */
 /*ARGSUSED*/
 static void ServertimeWakeupHandler(env, rc, LastSelectMask)
-pointer env;
+void * env;
 int rc;
-pointer LastSelectMask;
+void * LastSelectMask;
 {
     if (pnext_time)
     {
@@ -2472,7 +2472,7 @@ pointer LastSelectMask;
 
 static void
 ServertimeQueryValue(pCounter, pValue_return)
-    pointer pCounter;
+    void * pCounter;
     CARD64 *pValue_return;
 {
     GetTime();
@@ -2481,7 +2481,7 @@ ServertimeQueryValue(pCounter, pValue_return)
 
 static void
 ServertimeBracketValues(pCounter, pbracket_less, pbracket_greater)
-    pointer pCounter;
+    void * pCounter;
     CARD64 *pbracket_less;
     CARD64 *pbracket_greater;
 {

--- a/nx-X11/programs/Xserver/Xext/vidmodeproc.h
+++ b/nx-X11/programs/Xserver/Xext/vidmodeproc.h
@@ -36,7 +36,7 @@ typedef enum {
 } VidModeSelectMonitor;
 
 typedef union {
-  pointer ptr;
+  void * ptr;
   int i;
   float f;
 } vidMonitorValue;
@@ -44,31 +44,31 @@ typedef union {
 void XFree86VidModeExtensionInit(void);
 
 Bool VidModeAvailable(int scrnIndex);
-Bool VidModeGetCurrentModeline(int scrnIndex, pointer *mode, int *dotClock);
-Bool VidModeGetFirstModeline(int scrnIndex, pointer *mode, int *dotClock);
-Bool VidModeGetNextModeline(int scrnIndex, pointer *mode, int *dotClock);
-Bool VidModeDeleteModeline(int scrnIndex, pointer mode);
+Bool VidModeGetCurrentModeline(int scrnIndex, void **mode, int *dotClock);
+Bool VidModeGetFirstModeline(int scrnIndex, void **mode, int *dotClock);
+Bool VidModeGetNextModeline(int scrnIndex, void **mode, int *dotClock);
+Bool VidModeDeleteModeline(int scrnIndex, void * mode);
 Bool VidModeZoomViewport(int scrnIndex, int zoom);
 Bool VidModeGetViewPort(int scrnIndex, int *x, int *y);
 Bool VidModeSetViewPort(int scrnIndex, int x, int y);
-Bool VidModeSwitchMode(int scrnIndex, pointer mode);
+Bool VidModeSwitchMode(int scrnIndex, void * mode);
 Bool VidModeLockZoom(int scrnIndex, Bool lock);
-Bool VidModeGetMonitor(int scrnIndex, pointer *monitor);
+Bool VidModeGetMonitor(int scrnIndex, void **monitor);
 int VidModeGetNumOfClocks(int scrnIndex, Bool *progClock);
 Bool VidModeGetClocks(int scrnIndex, int *Clocks);
-ModeStatus VidModeCheckModeForMonitor(int scrnIndex, pointer mode);
-ModeStatus VidModeCheckModeForDriver(int scrnIndex, pointer mode);
-void VidModeSetCrtcForMode(int scrnIndex, pointer mode);
-Bool VidModeAddModeline(int scrnIndex, pointer mode);
+ModeStatus VidModeCheckModeForMonitor(int scrnIndex, void * mode);
+ModeStatus VidModeCheckModeForDriver(int scrnIndex, void * mode);
+void VidModeSetCrtcForMode(int scrnIndex, void * mode);
+Bool VidModeAddModeline(int scrnIndex, void * mode);
 int VidModeGetDotClock(int scrnIndex, int Clock);
 int VidModeGetNumOfModes(int scrnIndex);
 Bool VidModeSetGamma(int scrnIndex, float red, float green, float blue);
 Bool VidModeGetGamma(int scrnIndex, float *red, float *green, float *blue);
-pointer VidModeCreateMode(void);
-void VidModeCopyMode(pointer modefrom, pointer modeto);
-int VidModeGetModeValue(pointer mode, int valtyp);
-void VidModeSetModeValue(pointer mode, int valtyp, int val);
-vidMonitorValue VidModeGetMonitorValue(pointer monitor, int valtyp, int indx);
+void * VidModeCreateMode(void);
+void VidModeCopyMode(void * modefrom, void * modeto);
+int VidModeGetModeValue(void * mode, int valtyp);
+void VidModeSetModeValue(void * mode, int valtyp, int val);
+vidMonitorValue VidModeGetMonitorValue(void * monitor, int valtyp, int indx);
 Bool VidModeSetGammaRamp(int, int, CARD16 *, CARD16 *, CARD16 *);
 Bool VidModeGetGammaRamp(int, int, CARD16 *, CARD16 *, CARD16 *);
 int VidModeGetGammaRampSize(int scrnIndex);

--- a/nx-X11/programs/Xserver/Xext/xevie.c
+++ b/nx-X11/programs/Xserver/Xext/xevie.c
@@ -114,15 +114,15 @@ static int              ErrorBase;
 
 static Bool XevieStart(void);
 static void XevieEnd(int clientIndex);
-static void XevieClientStateCallback(CallbackListPtr *pcbl, pointer nulldata,
-                                    pointer calldata);
+static void XevieClientStateCallback(CallbackListPtr *pcbl, void * nulldata,
+                                    void * calldata);
 static void XevieServerGrabStateCallback(CallbackListPtr *pcbl,
-                                         pointer nulldata,
-                                         pointer calldata);
+                                         void * nulldata,
+                                         void * calldata);
 
-static Bool XevieAdd(DeviceIntPtr device, pointer data);
+static Bool XevieAdd(DeviceIntPtr device, void * data);
 static void XevieWrap(DeviceIntPtr device, ProcessInputProc proc);
-static Bool XevieRemove(DeviceIntPtr device, pointer data);
+static Bool XevieRemove(DeviceIntPtr device, void * data);
 static void doSendEvent(xEvent *xE, DeviceIntPtr device);
 static void XeviePointerProcessInputProc(xEvent *xE, DeviceIntPtr dev,
                                          int count);
@@ -570,8 +570,8 @@ XevieEnd(int clientIndex)
 }
 
 static void
-XevieClientStateCallback(CallbackListPtr *pcbl, pointer nulldata,
-                        pointer calldata)
+XevieClientStateCallback(CallbackListPtr *pcbl, void * nulldata,
+                        void * calldata)
 {
     NewClientInfoRec *pci = (NewClientInfoRec *)calldata;
     ClientPtr client = pci->client;
@@ -581,8 +581,8 @@ XevieClientStateCallback(CallbackListPtr *pcbl, pointer nulldata,
 }
 
 static void
-XevieServerGrabStateCallback(CallbackListPtr *pcbl, pointer nulldata,
-                            pointer calldata)
+XevieServerGrabStateCallback(CallbackListPtr *pcbl, void * nulldata,
+                            void * calldata)
 {
     ServerGrabInfoRec *grbinfo = (ServerGrabInfoRec *)calldata;
     if (grbinfo->grabstate == SERVER_GRABBED)
@@ -599,7 +599,7 @@ XevieServerGrabStateCallback(CallbackListPtr *pcbl, pointer nulldata,
     device->unwrapProc = proc;
 
 static void
-xevieUnwrapProc(DeviceIntPtr device, DeviceHandleProc proc, pointer data)
+xevieUnwrapProc(DeviceIntPtr device, DeviceHandleProc proc, void * data)
 {
     xevieDeviceInfoPtr xeviep = XEVIEINFO(device);
     ProcessInputProc tmp = device->public.processInputProc;
@@ -643,7 +643,7 @@ XevieAdd(DeviceIntPtr device, void* data)
 }
 
 static Bool
-XevieRemove(DeviceIntPtr device,pointer data)
+XevieRemove(DeviceIntPtr device,void * data)
 {
     xevieDeviceInfoPtr xeviep = XEVIEINFO(device);
 
@@ -697,7 +697,7 @@ doSendEvent(xEvent *xE, DeviceIntPtr dev)
         dev->key->modifierMap[xE->u.u.detail] = 0;  
 
 	if(dev->key->xkbInfo->repeatKey != 0 && xE->u.u.type != KeyPress)
-            XkbLastRepeatEvent=     (pointer)xE;
+            XkbLastRepeatEvent=     (void *)xE;
         UNWRAP_INPUTPROC(dev,xeviep);
         dev->public.processInputProc(xE,dev,1);
         COND_WRAP_INPUTPROC(dev,xeviep,tmp);

--- a/nx-X11/programs/Xserver/Xext/xf86dga2.c
+++ b/nx-X11/programs/Xserver/Xext/xf86dga2.c
@@ -59,7 +59,7 @@ static DISPATCH_PROC(ProcXDGACreateColormap);
 
 static void XDGAResetProc(ExtensionEntry *extEntry);
 
-static void DGAClientStateChange (CallbackListPtr*, pointer, pointer);
+static void DGAClientStateChange (CallbackListPtr*, void *, void *);
 
 static ClientPtr DGAClients[MAXSCREENS];
 
@@ -291,8 +291,8 @@ ProcXDGAQueryModes(ClientPtr client)
 static void 
 DGAClientStateChange (
     CallbackListPtr* pcbl,
-    pointer nulldata,
-    pointer calldata
+    void * nulldata,
+    void * calldata
 ){
     NewClientInfoRec* pci = (NewClientInfoRec*) calldata;
     ClientPtr client = NULL;
@@ -370,7 +370,7 @@ ProcXDGASetMode(ClientPtr client)
     DGAClients[stuff->screen] = client;
 
     if(pPix) {
-	if(AddResource(stuff->pid, RT_PIXMAP, (pointer)(pPix))) {
+	if(AddResource(stuff->pid, RT_PIXMAP, (void *)(pPix))) {
 	    pPix->drawable.id = (int)stuff->pid;
 	    rep.flags = DGA_PIXMAP_AVAILABLE;
 	}

--- a/nx-X11/programs/Xserver/Xext/xf86misc.c
+++ b/nx-X11/programs/Xserver/Xext/xf86misc.c
@@ -265,7 +265,7 @@ ProcXF86MiscGetMouseSettings(client)
 {
     xXF86MiscGetMouseSettingsReply rep;
     char *devname;
-    pointer mouse;
+    void * mouse;
     register int n;
 
     DEBUG_P("XF86MiscGetMouseSettings");
@@ -316,7 +316,7 @@ ProcXF86MiscGetKbdSettings(client)
     register ClientPtr client;
 {
     xXF86MiscGetKbdSettingsReply rep;
-    pointer kbd;
+    void * kbd;
     register int n;
 
     DEBUG_P("XF86MiscGetKbdSettings");
@@ -348,7 +348,7 @@ ProcXF86MiscSetMouseSettings(client)
     register ClientPtr client;
 {
     MiscExtReturn ret;
-    pointer mouse;
+    void * mouse;
     char *devname = NULL;
     int major, minor;
     
@@ -369,7 +369,7 @@ ProcXF86MiscSetMouseSettings(client)
 		(int)stuff->resolution, (unsigned long)stuff->flags);
     }
 
-    if ((mouse = MiscExtCreateStruct(MISC_POINTER)) == (pointer) 0)
+    if ((mouse = MiscExtCreateStruct(MISC_POINTER)) == (void *) 0)
 	return BadAlloc;
 
     MiscExtSetMouseValue(mouse, MISC_MSE_PROTO,		stuff->mousetype);
@@ -425,7 +425,7 @@ ProcXF86MiscSetKbdSettings(client)
     register ClientPtr client;
 {
     MiscExtReturn ret;
-    pointer kbd;
+    void * kbd;
     REQUEST(xXF86MiscSetKbdSettingsReq);
 
     DEBUG_P("XF86MiscSetKbdSettings");
@@ -437,7 +437,7 @@ ProcXF86MiscSetKbdSettings(client)
 		(int)stuff->kbdtype, (int)stuff->rate,
 		(int)stuff->delay, stuff->servnumlock);
 
-    if ((kbd = MiscExtCreateStruct(MISC_KEYBOARD)) == (pointer) 0)
+    if ((kbd = MiscExtCreateStruct(MISC_KEYBOARD)) == (void *) 0)
 	return BadAlloc;
 
     MiscExtSetKbdValue(kbd, MISC_KBD_TYPE,		stuff->kbdtype);

--- a/nx-X11/programs/Xserver/Xext/xf86miscproc.h
+++ b/nx-X11/programs/Xserver/Xext/xf86miscproc.h
@@ -50,17 +50,17 @@ typedef enum {
 
 void XFree86MiscExtensionInit(void);
 
-Bool MiscExtGetMouseSettings(pointer *mouse, char **devname);
-int  MiscExtGetMouseValue(pointer mouse, MiscExtMseValType valtype);
-Bool MiscExtSetMouseValue(pointer mouse, MiscExtMseValType valtype, int value);
-Bool MiscExtGetKbdSettings(pointer *kbd);
-int  MiscExtGetKbdValue(pointer kbd, MiscExtKbdValType valtype);
-Bool MiscExtSetKbdValue(pointer kbd, MiscExtKbdValType valtype, int value);
+Bool MiscExtGetMouseSettings(void **mouse, char **devname);
+int  MiscExtGetMouseValue(void * mouse, MiscExtMseValType valtype);
+Bool MiscExtSetMouseValue(void * mouse, MiscExtMseValType valtype, int value);
+Bool MiscExtGetKbdSettings(void **kbd);
+int  MiscExtGetKbdValue(void * kbd, MiscExtKbdValType valtype);
+Bool MiscExtSetKbdValue(void * kbd, MiscExtKbdValType valtype, int value);
 int MiscExtSetGrabKeysState(ClientPtr client, int enable);
-pointer MiscExtCreateStruct(MiscExtStructType mse_or_kbd);
-void    MiscExtDestroyStruct(pointer structure, MiscExtStructType mse_or_kbd);
-MiscExtReturn MiscExtApply(pointer structure, MiscExtStructType mse_or_kbd);
-Bool MiscExtSetMouseDevice(pointer mouse, char* device);
+void * MiscExtCreateStruct(MiscExtStructType mse_or_kbd);
+void    MiscExtDestroyStruct(void * structure, MiscExtStructType mse_or_kbd);
+MiscExtReturn MiscExtApply(void * structure, MiscExtStructType mse_or_kbd);
+Bool MiscExtSetMouseDevice(void * mouse, char* device);
 Bool MiscExtGetFilePaths(const char **configfile, const char **modulepath,
 			 const char **logfile);
 int  MiscExtPassMessage(int scrn, const char *msgtype, const char *msgval,

--- a/nx-X11/programs/Xserver/Xext/xf86vmode.c
+++ b/nx-X11/programs/Xserver/Xext/xf86vmode.c
@@ -155,7 +155,7 @@ typedef struct _XF86VidModeScreenPrivate {
 static int ScreenPrivateIndex;
 
 #define GetScreenPrivate(s) ((ScreenSaverScreenPrivatePtr)(s)->devPrivates[ScreenPrivateIndex].ptr)
-#define SetScreenPrivate(s,v) ((s)->devPrivates[ScreenPrivateIndex].ptr = (pointer) v);
+#define SetScreenPrivate(s,v) ((s)->devPrivates[ScreenPrivateIndex].ptr = (void *) v);
 #define SetupScreen(s)  ScreenSaverScreenPrivatePtr pPriv = GetScreenPrivate(s)
 
 #define New(t)  (xalloc (sizeof (t)))
@@ -338,7 +338,7 @@ setEventMask (ScreenPtr pScreen, ClientPtr client, unsigned long mask)
 }
 
 static int
-XF86VidModeFreeEvents(pointer value, XID id)
+XF86VidModeFreeEvents(void * value, XID id)
 {
     XF86VidModeEventPtr	pOld = (XF86VidModeEventPtr)value;
     ScreenPtr pScreen = pOld->screen;
@@ -437,7 +437,7 @@ ProcXF86VidModeGetModeLine(ClientPtr client)
     REQUEST(xXF86VidModeGetModeLineReq);
     xXF86VidModeGetModeLineReply rep;
     xXF86OldVidModeGetModeLineReply oldrep;
-    pointer mode;
+    void * mode;
     register int n;
     int dotClock;
     int ver;
@@ -539,7 +539,7 @@ ProcXF86VidModeGetAllModeLines(ClientPtr client)
     xXF86VidModeGetAllModeLinesReply rep;
     xXF86VidModeModeInfo mdinf;
     xXF86OldVidModeModeInfo oldmdinf;
-    pointer mode;
+    void * mode;
     int modecount, dotClock;
     register int n;
     int ver;
@@ -645,7 +645,7 @@ ProcXF86VidModeAddModeLine(ClientPtr client)
     xXF86OldVidModeAddModeLineReq *oldstuff =
 			(xXF86OldVidModeAddModeLineReq *)client->requestBuffer;
     xXF86VidModeAddModeLineReq newstuff;
-    pointer mode;
+    void * mode;
     int len;
     int dotClock;
     int ver;
@@ -805,7 +805,7 @@ ProcXF86VidModeDeleteModeLine(ClientPtr client)
     xXF86OldVidModeDeleteModeLineReq *oldstuff =
 		(xXF86OldVidModeDeleteModeLineReq *)client->requestBuffer;
     xXF86VidModeDeleteModeLineReq newstuff;
-    pointer mode;
+    void * mode;
     int len, dotClock;
     int ver;
 
@@ -922,7 +922,7 @@ ProcXF86VidModeModModeLine(ClientPtr client)
     xXF86OldVidModeModModeLineReq *oldstuff =
 			(xXF86OldVidModeModModeLineReq *)client->requestBuffer;
     xXF86VidModeModModeLineReq newstuff;
-    pointer mode, modetmp;
+    void * mode, modetmp;
     int len, dotClock;
     int ver;
 
@@ -1047,7 +1047,7 @@ ProcXF86VidModeValidateModeLine(ClientPtr client)
 		(xXF86OldVidModeValidateModeLineReq *)client->requestBuffer;
     xXF86VidModeValidateModeLineReq newstuff;
     xXF86VidModeValidateModeLineReply rep;
-    pointer mode, modetmp = NULL;
+    void * mode, modetmp = NULL;
     int len, status, dotClock;
     int ver;
 
@@ -1181,7 +1181,7 @@ ProcXF86VidModeSwitchToMode(ClientPtr client)
     xXF86OldVidModeSwitchToModeReq *oldstuff =
 		(xXF86OldVidModeSwitchToModeReq *)client->requestBuffer;
     xXF86VidModeSwitchToModeReq newstuff;
-    pointer mode;
+    void * mode;
     int len, dotClock;
     int ver;
 
@@ -1297,7 +1297,7 @@ ProcXF86VidModeGetMonitor(ClientPtr client)
     register int n;
     CARD32 *hsyncdata, *vsyncdata;
     int i, nHsync, nVrefresh;
-    pointer monitor;
+    void * monitor;
     
     DEBUG_P("XF86VidModeGetMonitor");
 

--- a/nx-X11/programs/Xserver/Xext/xres.c
+++ b/nx-X11/programs/Xserver/Xext/xres.c
@@ -106,7 +106,7 @@ ProcXResQueryClients (ClientPtr client)
 
 
 static void
-ResFindAllRes (pointer value, XID id, RESTYPE type, pointer cdata)
+ResFindAllRes (void * value, XID id, RESTYPE type, void * cdata)
 {
     int *counts = (int *)cdata;
 
@@ -186,7 +186,7 @@ ProcXResQueryClientResources (ClientPtr client)
 }
 
 static void 
-ResFindPixmaps (pointer value, XID id, pointer cdata)
+ResFindPixmaps (void * value, XID id, void * cdata)
 {
    unsigned long *bytes = (unsigned long *)cdata;
    PixmapPtr pix = (PixmapPtr)value;
@@ -216,7 +216,7 @@ ProcXResQueryClientPixmapBytes (ClientPtr client)
     bytes = 0;
 
     FindClientResourcesByType(clients[clientID], RT_PIXMAP, ResFindPixmaps, 
-                              (pointer)(&bytes));
+                              (void *)(&bytes));
 
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;

--- a/nx-X11/programs/Xserver/Xext/xtest1dd.c
+++ b/nx-X11/programs/Xserver/Xext/xtest1dd.c
@@ -1613,5 +1613,5 @@ ClientPtr	client;
 	rep.size_return = ACTION_ARRAY_SIZE;
 	WriteReplyToClient(client,
 			   sizeof(xTestQueryInputSizeReply),
-			   (pointer) &rep);		
+			   (void *) &rep);
 }		

--- a/nx-X11/programs/Xserver/Xext/xtest1di.c
+++ b/nx-X11/programs/Xserver/Xext/xtest1di.c
@@ -152,7 +152,7 @@ static void	SEventXTestDispatch(
 	);
 
 static int	XTestCurrentClientGone(
-	pointer			/* value */,
+	void *			/* value */,
 	XID			/* id */
 	);
 
@@ -752,7 +752,7 @@ XTestResetProc(unused)
 /*ARGSUSED*/
 static int
 XTestCurrentClientGone(value, id)
-	pointer	value;
+	void *	value;
 	XID	id;
 {
 	/*

--- a/nx-X11/programs/Xserver/Xext/xvmain.c
+++ b/nx-X11/programs/Xserver/Xext/xvmain.c
@@ -139,12 +139,12 @@ static Bool XvCloseScreen(int, ScreenPtr);
 static Bool XvDestroyPixmap(PixmapPtr);
 static Bool XvDestroyWindow(WindowPtr);
 static void XvResetProc(ExtensionEntry*);
-static int XvdiDestroyGrab(pointer, XID);
-static int XvdiDestroyEncoding(pointer, XID);
-static int XvdiDestroyVideoNotify(pointer, XID);
-static int XvdiDestroyPortNotify(pointer, XID);
-static int XvdiDestroyVideoNotifyList(pointer, XID);
-static int XvdiDestroyPort(pointer, XID);
+static int XvdiDestroyGrab(void *, XID);
+static int XvdiDestroyEncoding(void *, XID);
+static int XvdiDestroyVideoNotify(void *, XID);
+static int XvdiDestroyPortNotify(void *, XID);
+static int XvdiDestroyVideoNotifyList(void *, XID);
+static int XvdiDestroyPort(void *, XID);
 static int XvdiSendVideoNotify(XvPortPtr, DrawablePtr, int);
 
 
@@ -295,7 +295,7 @@ XvScreenInit(ScreenPtr pScreen)
       return BadAlloc;
     }
 
-  pScreen->devPrivates[XvScreenIndex].ptr = (pointer)pxvs;
+  pScreen->devPrivates[XvScreenIndex].ptr = (void *)pxvs;
 
   
   pxvs->DestroyPixmap = pScreen->DestroyPixmap;
@@ -327,7 +327,7 @@ XvCloseScreen(
 
   xfree(pxvs);
 
-  pScreen->devPrivates[XvScreenIndex].ptr = (pointer)NULL;
+  pScreen->devPrivates[XvScreenIndex].ptr = (void *)NULL;
 
   return (*pScreen->CloseScreen)(ii, pScreen);
 
@@ -479,20 +479,20 @@ XvdiVideoStopped(XvPortPtr pPort, int reason)
 }
 
 static int 
-XvdiDestroyPort(pointer pPort, XID id)
+XvdiDestroyPort(void * pPort, XID id)
 {
   return (* ((XvPortPtr)pPort)->pAdaptor->ddFreePort)(pPort);
 }
 
 static int
-XvdiDestroyGrab(pointer pGrab, XID id)
+XvdiDestroyGrab(void * pGrab, XID id)
 {
   ((XvGrabPtr)pGrab)->client = (ClientPtr)NULL;
   return Success;
 }
 
 static int
-XvdiDestroyVideoNotify(pointer pn, XID id)
+XvdiDestroyVideoNotify(void * pn, XID id)
 {
   /* JUST CLEAR OUT THE client POINTER FIELD */
 
@@ -501,7 +501,7 @@ XvdiDestroyVideoNotify(pointer pn, XID id)
 }
 
 static int
-XvdiDestroyPortNotify(pointer pn, XID id)
+XvdiDestroyPortNotify(void * pn, XID id)
 {
   /* JUST CLEAR OUT THE client POINTER FIELD */
 
@@ -510,7 +510,7 @@ XvdiDestroyPortNotify(pointer pn, XID id)
 }
 
 static int
-XvdiDestroyVideoNotifyList(pointer pn, XID id)
+XvdiDestroyVideoNotifyList(void * pn, XID id)
 {
   XvVideoNotifyPtr npn,cpn;
 
@@ -529,7 +529,7 @@ XvdiDestroyVideoNotifyList(pointer pn, XID id)
 }
 
 static int
-XvdiDestroyEncoding(pointer value, XID id)
+XvdiDestroyEncoding(void * value, XID id)
 {
   return Success;
 }

--- a/nx-X11/programs/Xserver/Xext/xvmc.c
+++ b/nx-X11/programs/Xserver/Xext/xvmc.c
@@ -66,7 +66,7 @@ typedef struct {
 
 
 static int
-XvMCDestroyContextRes(pointer data, XID id)
+XvMCDestroyContextRes(void * data, XID id)
 {
    XvMCContextPtr pContext = (XvMCContextPtr)data;
    
@@ -82,7 +82,7 @@ XvMCDestroyContextRes(pointer data, XID id)
 }
 
 static int
-XvMCDestroySurfaceRes(pointer data, XID id)
+XvMCDestroySurfaceRes(void * data, XID id)
 {
    XvMCSurfacePtr pSurface = (XvMCSurfacePtr)data;
    XvMCContextPtr pContext = pSurface->context;
@@ -91,14 +91,14 @@ XvMCDestroySurfaceRes(pointer data, XID id)
    (*pScreenPriv->adaptors[pContext->adapt_num].DestroySurface)(pSurface); 
    xfree(pSurface);
 
-   XvMCDestroyContextRes((pointer)pContext, pContext->context_id);
+   XvMCDestroyContextRes((void *)pContext, pContext->context_id);
 
    return Success;
 }
 
 
 static int
-XvMCDestroySubpictureRes(pointer data, XID id)
+XvMCDestroySubpictureRes(void * data, XID id)
 {
    XvMCSubpicturePtr pSubpict = (XvMCSubpicturePtr)data;
    XvMCContextPtr pContext = pSubpict->context;
@@ -107,7 +107,7 @@ XvMCDestroySubpictureRes(pointer data, XID id)
    (*pScreenPriv->adaptors[pContext->adapt_num].DestroySubpicture)(pSubpict); 
    xfree(pSubpict);
 
-   XvMCDestroyContextRes((pointer)pContext, pContext->context_id);
+   XvMCDestroyContextRes((void *)pContext, pContext->context_id);
 
    return Success;
 }
@@ -729,7 +729,7 @@ XvMCScreenInit(ScreenPtr pScreen, int num, XvMCAdaptorPtr pAdapt)
    if(!(pScreenPriv = (XvMCScreenPtr)xalloc(sizeof(XvMCScreenRec))))
 	return BadAlloc;
 
-   pScreen->devPrivates[XvMCScreenIndex].ptr = (pointer)pScreenPriv;
+   pScreen->devPrivates[XvMCScreenIndex].ptr = (void *)pScreenPriv;
 
    pScreenPriv->CloseScreen = pScreen->CloseScreen;
    pScreen->CloseScreen = XvMCCloseScreen;

--- a/nx-X11/programs/Xserver/Xext/xvmcext.h
+++ b/nx-X11/programs/Xserver/Xext/xvmcext.h
@@ -32,15 +32,15 @@ typedef struct {
   unsigned short height;
   CARD32 flags;
   int refcnt;
-  pointer port_priv;
-  pointer driver_priv;
+  void * port_priv;
+  void * driver_priv;
 } XvMCContextRec, *XvMCContextPtr;
 
 typedef struct {
   XID surface_id;
   int surface_type_id;
   XvMCContextPtr context;
-  pointer driver_priv;
+  void * driver_priv;
 } XvMCSurfaceRec, *XvMCSurfacePtr;
 
 
@@ -53,7 +53,7 @@ typedef struct {
   int entry_bytes;
   char component_order[4];
   XvMCContextPtr context;
-  pointer driver_priv;
+  void * driver_priv;
 } XvMCSubpictureRec, *XvMCSubpicturePtr;
 
 typedef int (*XvMCCreateContextProcPtr) (

--- a/nx-X11/programs/Xserver/Xi/devbell.c
+++ b/nx-X11/programs/Xserver/Xi/devbell.c
@@ -104,7 +104,7 @@ ProcXDeviceBell (client)
     int base;
     int newpercent;
     CARD8 class;
-    pointer ctrl;
+    void * ctrl;
     BellProcPtr proc;
 
     REQUEST(xDeviceBellReq);
@@ -137,7 +137,7 @@ ProcXDeviceBell (client)
 	    }
 	base = k->ctrl.bell;
 	proc = k->BellProc;
-	ctrl = (pointer) &(k->ctrl);
+	ctrl = (void *) &(k->ctrl);
 	class = KbdFeedbackClass;
 	}
     else if (stuff->feedbackclass == BellFeedbackClass)
@@ -153,7 +153,7 @@ ProcXDeviceBell (client)
 	    }
 	base = b->ctrl.percent;
 	proc = b->BellProc;
-	ctrl = (pointer) &(b->ctrl);
+	ctrl = (void *) &(b->ctrl);
 	class = BellFeedbackClass;
 	}
     else

--- a/nx-X11/programs/Xserver/Xi/exevents.c
+++ b/nx-X11/programs/Xserver/Xi/exevents.c
@@ -143,7 +143,7 @@ ProcessOtherEvent (xE, other, count)
 	DeviceEventInfoRec eventinfo;
 	eventinfo.events = (xEventPtr) xE;
 	eventinfo.count = count;
-	CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
     }
     for (i=1; i<count; i++)
 	if ((++xV)->type == DeviceValuator)
@@ -751,7 +751,7 @@ AddExtensionClient (pWin, client, mask, mskidx)
     others->resource = FakeClientID(client->index);
     others->next = pWin->optional->inputMasks->inputClients;
     pWin->optional->inputMasks->inputClients = others;
-    if (!AddResource(others->resource, RT_INPUTCLIENT, (pointer)pWin))
+    if (!AddResource(others->resource, RT_INPUTCLIENT, (void *)pWin))
 	return BadAlloc;
     return Success;
     }
@@ -846,7 +846,7 @@ InputClientGone(pWin, id)
 		    {
 		    other->resource = FakeClientID(0);
 		    if (!AddResource(other->resource, RT_INPUTCLIENT, 
-			(pointer)pWin))
+			(void *)pWin))
 			return BadAlloc;
 		    }
 		}

--- a/nx-X11/programs/Xserver/Xi/stubs.c
+++ b/nx-X11/programs/Xserver/Xi/stubs.c
@@ -209,7 +209,7 @@ AddOtherInputDevices ()
 
     DeviceIntPtr dev;
     DeviceProc deviceProc;
-    pointer private;
+    void * private;
 
     dev = (DeviceIntPtr) AddInputDevice(deviceProc, TRUE);
     dev->public.devicePrivate = private;

--- a/nx-X11/programs/Xserver/composite/compext.c
+++ b/nx-X11/programs/Xserver/composite/compext.c
@@ -42,8 +42,8 @@ typedef struct _CompositeClient {
 
 static void
 CompositeClientCallback (CallbackListPtr	*list,
-		      pointer		closure,
-		      pointer		data)
+			 void		*closure,
+			 void		*data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;
@@ -59,7 +59,7 @@ CompositeResetProc (ExtensionEntry *extEntry)
 }
     
 static int
-FreeCompositeClientWindow (pointer value, XID ccwid)
+FreeCompositeClientWindow (void * value, XID ccwid)
 {
     WindowPtr	pWin = value;
 
@@ -68,7 +68,7 @@ FreeCompositeClientWindow (pointer value, XID ccwid)
 }
 
 static int
-FreeCompositeClientSubwindows (pointer value, XID ccwid)
+FreeCompositeClientSubwindows (void * value, XID ccwid)
 {
     WindowPtr	pWin = value;
 
@@ -203,7 +203,7 @@ ProcCompositeCreateRegionFromBorderClip (ClientPtr client)
 	return BadAlloc;
     REGION_TRANSLATE (pScreen, pRegion, -pWin->drawable.x, -pWin->drawable.y);
     
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
 
     return(client->noClientException);
@@ -237,7 +237,7 @@ ProcCompositeNameWindowPixmap (ClientPtr client)
 
     ++pPixmap->refcnt;
     
-    if (!AddResource (stuff->pixmap, RT_PIXMAP, (pointer) pPixmap))
+    if (!AddResource (stuff->pixmap, RT_PIXMAP, (void *) pPixmap))
 	return BadAlloc;
 
     return(client->noClientException);

--- a/nx-X11/programs/Xserver/composite/compinit.c
+++ b/nx-X11/programs/Xserver/composite/compinit.c
@@ -93,9 +93,9 @@ compScreenUpdate (ScreenPtr pScreen)
 
 static void
 compBlockHandler (int	    i,
-		  pointer   blockData,
-		  pointer   pTimeout,
-		  pointer   pReadmask)
+		  void      *blockData,
+		  void      *pTimeout,
+		  void      *pReadmask)
 {
     ScreenPtr	    pScreen = screenInfo.screens[i];
     CompScreenPtr   cs = GetCompScreen (pScreen);
@@ -385,6 +385,6 @@ compScreenInit (ScreenPtr pScreen)
     cs->CloseScreen = pScreen->CloseScreen;
     pScreen->CloseScreen = compCloseScreen;
 
-    pScreen->devPrivates[CompScreenPrivateIndex].ptr = (pointer) cs;
+    pScreen->devPrivates[CompScreenPrivateIndex].ptr = (void *) cs;
     return TRUE;
 }

--- a/nx-X11/programs/Xserver/composite/compwindow.c
+++ b/nx-X11/programs/Xserver/composite/compwindow.c
@@ -30,7 +30,7 @@
 
 #ifdef COMPOSITE_DEBUG
 static int
-compCheckWindow (WindowPtr pWin, pointer data)
+compCheckWindow (WindowPtr pWin, void * data)
 {
     ScreenPtr	pScreen = pWin->drawable.pScreen;
     PixmapPtr	pWinPixmap = (*pScreen->GetWindowPixmap) (pWin);
@@ -71,7 +71,7 @@ typedef struct _compPixmapVisit {
 } CompPixmapVisitRec, *CompPixmapVisitPtr;
 
 static Bool
-compRepaintBorder (ClientPtr pClient, pointer closure)
+compRepaintBorder (ClientPtr pClient, void * closure)
 {
     WindowPtr	pWindow = LookupWindow ((XID) closure, pClient);
 
@@ -88,7 +88,7 @@ compRepaintBorder (ClientPtr pClient, pointer closure)
 }
 
 static int
-compSetPixmapVisitWindow (WindowPtr pWindow, pointer data)
+compSetPixmapVisitWindow (WindowPtr pWindow, void * data)
 {
     CompPixmapVisitPtr	pVisit = (CompPixmapVisitPtr) data;
     ScreenPtr		pScreen = pWindow->drawable.pScreen;
@@ -105,7 +105,7 @@ compSetPixmapVisitWindow (WindowPtr pWindow, pointer data)
     SetBorderSize (pWindow);
     if (HasBorder (pWindow))
 	QueueWorkProc (compRepaintBorder, serverClient, 
-		       (pointer) pWindow->drawable.id);
+		       (void *) pWindow->drawable.id);
     return WT_WALKCHILDREN;
 }
 
@@ -116,7 +116,7 @@ compSetPixmap (WindowPtr pWindow, PixmapPtr pPixmap)
 
     visitRec.pWindow = pWindow;
     visitRec.pPixmap = pPixmap;
-    TraverseTree (pWindow, compSetPixmapVisitWindow, (pointer) &visitRec);
+    TraverseTree (pWindow, compSetPixmapVisitWindow, (void *) &visitRec);
     compCheckTree (pWindow->drawable.pScreen);
 }
 

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -216,7 +216,7 @@ ProcDamageCreate (ClientPtr client)
 	xfree (pDamageExt);
 	return BadAlloc;
     }
-    if (!AddResource (stuff->damage, DamageExtType, (pointer) pDamageExt))
+    if (!AddResource (stuff->damage, DamageExtType, (void *) pDamageExt))
 	return BadAlloc;
 
     DamageRegister (pDamageExt->pDrawable, pDamageExt->pDamage);
@@ -376,8 +376,8 @@ SProcDamageDispatch (ClientPtr client)
 
 static void
 DamageClientCallback (CallbackListPtr	*list,
-		      pointer		closure,
-		      pointer		data)
+		      void *		closure,
+		      void *		data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;
@@ -396,7 +396,7 @@ DamageResetProc (ExtensionEntry *extEntry)
 }
 
 static int
-FreeDamageExt (pointer value, XID did)
+FreeDamageExt (void * value, XID did)
 {
     DamageExtPtr    pDamageExt = (DamageExtPtr) value;
 
@@ -416,7 +416,7 @@ FreeDamageExt (pointer value, XID did)
 }
 
 static int
-FreeDamageExtWin (pointer value, XID wid)
+FreeDamageExtWin (void * value, XID wid)
 {
     DamageExtPtr    pDamageExt = (DamageExtPtr) value;
 

--- a/nx-X11/programs/Xserver/dbe/dbe.c
+++ b/nx-X11/programs/Xserver/dbe/dbe.c
@@ -188,11 +188,11 @@ DbeAllocWinPriv(pScreen)
         {
             if ((size = *sizes))
             {
-                ppriv->ptr = (pointer)ptr;
+                ppriv->ptr = (void *)ptr;
                 ptr += size;
             }
             else
-                ppriv->ptr = (pointer)NULL;
+                ppriv->ptr = (void *)NULL;
         }
     }
 
@@ -497,7 +497,7 @@ ProcDbeAllocateBackBufferName(client)
 
         /* Make the window priv a DBE window priv resource. */
         if (!AddResource(stuff->buffer, dbeWindowPrivResType,
-            (pointer)pDbeWindowPriv))
+            (void *)pDbeWindowPriv))
         {
             xfree(pDbeWindowPriv);
             return(BadAlloc);
@@ -524,7 +524,7 @@ ProcDbeAllocateBackBufferName(client)
 
 
         /* Actually connect the window priv to the window. */
-        pWin->devPrivates[dbeWindowPrivIndex].ptr = (pointer)pDbeWindowPriv;
+        pWin->devPrivates[dbeWindowPrivIndex].ptr = (void *)pDbeWindowPriv;
 
     } /* if -- There is no buffer associated with the window. */
 
@@ -592,7 +592,7 @@ ProcDbeAllocateBackBufferName(client)
 
         /* Associate the new ID with an existing window priv. */
         if (!AddResource(stuff->buffer, dbeWindowPrivResType,
-                         (pointer)pDbeWindowPriv))
+                         (void *)pDbeWindowPriv))
         {
             pDbeWindowPriv->IDs[i] = DBE_FREE_ID_ELEMENT;
             return(BadAlloc);
@@ -1490,7 +1490,7 @@ DbeSetupBackgroundPainter(pWin, pGC)
     WindowPtr	pWin;
     GCPtr	pGC;
 {
-    pointer	gcvalues[4];
+    void	*gcvalues[4];
     int		ts_x_origin, ts_y_origin;
     PixUnion	background;
     int		backgroundState;
@@ -1516,16 +1516,16 @@ DbeSetupBackgroundPainter(pWin, pGC)
     switch (backgroundState)
     {
         case BackgroundPixel:
-            gcvalues[0] = (pointer)background.pixel;
-            gcvalues[1] = (pointer)FillSolid;
+            gcvalues[0] = (void *)background.pixel;
+            gcvalues[1] = (void *)FillSolid;
             gcmask = GCForeground|GCFillStyle;
             break;
 
         case BackgroundPixmap:
-            gcvalues[0] = (pointer)FillTiled;
-            gcvalues[1] = (pointer)background.pixmap;
-            gcvalues[2] = (pointer)(long)ts_x_origin;
-            gcvalues[3] = (pointer)(long)ts_y_origin;
+            gcvalues[0] = (void *)FillTiled;
+            gcvalues[1] = (void *)background.pixmap;
+            gcvalues[2] = (void *)(long)ts_x_origin;
+            gcvalues[3] = (void *)(long)ts_y_origin;
             gcmask = GCFillStyle|GCTile|GCTileStipXOrigin|GCTileStipYOrigin;
             break;
 
@@ -1562,7 +1562,7 @@ DbeSetupBackgroundPainter(pWin, pGC)
  *****************************************************************************/
 static int
 DbeDrawableDelete(pDrawable, id)
-    pointer	pDrawable;
+    void	*pDrawable;
     XID		id;
 {
     return(Success);
@@ -1583,7 +1583,7 @@ DbeDrawableDelete(pDrawable, id)
  *****************************************************************************/
 static int
 DbeWindowPrivDelete(pDbeWinPriv, id)
-    pointer	pDbeWinPriv;
+    void	*pDbeWinPriv;
     XID		id;
 {
     DbeScreenPrivPtr	pDbeScreenPriv;
@@ -1668,7 +1668,7 @@ DbeWindowPrivDelete(pDbeWinPriv, id)
     {
         /* Reset the DBE window priv pointer. */
         pDbeWindowPriv->pWindow->devPrivates[dbeWindowPrivIndex].ptr =
-            (pointer)NULL;
+            (void *)NULL;
 
         /* We are done with the window priv. */
         xfree(pDbeWindowPriv);
@@ -1888,7 +1888,7 @@ DbeExtensionInit()
 	    return;
 	}
 
-	pScreen->devPrivates[dbeScreenPrivIndex].ptr = (pointer)pDbeScreenPriv;
+	pScreen->devPrivates[dbeScreenPrivIndex].ptr = (void *)pDbeScreenPriv;
 
         /* Store the DBE priv priv size info for later use when allocating
          * priv privs at the driver level.

--- a/nx-X11/programs/Xserver/dbe/dbemodule.c
+++ b/nx-X11/programs/Xserver/dbe/dbemodule.c
@@ -38,11 +38,11 @@ static XF86ModuleVersionInfo VersRec =
  */
 XF86ModuleData dbeModuleData = { &VersRec, dbeSetup, NULL };
 
-static pointer
-dbeSetup(pointer module, pointer opts, int *errmaj, int *errmin)
+static void *
+dbeSetup(void * module, void * opts, int *errmaj, int *errmin)
 {
     LoadExtension(&dbeExt, FALSE);
 
     /* Need a non-NULL return value to indicate success */
-    return (pointer)1;
+    return (void *)1;
 }

--- a/nx-X11/programs/Xserver/dbe/midbe.c
+++ b/nx-X11/programs/Xserver/dbe/midbe.c
@@ -214,7 +214,7 @@ miDbeAllocBackBufferName(pWin, bufId, swapAction)
 
         /* Make the back pixmap a DBE drawable resource. */
         if (!AddResource(bufId, dbeDrawableResType,
-            (pointer)pDbeWindowPrivPriv->pBackBuffer))
+            (void *)pDbeWindowPrivPriv->pBackBuffer))
         {
             /* free the buffer and the drawable resource */
             FreeResource(bufId, RT_NONE);
@@ -224,7 +224,7 @@ miDbeAllocBackBufferName(pWin, bufId, swapAction)
 
         /* Attach the priv priv to the priv. */
 	pDbeWindowPriv->devPrivates[miDbeWindowPrivPrivIndex].ptr =
-            (pointer)pDbeWindowPrivPriv;
+            (void *)pDbeWindowPrivPriv;
 
 
         /* Clear the back buffer. */
@@ -252,7 +252,7 @@ miDbeAllocBackBufferName(pWin, bufId, swapAction)
         /* Associate the new ID with an existing pixmap. */
         pDbeWindowPrivPriv = MI_DBE_WINDOW_PRIV_PRIV(pDbeWindowPriv);
         if (!AddResource(bufId, dbeDrawableResType,
-                         (pointer)pDbeWindowPrivPriv->pBackBuffer))
+                         (void *)pDbeWindowPrivPriv->pBackBuffer))
         {
             return(BadAlloc);
         }
@@ -286,7 +286,7 @@ miDbeAliasBuffers(pDbeWindowPriv)
     for (i = 0; i < pDbeWindowPriv->nBufferIDs; i++)
     {
         ChangeResourceValue(pDbeWindowPriv->IDs[i], dbeDrawableResType,
-                            (pointer)pDbeWindowPrivPriv->pBackBuffer);
+                            (void *)pDbeWindowPrivPriv->pBackBuffer);
     }
 
 } /* miDbeAliasBuffers() */

--- a/nx-X11/programs/Xserver/dix/colormap.c
+++ b/nx-X11/programs/Xserver/dix/colormap.c
@@ -382,7 +382,7 @@ CreateColormap (Colormap mid, ScreenPtr pScreen, VisualPtr pVisual,
 	    pmap->numPixelsBlue[client] = size;
 	}
     }
-    if (!AddResource(mid, RT_COLORMAP, (pointer)pmap))
+    if (!AddResource(mid, RT_COLORMAP, (void *)pmap))
 	return (BadAlloc);
     /* If the device wants a chance to initialize the colormap in any way,
      * this is it.  In specific, if this is a Static colormap, this is the
@@ -422,7 +422,7 @@ CreateColormap (Colormap mid, ScreenPtr pScreen, VisualPtr pVisual,
  * \param value  must conform to DeleteType
  */
 int
-FreeColormap (pointer value, XID mid)
+FreeColormap (void * value, XID mid)
 {
     int		i;
     register EntryPtr pent;
@@ -431,7 +431,7 @@ FreeColormap (pointer value, XID mid)
     if(CLIENT_ID(mid) != SERVER_ID)
     {
         (*pmap->pScreen->UninstallColormap) (pmap);
-        WalkTree(pmap->pScreen, (VisitWindowProcPtr)TellNoMap, (pointer) &mid);
+        WalkTree(pmap->pScreen, (VisitWindowProcPtr)TellNoMap, (void *) &mid);
     }
 
     /* This is the device's chance to undo anything it needs to, especially
@@ -506,7 +506,7 @@ TellNoMap (WindowPtr pwin, Colormap *pmid)
 
 /* Tell window that pmid got uninstalled */
 int
-TellLostMap (WindowPtr pwin, pointer value)
+TellLostMap (WindowPtr pwin, void * value)
 {
     Colormap 	*pmid = (Colormap *)value;
     xEvent 	xE;
@@ -531,7 +531,7 @@ TellLostMap (WindowPtr pwin, pointer value)
 
 /* Tell window that pmid got installed */
 int
-TellGainedMap (WindowPtr pwin, pointer value)
+TellGainedMap (WindowPtr pwin, void * value)
 {
     Colormap 	*pmid = (Colormap *)value;
     xEvent 	xE;
@@ -974,7 +974,7 @@ AllocColor (ColormapPtr pmap,
 	}
 	pcr->mid = pmap->mid;
 	pcr->client = client;
-	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (pointer)pcr))
+	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (void *)pcr))
 	    return (BadAlloc);
     }
     return (Success);
@@ -1599,7 +1599,7 @@ FreePixels(register ColormapPtr pmap, register int client)
  *  \unused fakeid
  */
 int
-FreeClientPixels (pointer value, XID fakeid)
+FreeClientPixels (void * value, XID fakeid)
 {
     ColormapPtr pmap;
     colorResource *pcr = (colorResource *)value;
@@ -1674,7 +1674,7 @@ AllocColorCells (int client, ColormapPtr pmap, int colors, int planes,
     {
 	pcr->mid = pmap->mid;
 	pcr->client = client;
-	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (pointer)pcr))
+	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (void *)pcr))
 	    ok = BadAlloc;
     } else if (pcr)
 	xfree(pcr);
@@ -1765,7 +1765,7 @@ AllocColorPlanes (int client, ColormapPtr pmap, int colors,
     {
 	pcr->mid = pmap->mid;
 	pcr->client = client;
-	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (pointer)pcr))
+	if (!AddResource(FakeClientID(client), RT_CMAPENTRY, (void *)pcr))
 	    ok = BadAlloc;
     } else if (pcr)
 	xfree(pcr);

--- a/nx-X11/programs/Xserver/dix/cursor.c
+++ b/nx-X11/programs/Xserver/dix/cursor.c
@@ -110,7 +110,7 @@ FreeCursorBits(CursorBitsPtr bits)
  *  \param value must conform to DeleteType
  */
 int
-FreeCursor(pointer value, XID cid)
+FreeCursor(void * value, XID cid)
 {
     int		nscr;
     CursorPtr 	pCurs = (CursorPtr)value;
@@ -452,7 +452,7 @@ CreateRootCursor(char *pfilename, unsigned glyph)
 			 0, 0, 0, ~0, ~0, ~0, &curs, serverClient) != Success)
 	return NullCursor;
 
-    if (!AddResource(FakeClientID(0), RT_CURSOR, (pointer)curs))
+    if (!AddResource(FakeClientID(0), RT_CURSOR, (void *)curs))
 	return NullCursor;
 
     return curs;

--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -1449,7 +1449,7 @@ ProcBell(ClientPtr client)
 	else
 #endif
     (*keybd->kbdfeed->BellProc)(newpercent, keybd,
-				(pointer) &keybd->kbdfeed->ctrl, 0);
+				(void *) &keybd->kbdfeed->ctrl, 0);
     return Success;
 } 
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -531,7 +531,7 @@ ProcCreateWindow(ClientPtr client)
 	Mask mask = pWin->eventMask;
 
 	pWin->eventMask = 0; /* subterfuge in case AddResource fails */
-	if (!AddResource(stuff->wid, RT_WINDOW, (pointer)pWin))
+	if (!AddResource(stuff->wid, RT_WINDOW, (void *)pWin))
 	    return BadAlloc;
 	pWin->eventMask = mask;
     }
@@ -1171,7 +1171,7 @@ ProcGrabServer(register ClientPtr client)
 	ServerGrabInfoRec grabinfo;
 	grabinfo.client = client;
 	grabinfo.grabstate  = SERVER_GRABBED;
-	CallCallbacks(&ServerGrabCallback, (pointer)&grabinfo);
+	CallCallbacks(&ServerGrabCallback, (void *)&grabinfo);
     }
 
     return(client->noClientException);
@@ -1200,7 +1200,7 @@ UngrabServer(ClientPtr client)
 	ServerGrabInfoRec grabinfo;
 	grabinfo.client = client;
 	grabinfo.grabstate  = SERVER_UNGRABBED;
-	CallCallbacks(&ServerGrabCallback, (pointer)&grabinfo);
+	CallCallbacks(&ServerGrabCallback, (void *)&grabinfo);
     }
 }
 
@@ -1468,7 +1468,7 @@ ProcListFontsWithInfo(register ClientPtr client)
  *  \param value must conform to DeleteType
  */
 int
-dixDestroyPixmap(pointer value, XID pid)
+dixDestroyPixmap(void * value, XID pid)
 {
     PixmapPtr pPixmap = (PixmapPtr)value;
     return (*pPixmap->drawable.pScreen->DestroyPixmap)(pPixmap);
@@ -1527,7 +1527,7 @@ CreatePmap:
     {
 	pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	pMap->drawable.id = stuff->pid;
-	if (AddResource(stuff->pid, RT_PIXMAP, (pointer)pMap))
+	if (AddResource(stuff->pid, RT_PIXMAP, (void *)pMap))
 	    return(client->noClientException);
     }
     return (BadAlloc);
@@ -1576,7 +1576,7 @@ ProcCreateGC(register ClientPtr client)
 			 (XID *) &stuff[1], &error);
     if (error != Success)
         return error;
-    if (!AddResource(stuff->gc, RT_GC, (pointer)pGC))
+    if (!AddResource(stuff->gc, RT_GC, (void *)pGC))
 	return (BadAlloc);
     return(client->noClientException);
 }
@@ -2250,7 +2250,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 				         nlines,
 				         format,
 				         planemask,
-				         (pointer) pBuf);
+				         (void *) pBuf);
 #ifdef XCSECURITY
 	    if (pVisibleRegion)
 		SecurityCensorImage(client, pVisibleRegion, widthBytesLine,
@@ -2291,7 +2291,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 				                 nlines,
 				                 format,
 				                 plane,
-				                 (pointer)pBuf);
+				                 (void *)pBuf);
 #ifdef XCSECURITY
 		    if (pVisibleRegion)
 			SecurityCensorImage(client, pVisibleRegion,
@@ -3122,7 +3122,7 @@ ProcCreateCursor (register ClientPtr client)
     /* zeroing the (pad) bits helps some ddx cursor handling */
     bzero((char *)srcbits, n);
     (* src->drawable.pScreen->GetImage)( (DrawablePtr)src, 0, 0, width, height,
-					 XYPixmap, 1, (pointer)srcbits);
+					 XYPixmap, 1, (void *)srcbits);
     if ( msk == (PixmapPtr)NULL)
     {
 	register unsigned char *bits = mskbits;
@@ -3134,7 +3134,7 @@ ProcCreateCursor (register ClientPtr client)
 	/* zeroing the (pad) bits helps some ddx cursor handling */
 	bzero((char *)mskbits, n);
 	(* msk->drawable.pScreen->GetImage)( (DrawablePtr)msk, 0, 0, width,
-					height, XYPixmap, 1, (pointer)mskbits);
+					height, XYPixmap, 1, (void *)mskbits);
     }
     cm.width = width;
     cm.height = height;
@@ -3144,7 +3144,7 @@ ProcCreateCursor (register ClientPtr client)
 	    stuff->foreRed, stuff->foreGreen, stuff->foreBlue,
 	    stuff->backRed, stuff->backGreen, stuff->backBlue);
 
-    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
 	    return (client->noClientException);
     return BadAlloc;
 }
@@ -3167,7 +3167,7 @@ ProcCreateGlyphCursor (register ClientPtr client)
 			   &pCursor, client);
     if (res != Success)
 	return res;
-    if (AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
 	return client->noClientException;
     return BadAlloc;
 }
@@ -3311,10 +3311,10 @@ ProcChangeHosts(register ClientPtr client)
 
     if(stuff->mode == HostInsert)
 	result = AddHost(client, (int)stuff->hostFamily,
-			 stuff->hostLength, (pointer)&stuff[1]);
+			 stuff->hostLength, (void *)&stuff[1]);
     else if (stuff->mode == HostDelete)
 	result = RemoveHost(client, (int)stuff->hostFamily, 
-			    stuff->hostLength, (pointer)&stuff[1]);  
+			    stuff->hostLength, (void *)&stuff[1]);  
     else
     {
 	client->errorValue = stuff->mode;
@@ -3330,7 +3330,7 @@ ProcListHosts(register ClientPtr client)
 {
     xListHostsReply reply;
     int	len, nHosts, result;
-    pointer	pdata;
+    void *	pdata;
     /* REQUEST(xListHostsReq); */
 
     REQUEST_SIZE_MATCH(xListHostsReq);
@@ -3582,7 +3582,7 @@ CloseDownClient(register ClientPtr client)
 		clientinfo.client = client; 
 		clientinfo.prefix = (xConnSetupPrefix *)NULL;  
 		clientinfo.setup = (xConnSetup *) NULL;
-		CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+		CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
             } 
 	}
 	client->clientGone = TRUE;  /* so events aren't sent to client */
@@ -3619,7 +3619,7 @@ CloseDownClient(register ClientPtr client)
 	    clientinfo.client = client; 
 	    clientinfo.prefix = (xConnSetupPrefix *)NULL;  
 	    clientinfo.setup = (xConnSetup *) NULL;
-	    CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	    CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
 	} 	    
 	FreeClientResources(client);
 	if (client->index < nextFreeClientID)
@@ -3669,7 +3669,7 @@ CloseDownRetainedResources()
     }
 }
 
-void InitClient(ClientPtr client, int i, pointer ospriv)
+void InitClient(ClientPtr client, int i, void * ospriv)
 {
     client->index = i;
     client->sequence = 0; 
@@ -3759,11 +3759,11 @@ InitClientPrivates(ClientPtr client)
     {
 	if ( (size = *sizes) )
 	{
-	    ppriv->ptr = (pointer)ptr;
+	    ppriv->ptr = (void *)ptr;
 	    ptr += size;
 	}
 	else
-	    ppriv->ptr = (pointer)NULL;
+	    ppriv->ptr = (void *)NULL;
     }
     return 1;
 }
@@ -3775,7 +3775,7 @@ InitClientPrivates(ClientPtr client)
  * Returns NULL if there are no free clients.
  *************************/
 
-ClientPtr NextAvailableClient(pointer ospriv)
+ClientPtr NextAvailableClient(void * ospriv)
 {
     register int i;
     register ClientPtr client;
@@ -3813,7 +3813,7 @@ ClientPtr NextAvailableClient(pointer ospriv)
         clientinfo.client = client; 
         clientinfo.prefix = (xConnSetupPrefix *)NULL;  
         clientinfo.setup = (xConnSetup *) NULL;
-	CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
     } 	
     return(client);
 }
@@ -3948,7 +3948,7 @@ SendConnSetup(register ClientPtr client, char *reason)
         clientinfo.client = client; 
         clientinfo.prefix = lconnSetupPrefix;  
         clientinfo.setup = (xConnSetup *)lConnectionInfo;
-	CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
     } 	
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -144,7 +144,7 @@ _NXGetFontPathError:
 
 #define QUERYCHARINFO(pci, pr)  *(pr) = (pci)->metrics
 
-extern pointer fosNaturalParams;
+extern void * fosNaturalParams;
 extern FontPtr defaultFont;
 
 static FontPathElementPtr *font_path_elements = (FontPathElementPtr *) 0;
@@ -258,7 +258,7 @@ RemoveFontWakeup(FontPathElementPtr fpe)
 }
 
 void
-FontWakeup(pointer data, int count, pointer LastSelectMask)
+FontWakeup(void * data, int count, void * LastSelectMask)
 {
     int         i;
     FontPathElementPtr fpe;
@@ -338,7 +338,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	if (c->current_fpe < c->num_fpes)
 	{
 	    fpe = c->fpe_list[c->current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -346,7 +346,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
     while (c->current_fpe < c->num_fpes) {
 	fpe = c->fpe_list[c->current_fpe];
 	err = (*fpe_functions[fpe->type].open_font)
-	    ((pointer) client, fpe, c->flags,
+	    ((void *) client, fpe, c->flags,
 	     c->fontname, c->fnamelen, FontFormat,
 	     BitmapFormatMaskByte |
 	     BitmapFormatMaskBit |
@@ -380,7 +380,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	if (err == Suspended) {
 	    if (!c->slept) {
 		c->slept = TRUE;
-		ClientSleep(client, (ClientSleepProcPtr)doOpenFont, (pointer) c);
+		ClientSleep(client, (ClientSleepProcPtr)doOpenFont, (void *) c);
 	    }
 	    return TRUE;
 	}
@@ -418,7 +418,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	    }
 	}
     }
-    if (!AddResource(c->fontid, RT_FONT, (pointer) pfont)) {
+    if (!AddResource(c->fontid, RT_FONT, (void *) pfont)) {
 	err = AllocError;
 	goto bail;
     }
@@ -481,7 +481,7 @@ OpenFont(ClientPtr client, XID fid, Mask flags, unsigned lenfname, char *pfontna
 	cached = FindCachedFontPattern(patternCache, pfontname, lenfname);
 	if (cached && cached->info.cachable)
 	{
-	    if (!AddResource(fid, RT_FONT, (pointer) cached))
+	    if (!AddResource(fid, RT_FONT, (void *) cached))
 		return BadAlloc;
 	    cached->refcnt++;
 	    return Success;
@@ -532,7 +532,7 @@ OpenFont(ClientPtr client, XID fid, Mask flags, unsigned lenfname, char *pfontna
  *  \param value must conform to DeleteType
  */
 int
-CloseFont(pointer value, XID fid)
+CloseFont(void * value, XID fid)
 {
     int         nscr;
     ScreenPtr   pscr;
@@ -660,7 +660,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 	if (c->current.current_fpe < c->num_fpes)
 	{
 	    fpe = c->fpe_list[c->current.current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -678,7 +678,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 	    /* This FPE doesn't support/require list_fonts_and_aliases */
 
 	    err = (*fpe_functions[fpe->type].list_fonts)
-		((pointer) c->client, fpe, c->current.pattern,
+		((void *) c->client, fpe, c->current.pattern,
 		 c->current.patlen, c->current.max_names - c->names->nnames,
 		 c->names);
 
@@ -687,7 +687,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 		    c->slept = TRUE;
 		    ClientSleep(client,
 			(ClientSleepProcPtr)doListFontsAndAliases,
-			(pointer) c);
+			(void *) c);
 		}
 		return TRUE;
 	    }
@@ -707,14 +707,14 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 
 	    if (!c->current.list_started) {
 		err = (*fpe_functions[fpe->type].start_list_fonts_and_aliases)
-		    ((pointer) c->client, fpe, c->current.pattern,
+		    ((void *) c->client, fpe, c->current.pattern,
 		     c->current.patlen, c->current.max_names - c->names->nnames,
 		     &c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)doListFontsAndAliases,
-				    (pointer) c);
+				    (void *) c);
 			c->slept = TRUE;
 		    }
 		    return TRUE;
@@ -726,13 +726,13 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 		char    *tmpname;
 		name = 0;
 		err = (*fpe_functions[fpe->type].list_next_font_or_alias)
-		    ((pointer) c->client, fpe, &name, &namelen, &tmpname,
+		    ((void *) c->client, fpe, &name, &namelen, &tmpname,
 		     &resolvedlen, c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)doListFontsAndAliases,
-				    (pointer) c);
+				    (void *) c);
 			c->slept = TRUE;
 		    }
 		    return TRUE;
@@ -780,7 +780,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 
 		    tmpname = 0;
 		    (void) (*fpe_functions[fpe->type].list_next_font_or_alias)
-			((pointer) c->client, fpe, &tmpname, &tmpnamelen,
+			((void *) c->client, fpe, &tmpname, &tmpnamelen,
 			 &tmpname, &tmpnamelen, c->current.private);
 		    if (--aliascount <= 0)
 		    {
@@ -968,7 +968,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
 	if (c->current.current_fpe < c->num_fpes)
  	{
 	    fpe = c->fpe_list[c->current.current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -1237,7 +1237,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
     if (client->clientGone)
     {
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 
 	if (c->slept)
 	{
@@ -1265,7 +1265,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
 	   the FPE code to clean up after client and avoid further
 	   rendering while we clean up after ourself.  */
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	c->pDraw = (DrawablePtr)0;
     }
 
@@ -1429,7 +1429,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
 		    c->slept = TRUE;
 		    ClientSleep(client,
 		    	     (ClientSleepProcPtr)doPolyText,
-			     (pointer) c);
+			     (void *) c);
 
 		    /* Set up to perform steps 3 and 4 */
 		    client_state = START_SLEEP;
@@ -1535,7 +1535,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
     if (client->clientGone)
     {
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	err = Success;
 	goto bail;
     }
@@ -1549,7 +1549,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
 	/* Our drawable has disappeared.  Treat like client died... ask
 	   the FPE code to clean up after client. */
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	err = Success;
 	goto bail;
     }
@@ -1616,7 +1616,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
 	    ValidateGC(c->pDraw, c->pGC);
 
 	    c->slept = TRUE;
-            ClientSleep(client, (ClientSleepProcPtr)doImageText, (pointer) c);
+            ClientSleep(client, (ClientSleepProcPtr)doImageText, (void *) c);
         }
         return TRUE;
     }
@@ -1966,7 +1966,7 @@ DeleteClientFontStuff(ClientPtr client)
     {
 	fpe = font_path_elements[i];
 	if (fpe_functions[fpe->type].client_died)
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
     }
 }
 
@@ -2106,7 +2106,7 @@ GetNewFontClientID()
 int
 StoreFontClientFont(FontPtr pfont, Font id)
 {
-    return AddResource(id, RT_NONE, (pointer) pfont);
+    return AddResource(id, RT_NONE, (void *) pfont);
 }
 
 void
@@ -2139,7 +2139,7 @@ init_fs_handlers(FontPathElementPtr fpe, BlockHandlerProcPtr block_handler)
 #endif
 
 	if (!RegisterBlockAndWakeupHandlers(block_handler,
-					    FontWakeup, (pointer) 0))
+					    FontWakeup, (void *) 0))
 	    return AllocError;
 	fs_handlers_installed++;
     }
@@ -2159,7 +2159,7 @@ remove_fs_handlers(FontPathElementPtr fpe, BlockHandlerProcPtr block_handler, Bo
 #endif
 
 	    RemoveBlockAndWakeupHandlers(block_handler, FontWakeup,
-					 (pointer) 0);
+					 (void *) 0);
 	}
     }
     RemoveFontWakeup(fpe);
@@ -2190,7 +2190,7 @@ dump_char_ascii(CharInfoPtr cip)
 
     bpr = GLYPH_SIZE(cip, 4);
     for (r = 0; r < (cip->metrics.ascent + cip->metrics.descent); r++) {
-	pointer     row = (pointer) cip->bits + r * bpr;
+	void *     row = (void *) cip->bits + r * bpr;
 
 	byte = 0;
 	for (l = 0; l <= (cip->metrics.rightSideBearing -

--- a/nx-X11/programs/Xserver/dix/dixutils.c
+++ b/nx-X11/programs/Xserver/dix/dixutils.c
@@ -236,23 +236,23 @@ SecurityLookupWindow(XID rid, ClientPtr client, Mask access_mode)
 }
 
 
-pointer
+void *
 SecurityLookupDrawable(XID rid, ClientPtr client, Mask access_mode)
 {
     register DrawablePtr pDraw;
 
     if(rid == INVALID)
-	return (pointer) NULL;
+	return (void *) NULL;
     if (client->trustLevel != XSecurityClientTrusted)
 	return (DrawablePtr)SecurityLookupIDByClass(client, rid, RC_DRAWABLE,
 						    access_mode);
     if (client->lastDrawableID == rid)
-	return ((pointer) client->lastDrawable);
+	return ((void *) client->lastDrawable);
     pDraw = (DrawablePtr)SecurityLookupIDByClass(client, rid, RC_DRAWABLE,
 						 access_mode);
     if (pDraw && (pDraw->type != UNDRAWABLE_WINDOW))
-        return (pointer)pDraw;		
-    return (pointer)NULL;
+        return (void *)pDraw;
+    return (void *)NULL;
 }
 
 /* We can't replace the LookupWindow and LookupDrawable functions with
@@ -265,7 +265,7 @@ LookupWindow(XID rid, ClientPtr client)
     return SecurityLookupWindow(rid, client, SecurityUnknownAccess);
 }
 
-pointer
+void *
 LookupDrawable(XID rid, ClientPtr client)
 {
     return SecurityLookupDrawable(rid, client, SecurityUnknownAccess);
@@ -298,19 +298,19 @@ LookupWindow(XID rid, ClientPtr client)
 }
 
 
-pointer
+void *
 LookupDrawable(XID rid, ClientPtr client)
 {
     register DrawablePtr pDraw;
 
     if(rid == INVALID)
-	return (pointer) NULL;
+	return (void *) NULL;
     if (client->lastDrawableID == rid)
-	return ((pointer) client->lastDrawable);
+	return ((void *) client->lastDrawable);
     pDraw = (DrawablePtr)LookupIDByClass(rid, RC_DRAWABLE);
     if (pDraw && (pDraw->type != UNDRAWABLE_WINDOW))
-        return (pointer)pDraw;		
-    return (pointer)NULL;
+        return (void *)pDraw;
+    return (void *)NULL;
 }
 
 #endif /* XCSECURITY */
@@ -318,7 +318,7 @@ LookupDrawable(XID rid, ClientPtr client)
 ClientPtr
 LookupClient(XID rid, ClientPtr client)
 {
-    pointer pRes = (pointer)SecurityLookupIDByClass(client, rid, RC_ANY,
+    void * pRes = (void *)SecurityLookupIDByClass(client, rid, RC_ANY,
 						    SecurityReadAccess);
     int clientIndex = CLIENT_ID(rid);
 
@@ -343,7 +343,7 @@ AlterSaveSetForClient(ClientPtr client, WindowPtr pWin, unsigned mode,
     if (numnow)
     {
 	pTmp = client->saveSet;
-	while ((j < numnow) && (SaveSetWindow(pTmp[j]) != (pointer)pWin))
+	while ((j < numnow) && (SaveSetWindow(pTmp[j]) != (void *)pWin))
 	    j++;
     }
     if (mode == SetModeInsert)
@@ -413,7 +413,7 @@ NoopDDA(void)
 typedef struct _BlockHandler {
     BlockHandlerProcPtr BlockHandler;
     WakeupHandlerProcPtr WakeupHandler;
-    pointer blockData;
+    void * blockData;
     Bool    deleted;
 } BlockHandlerRec, *BlockHandlerPtr;
 
@@ -429,7 +429,7 @@ static Bool		handlerDeleted;
  *  \param pReadMask  nor how it represents the det of descriptors
  */
 void
-BlockHandler(pointer pTimeout, pointer pReadmask)
+BlockHandler(void * pTimeout, void * pReadmask)
 {
     register int i, j;
     
@@ -463,7 +463,7 @@ BlockHandler(pointer pTimeout, pointer pReadmask)
  *  \param pReadmask the resulting descriptor mask
  */
 void
-WakeupHandler(int result, pointer pReadmask)
+WakeupHandler(int result, void * pReadmask)
 {
     register int i, j;
 
@@ -498,7 +498,7 @@ WakeupHandler(int result, pointer pReadmask)
 Bool
 RegisterBlockAndWakeupHandlers (BlockHandlerProcPtr blockHandler, 
                                 WakeupHandlerProcPtr wakeupHandler, 
-                                pointer blockData)
+                                void * blockData)
 {
     BlockHandlerPtr new;
 
@@ -522,7 +522,7 @@ RegisterBlockAndWakeupHandlers (BlockHandlerProcPtr blockHandler,
 void
 RemoveBlockAndWakeupHandlers (BlockHandlerProcPtr blockHandler, 
                               WakeupHandlerProcPtr wakeupHandler, 
-                              pointer blockData)
+                              void * blockData)
 {
     int	    i;
 
@@ -616,8 +616,8 @@ ProcessWorkQueueZombies(void)
 
 Bool
 QueueWorkProc (
-    Bool (*function)(ClientPtr /* pClient */, pointer /* closure */),
-    ClientPtr client, pointer closure)
+    Bool (*function)(ClientPtr /* pClient */, void * /* closure */),
+    ClientPtr client, void * closure)
 {
     WorkQueuePtr    q;
 
@@ -645,13 +645,13 @@ typedef struct _SleepQueue {
     struct _SleepQueue	*next;
     ClientPtr		client;
     ClientSleepProcPtr  function;
-    pointer		closure;
+    void *		closure;
 } SleepQueueRec, *SleepQueuePtr;
 
 static SleepQueuePtr	sleepQueue = NULL;
 
 Bool
-ClientSleep (ClientPtr client, ClientSleepProcPtr function, pointer closure)
+ClientSleep (ClientPtr client, ClientSleepProcPtr function, void * closure)
 {
     SleepQueuePtr   q;
 
@@ -731,7 +731,7 @@ static Bool
 _AddCallback(
     CallbackListPtr *pcbl,
     CallbackProcPtr callback,
-    pointer         data)
+    void            *data)
 {
     CallbackPtr     cbr;
 
@@ -750,7 +750,7 @@ static Bool
 _DeleteCallback(
     CallbackListPtr *pcbl,
     CallbackProcPtr callback,
-    pointer         data)
+    void            *data)
 {
     CallbackListPtr cbl = *pcbl;
     CallbackPtr     cbr, pcbr;
@@ -785,7 +785,7 @@ _DeleteCallback(
 static void 
 _CallCallbacks(
     CallbackListPtr    *pcbl,
-    pointer	    call_data)
+    void	       *call_data)
 {
     CallbackListPtr cbl = *pcbl;
     CallbackPtr     cbr, pcbr;
@@ -914,7 +914,7 @@ CreateCallbackList(CallbackListPtr *pcbl, CallbackFuncsPtr cbfuncs)
 }
 
 Bool 
-AddCallback(CallbackListPtr *pcbl, CallbackProcPtr callback, pointer data)
+AddCallback(CallbackListPtr *pcbl, CallbackProcPtr callback, void * data)
 {
     if (!pcbl) return FALSE;
     if (!*pcbl)
@@ -926,14 +926,14 @@ AddCallback(CallbackListPtr *pcbl, CallbackProcPtr callback, pointer data)
 }
 
 Bool 
-DeleteCallback(CallbackListPtr *pcbl, CallbackProcPtr callback, pointer data)
+DeleteCallback(CallbackListPtr *pcbl, CallbackProcPtr callback, void * data)
 {
     if (!pcbl || !*pcbl) return FALSE;
     return ((*(*pcbl)->funcs.DeleteCallback) (pcbl, callback, data));
 }
 
 void 
-CallCallbacks(CallbackListPtr *pcbl, pointer call_data)
+CallCallbacks(CallbackListPtr *pcbl, void * call_data)
 {
     if (!pcbl || !*pcbl) return;
     (*(*pcbl)->funcs.CallCallbacks) (pcbl, call_data);

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -1079,7 +1079,7 @@ EnqueueEvent(xEvent *xE, DeviceIntPtr device, int count)
 		WindowTable[sprite.hotPhys.pScreen->myNum]->drawable.id;
 	eventinfo.events = xE;
 	eventinfo.count = count;
-	CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
     }
     if (xE->u.u.type == MotionNotify)
     {
@@ -2587,7 +2587,7 @@ CheckPassiveGrabsOnWindow(
 a passive grab to be activated.  If the event is a keyboard event, the
 ancestors of the focus window are traced down and tried to see if they have
 any passive grabs to be activated.  If the focus window itself is reached and
-it's descendants contain they pointer, the ancestors of the window that the
+its descendants contain the pointer, the ancestors of the window that the
 pointer is in are then traced down starting at the focus window, otherwise no
 grabs are activated.  If the event is a pointer event, the ancestors of the
 window that the pointer is in are traced down starting at the root until
@@ -2812,7 +2812,7 @@ drawable.id:0;
 	    DeviceEventInfoRec eventinfo;
 	    eventinfo.events = xE;
 	    eventinfo.count = count;
-	    CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	    CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
 	}
     }
 #ifdef XEVIE
@@ -2998,7 +2998,7 @@ ProcessPointerEvent (register xEvent *xE, register DeviceIntPtr mouse, int count
 		    WindowTable[sprite.hotPhys.pScreen->myNum]->drawable.id;
 	    eventinfo.events = xE;
 	    eventinfo.count = count;
-	    CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	    CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
 	}
     }
     if (xE->u.u.type != MotionNotify)
@@ -3111,7 +3111,7 @@ RecalculateDeliverableEvents(pWin)
  *  \param value must conform to DeleteType
  */
 int
-OtherClientGone(pointer value, XID id)
+OtherClientGone(void * value, XID id)
 {
     register OtherClientsPtr other, prev;
     register WindowPtr pWin = (WindowPtr)value;
@@ -3206,7 +3206,7 @@ EventSelectForWindow(register WindowPtr pWin, register ClientPtr client, Mask ma
 	others->resource = FakeClientID(client->index);
 	others->next = pWin->optional->otherClients;
 	pWin->optional->otherClients = others;
-	if (!AddResource(others->resource, RT_OTHERCLIENT, (pointer)pWin))
+	if (!AddResource(others->resource, RT_OTHERCLIENT, (void *)pWin))
 	    return BadAlloc;
     }
 maskSet: 
@@ -4653,7 +4653,7 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 	eventinfo.client = pClient;
 	eventinfo.events = events;
 	eventinfo.count = count;
-	CallCallbacks(&EventCallback, (pointer)&eventinfo);
+	CallCallbacks(&EventCallback, (void *)&eventinfo);
     }
     if(pClient->swapped)
     {

--- a/nx-X11/programs/Xserver/dix/gc.c
+++ b/nx-X11/programs/Xserver/dix/gc.c
@@ -442,7 +442,7 @@ dixChangeGC(ClientPtr client, register GC *pGC, register BITS32 mask, CARD32 *pC
 		if(error == Success)
 		{
 		    (*pGC->funcs->ChangeClip)(pGC, clipType,
-					      (pointer)pPixmap, 0);
+					      (void *)pPixmap, 0);
 		}
 		break;
 	    }
@@ -534,7 +534,7 @@ ChangeGC(register GC *pGC, register BITS32 mask, XID *pval)
    pval contains an appropriate value for each mask.
    fPointer is true if the values for tiles, stipples, fonts or clipmasks
    are pointers instead of IDs.  Note: if you are passing pointers you
-   MUST declare the array of values as type pointer!  Other data types
+   MUST declare the array of values as type void*!  Other data types
    may not be large enough to hold pointers on some machines.  Yes,
    this means you have to cast to (XID *) when you pass the array to
    DoChangeGC.  Similarly, if you are not passing pointers (fPointer = 0) you
@@ -591,11 +591,11 @@ AllocateGC(ScreenPtr pScreen)
 	{
 	    if ( (size = *sizes) )
 	    {
-		ppriv->ptr = (pointer)ptr;
+		ppriv->ptr = (void *)ptr;
 		ptr += size;
 	    }
 	    else
-		ppriv->ptr = (pointer)NULL;
+		ppriv->ptr = (void *)NULL;
 	}
     }
     return pGC;
@@ -651,7 +651,7 @@ CreateGC(DrawablePtr pDrawable, BITS32 mask, XID *pval, int *pStatus)
     pGC->clipOrg.x = 0;
     pGC->clipOrg.y = 0;
     pGC->clientClipType = CT_NONE;
-    pGC->clientClip = (pointer)NULL;
+    pGC->clientClip = (void *)NULL;
     pGC->numInDashList = 2;
     pGC->dash = DefaultDash;
     pGC->dashOffset = 0;
@@ -890,7 +890,7 @@ CopyGC(register GC *pgcSrc, register GC *pgcDst, register BITS32 mask)
  *  \param value  must conform to DeleteType
  */
 int
-FreeGC(pointer value, XID gid)
+FreeGC(void * value, XID gid)
 {
     GCPtr pGC = (GCPtr)value;
 
@@ -1208,7 +1208,7 @@ SetClipRects(GCPtr pGC, int xOrigin, int yOrigin, int nrects,
 
     if (size)
 	memmove((char *)prectsNew, (char *)prects, size);
-    (*pGC->funcs->ChangeClip)(pGC, newct, (pointer)prectsNew, nrects);
+    (*pGC->funcs->ChangeClip)(pGC, newct, (void *)prectsNew, nrects);
     if (pGC->funcs->ChangeGC)
 	(*pGC->funcs->ChangeGC) (pGC, GCClipXOrigin|GCClipYOrigin|GCClipMask);
     return Success;

--- a/nx-X11/programs/Xserver/dix/glyphcurs.c
+++ b/nx-X11/programs/Xserver/dix/glyphcurs.c
@@ -119,7 +119,7 @@ ServerBitsFromGlyph(FontPtr pfont, unsigned ch, register CursorMetricPtr cm, uns
     /* fill the pixmap with 0 */
     gcval[0].val = GXcopy;
     gcval[1].val = 0;
-    gcval[2].ptr = (pointer)pfont;
+    gcval[2].ptr = (void *)pfont;
     dixChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFont,
 		NULL, gcval);
     ValidateGC((DrawablePtr)ppix, pGC);

--- a/nx-X11/programs/Xserver/dix/grabs.c
+++ b/nx-X11/programs/Xserver/dix/grabs.c
@@ -128,7 +128,7 @@ FreeGrab(GrabPtr pGrab)
 }
 
 int
-DeletePassiveGrab(pointer value, XID id)
+DeletePassiveGrab(void * value, XID id)
 {
     register GrabPtr g, prev;
     GrabPtr pGrab = (GrabPtr)value;
@@ -295,7 +295,7 @@ AddPassiveGrabToList(GrabPtr pGrab)
     }
     pGrab->next = pGrab->window->optional->passiveGrabs;
     pGrab->window->optional->passiveGrabs = pGrab;
-    if (AddResource(pGrab->resource, RT_PASSIVEGRAB, (pointer)pGrab))
+    if (AddResource(pGrab->resource, RT_PASSIVEGRAB, (void *)pGrab))
 	return Success;
     return BadAlloc;
 }
@@ -389,7 +389,7 @@ DeletePassiveGrabFromList(GrabPtr pMinuendGrab)
 		ok = FALSE;
 	    }
 	    else if (!AddResource(pNewGrab->resource, RT_PASSIVEGRAB,
-				  (pointer)pNewGrab))
+				  (void *)pNewGrab))
 		ok = FALSE;
 	    else
 		adds[nadds++] = pNewGrab;

--- a/nx-X11/programs/Xserver/dix/main.c
+++ b/nx-X11/programs/Xserver/dix/main.c
@@ -319,7 +319,7 @@ main(int argc, char *argv[], char *envp[])
 	    serverClient = (ClientPtr)xalloc(sizeof(ClientRec));
 	    if (!serverClient)
 		FatalError("couldn't create server client");
-	    InitClient(serverClient, 0, (pointer)NULL);
+	    InitClient(serverClient, 0, (void *)NULL);
 	}
 	else
 	    ResetWellKnownSockets ();

--- a/nx-X11/programs/Xserver/dix/pixmap.c
+++ b/nx-X11/programs/Xserver/dix/pixmap.c
@@ -53,7 +53,7 @@ from The Open Group.
 /* callable by ddx */
 PixmapPtr
 GetScratchPixmapHeader(ScreenPtr pScreen, int width, int height, int depth, 
-                       int bitsPerPixel, int devKind, pointer pPixData)
+                       int bitsPerPixel, int devKind, void * pPixData)
 {
     PixmapPtr pPixmap = pScreen->pScratchPixmap;
 
@@ -139,11 +139,11 @@ AllocatePixmap(ScreenPtr pScreen, int pixDataSize)
     {
         if ((size = *sizes) != 0)
         {
-	    ppriv->ptr = (pointer)ptr;
+	    ppriv->ptr = (void *)ptr;
 	    ptr += size;
         }
         else
-	    ppriv->ptr = (pointer)NULL;
+	    ppriv->ptr = (void *)NULL;
     }
 #else
     pPixmap = (PixmapPtr)xalloc(sizeof(PixmapRec) + pixDataSize);

--- a/nx-X11/programs/Xserver/dix/property.c
+++ b/nx-X11/programs/Xserver/dix/property.c
@@ -263,10 +263,10 @@ ProcChangeProperty(ClientPtr client)
 
 #ifdef LBX
     err = LbxChangeWindowProperty(client, pWin, stuff->property, stuff->type,
-	 (int)format, (int)mode, len, TRUE, (pointer)&stuff[1], TRUE, NULL);
+	 (int)format, (int)mode, len, TRUE, (void *)&stuff[1], TRUE, NULL);
 #else
     err = ChangeWindowProperty(pWin, stuff->property, stuff->type, (int)format,
-			       (int)mode, len, (pointer)&stuff[1], TRUE);
+			       (int)mode, len, (void *)&stuff[1], TRUE);
 #endif
     if (err != Success)
 	return err;
@@ -276,7 +276,7 @@ ProcChangeProperty(ClientPtr client)
 
 int
 ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format, 
-                     int mode, unsigned long len, pointer value, 
+                     int mode, unsigned long len, void * value, 
                      Bool sendevent)
 {
 #ifdef LBX
@@ -288,7 +288,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
     xEvent event;
     int sizeInBytes;
     int totalSize;
-    pointer data;
+    void * data;
 
     sizeInBytes = format>>3;
     totalSize = len * sizeInBytes;
@@ -309,7 +309,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
         pProp = (PropertyPtr)xalloc(sizeof(PropertyRec));
 	if (!pProp)
 	    return(BadAlloc);
-        data = (pointer)xalloc(totalSize);
+        data = (void *)xalloc(totalSize);
 	if (!data && len)
 	{
 	    xfree(pProp);
@@ -340,7 +340,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
         {
 	    if (totalSize != pProp->size * (pProp->format >> 3))
 	    {
-	    	data = (pointer)xrealloc(pProp->data, totalSize);
+		data = (void *)xrealloc(pProp->data, totalSize);
 	    	if (!data && len)
 		    return(BadAlloc);
             	pProp->data = data;
@@ -357,7 +357,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
 	}
         else if (mode == PropModeAppend)
         {
-	    data = (pointer)xrealloc(pProp->data,
+	    data = (void *)xrealloc(pProp->data,
 				     sizeInBytes * (len + pProp->size));
 	    if (!data)
 		return(BadAlloc);
@@ -369,7 +369,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
 	}
         else if (mode == PropModePrepend)
         {
-            data = (pointer)xalloc(sizeInBytes * (len + pProp->size));
+            data = (void *)xalloc(sizeInBytes * (len + pProp->size));
 	    if (!data)
 		return(BadAlloc);
 	    memmove(&((char *)data)[totalSize], (char *)pProp->data, 

--- a/nx-X11/programs/Xserver/dix/resource.c
+++ b/nx-X11/programs/Xserver/dix/resource.c
@@ -139,7 +139,7 @@ typedef struct _Resource {
     struct _Resource	*next;
     XID			id;
     RESTYPE		type;
-    pointer		value;
+    void *		value;
 } ResourceRec, *ResourcePtr;
 #define NullResource ((ResourcePtr)NULL)
 
@@ -423,7 +423,7 @@ FakeClientID(register int client)
 }
 
 Bool
-AddResource(XID id, RESTYPE type, pointer value)
+AddResource(XID id, RESTYPE type, void * value)
 {
     int client;
     register ClientResourceRec *rrec;
@@ -595,7 +595,7 @@ FreeResourceByType(XID id, RESTYPE type, Bool skipFree)
  */
 
 Bool
-ChangeResourceValue (XID id, RESTYPE rtype, pointer value)
+ChangeResourceValue (XID id, RESTYPE rtype, void * value)
 {
     int    cid;
     register    ResourcePtr res;
@@ -627,7 +627,7 @@ FindClientResourcesByType(
     ClientPtr client,
     RESTYPE type,
     FindResType func,
-    pointer cdata
+    void * cdata
 ){
     register ResourcePtr *resources;
     register ResourcePtr this, next;
@@ -658,7 +658,7 @@ void
 FindAllClientResources(
     ClientPtr client,
     FindAllRes func,
-    pointer cdata
+    void * cdata
 ){
     register ResourcePtr *resources;
     register ResourcePtr this, next;
@@ -684,12 +684,12 @@ FindAllClientResources(
 }
 
 
-pointer
+void *
 LookupClientResourceComplex(
     ClientPtr client,
     RESTYPE type,
     FindComplexResType func,
-    pointer cdata
+    void * cdata
 ){
     ResourcePtr *resources;
     ResourcePtr this;
@@ -831,12 +831,12 @@ LegalNewID(XID id, register ClientPtr client)
  * else NULL is returned.
  */
 
-pointer
+void *
 SecurityLookupIDByType(ClientPtr client, XID id, RESTYPE rtype, Mask mode)
 {
     int    cid;
     register    ResourcePtr res;
-    pointer retval = NULL;
+    void * retval = NULL;
 
     assert(client == NullClient ||
      (client->index <= currentMaxClients && clients[client->index] == client));
@@ -860,12 +860,12 @@ SecurityLookupIDByType(ClientPtr client, XID id, RESTYPE rtype, Mask mode)
 }
 
 
-pointer
+void *
 SecurityLookupIDByClass(ClientPtr client, XID id, RESTYPE classes, Mask mode)
 {
     int    cid;
     register ResourcePtr res = NULL;
-    pointer retval = NULL;
+    void * retval = NULL;
 
     assert(client == NullClient ||
      (client->index <= currentMaxClients && clients[client->index] == client));
@@ -892,14 +892,14 @@ SecurityLookupIDByClass(ClientPtr client, XID id, RESTYPE classes, Mask mode)
  * macros because of compatibility with loadable servers.
  */
 
-pointer
+void *
 LookupIDByType(XID id, RESTYPE rtype)
 {
     return SecurityLookupIDByType(NullClient, id, rtype,
 				  SecurityUnknownAccess);
 }
 
-pointer
+void *
 LookupIDByClass(XID id, RESTYPE classes)
 {
     return SecurityLookupIDByClass(NullClient, id, classes,
@@ -911,7 +911,7 @@ LookupIDByClass(XID id, RESTYPE classes)
 /*
  *  LookupIDByType returns the object with the given id and type, else NULL.
  */ 
-pointer
+void *
 LookupIDByType(XID id, RESTYPE rtype)
 {
     int    cid;
@@ -926,14 +926,14 @@ LookupIDByType(XID id, RESTYPE rtype)
 	    if ((res->id == id) && (res->type == rtype))
 		return res->value;
     }
-    return (pointer)NULL;
+    return (void *)NULL;
 }
 
 /*
  *  LookupIDByClass returns the object with the given id and any one of the
  *  given classes, else NULL.
  */ 
-pointer
+void *
 LookupIDByClass(XID id, RESTYPE classes)
 {
     int    cid;
@@ -948,7 +948,7 @@ LookupIDByClass(XID id, RESTYPE classes)
 	    if ((res->id == id) && (res->type & classes))
 		return res->value;
     }
-    return (pointer)NULL;
+    return (void *)NULL;
 }
 
 #endif /* XCSECURITY */

--- a/nx-X11/programs/Xserver/dix/window.c
+++ b/nx-X11/programs/Xserver/dix/window.c
@@ -203,7 +203,7 @@ PrintWindowTree()
 #endif
 
 int
-TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, pointer data)
+TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, void * data)
 {
     register int result;
     register WindowPtr pChild;
@@ -238,7 +238,7 @@ TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, pointer data)
  *****/
 
 int
-WalkTree(ScreenPtr pScreen, VisitWindowProcPtr func, pointer data)
+WalkTree(ScreenPtr pScreen, VisitWindowProcPtr func, void * data)
 {
     return(TraverseTree(WindowTable[pScreen->myNum], func, data));
 }
@@ -264,7 +264,7 @@ SetWindowToDefaults(register WindowPtr pWin)
 
     pWin->backingStore = NotUseful;
     pWin->DIXsaveUnder = FALSE;
-    pWin->backStorage = (pointer) NULL;
+    pWin->backStorage = (void *) NULL;
 
     pWin->mapped = FALSE;	    /* off */
     pWin->realized = FALSE;	/* off */
@@ -356,11 +356,11 @@ AllocateWindow(ScreenPtr pScreen)
 	{
 	    if ( (size = *sizes) )
 	    {
-		ppriv->ptr = (pointer)ptr;
+		ppriv->ptr = (void *)ptr;
 		ptr += size;
 	    }
 	    else
-		ppriv->ptr = (pointer)NULL;
+		ppriv->ptr = (void *)NULL;
 	}
     }
     return pWin;
@@ -454,7 +454,7 @@ CreateRootWindow(ScreenPtr pScreen)
     pWin->border.pixel = pScreen->blackPixel;
     pWin->borderWidth = 0;
 
-    if (!AddResource(pWin->drawable.id, RT_WINDOW, (pointer)pWin))
+    if (!AddResource(pWin->drawable.id, RT_WINDOW, (void *)pWin))
 	return FALSE;
 
     if (disableBackingStore)
@@ -879,7 +879,7 @@ CrushTree(WindowPtr pWin)
  *****/
 
 int
-DeleteWindow(pointer value, XID wid)
+DeleteWindow(void * value, XID wid)
  {
     register WindowPtr pParent;
     register WindowPtr pWin = (WindowPtr)value;
@@ -2525,7 +2525,7 @@ CirculateWindow(WindowPtr pParent, int direction, ClientPtr client)
 static int
 CompareWIDs(
     WindowPtr pWin,
-    pointer   value) /* must conform to VisitWindowProcPtr */
+    void *   value) /* must conform to VisitWindowProcPtr */
 {
     Window *wid = (Window *)value;
 
@@ -2550,7 +2550,7 @@ ReparentWindow(register WindowPtr pWin, register WindowPtr pParent,
     register ScreenPtr pScreen;
 
     pScreen = pWin->drawable.pScreen;
-    if (TraverseTree(pWin, CompareWIDs, (pointer)&pParent->drawable.id) == WT_STOPWALKING)
+    if (TraverseTree(pWin, CompareWIDs, (void *)&pParent->drawable.id) == WT_STOPWALKING)
 	return(BadMatch);		
     if (!MakeWindowOptional(pWin))
 	return(BadAlloc);
@@ -3483,7 +3483,7 @@ TileScreenSaver(int i, int kind)
 	if (cursor)
 	{
 	    cursorID = FakeClientID(0);
-	    if (AddResource (cursorID, RT_CURSOR, (pointer) cursor))
+	    if (AddResource (cursorID, RT_CURSOR, (void *) cursor))
 	    {
 		attributes[attri] = cursorID;
 		mask |= CWCursor;
@@ -3514,7 +3514,7 @@ TileScreenSaver(int i, int kind)
 	return FALSE;
 
     if (!AddResource(pWin->drawable.id, RT_WINDOW,
-		     (pointer)savedScreenInfo[i].pWindow))
+		     (void *)savedScreenInfo[i].pWindow))
 	return FALSE;
 
     if (mask & CWBackPixmap)

--- a/nx-X11/programs/Xserver/fb/fb.h
+++ b/nx-X11/programs/Xserver/fb/fb.h
@@ -795,7 +795,7 @@ fb24_32ModifyPixmapHeader (PixmapPtr   pPixmap,
 			   int         depth,
 			   int         bitsPerPixel,
 			   int         devKind,
-			   pointer     pPixData);
+			   void        *pPixData);
 
 /*
  * fballpriv.c
@@ -1486,7 +1486,7 @@ fbPolyGlyphBlt (DrawablePtr	pDrawable,
 		int		y,
 		unsigned int	nglyph,
 		CharInfoPtr	*ppci,
-		pointer		pglyphBase);
+		void		*pglyphBase);
 
 void
 fbImageGlyphBlt (DrawablePtr	pDrawable,
@@ -1495,7 +1495,7 @@ fbImageGlyphBlt (DrawablePtr	pDrawable,
 		 int		y,
 		 unsigned int	nglyph,
 		 CharInfoPtr	*ppci,
-		 pointer	pglyphBase);
+		 void	        *pglyphBase);
 
 /*
  * fbimage.c
@@ -1732,7 +1732,7 @@ _fbSetWindowPixmap (WindowPtr pWindow, PixmapPtr pPixmap);
 
 Bool
 fbSetupScreen(ScreenPtr	pScreen, 
-	      pointer	pbits,		/* pointer to screen bitmap */
+	      void	*pbits,		/* pointer to screen bitmap */
 	      int	xsize, 		/* in pixels */
 	      int	ysize,
 	      int	dpix,		/* dots per inch */
@@ -1742,7 +1742,7 @@ fbSetupScreen(ScreenPtr	pScreen,
 
 Bool
 fbFinishScreenInit(ScreenPtr	pScreen,
-		   pointer	pbits,
+		   void		*pbits,
 		   int		xsize,
 		   int		ysize,
 		   int		dpix,
@@ -1752,7 +1752,7 @@ fbFinishScreenInit(ScreenPtr	pScreen,
 
 Bool
 fbScreenInit(ScreenPtr	pScreen,
-	     pointer	pbits,
+	     void	*pbits,
 	     int	xsize,
 	     int	ysize,
 	     int	dpix,

--- a/nx-X11/programs/Xserver/fb/fb24_32.c
+++ b/nx-X11/programs/Xserver/fb/fb24_32.c
@@ -571,7 +571,7 @@ fb24_32ReformatTile(PixmapPtr pOldTile, int bitsPerPixel)
 }
 
 typedef struct {
-    pointer pbits; 
+    void * pbits; 
     int width;   
 } miScreenInitParmsRec, *miScreenInitParmsPtr;
 
@@ -603,7 +603,7 @@ fb24_32ModifyPixmapHeader (PixmapPtr   pPixmap,
 			   int         depth,
 			   int         bitsPerPixel,
 			   int         devKind,
-			   pointer     pPixData)
+			   void        *pPixData)
 {
     int	    bpp, w;
 

--- a/nx-X11/programs/Xserver/fb/fb24_32.h
+++ b/nx-X11/programs/Xserver/fb/fb24_32.h
@@ -32,7 +32,7 @@
 
 Bool
 fb24_32FinishScreenInit(ScreenPtr    pScreen,
-			pointer      pbits,
+			void         *pbits,
 			int          xsize,
 			int          ysize,
 			int          dpix,
@@ -42,7 +42,7 @@ fb24_32FinishScreenInit(ScreenPtr    pScreen,
 
 Bool
 fb24_32ScreenInit(ScreenPtr  pScreen,
-		  pointer    pbits,
+		  void       *pbits,
 		  int        xsize,
 		  int        ysize,
 		  int        dpix,

--- a/nx-X11/programs/Xserver/fb/fballpriv.c
+++ b/nx-X11/programs/Xserver/fb/fballpriv.c
@@ -86,7 +86,7 @@ fbAllocatePrivates(ScreenPtr pScreen, int *pGCIndex)
 	pScreenPriv = (FbScreenPrivPtr) xalloc (sizeof (FbScreenPrivRec));
 	if (!pScreenPriv)
 	    return FALSE;
-	pScreen->devPrivates[fbScreenPrivateIndex].ptr = (pointer) pScreenPriv;
+	pScreen->devPrivates[fbScreenPrivateIndex].ptr = (void *) pScreenPriv;
     }
 #endif
     return TRUE;

--- a/nx-X11/programs/Xserver/fb/fbglyph.c
+++ b/nx-X11/programs/Xserver/fb/fbglyph.c
@@ -262,7 +262,7 @@ fbPolyGlyphBlt (DrawablePtr	pDrawable,
 		int		y,
 		unsigned int	nglyph,
 		CharInfoPtr	*ppci,
-		pointer		pglyphBase)
+		void *		pglyphBase)
 {
     FbGCPrivPtr	    pPriv = fbGetGCPrivate (pGC);
     CharInfoPtr	    pci;
@@ -350,7 +350,7 @@ fbImageGlyphBlt (DrawablePtr	pDrawable,
 		 int		y,
 		 unsigned int	nglyph,
 		 CharInfoPtr	*ppciInit,
-		 pointer	pglyphBase)
+		 void *	pglyphBase)
 {
     FbGCPrivPtr	    pPriv = fbGetGCPrivate(pGC);
     CharInfoPtr	    *ppci;

--- a/nx-X11/programs/Xserver/fb/fboverlay.c
+++ b/nx-X11/programs/Xserver/fb/fboverlay.c
@@ -64,7 +64,7 @@ fbOverlayCreateWindow(WindowPtr pWin)
 	pPixmap = pScrPriv->layer[i].u.run.pixmap;
 	if (pWin->drawable.depth == pPixmap->drawable.depth)
 	{
-	    pWin->devPrivates[fbWinPrivateIndex].ptr = (pointer) pPixmap;
+	    pWin->devPrivates[fbWinPrivateIndex].ptr = (void *) pPixmap;
 	    /*
 	     * Make sure layer keys are written correctly by
 	     * having non-root layers set to full while the
@@ -108,7 +108,7 @@ fbOverlayWindowLayer(WindowPtr pWin)
 
     for (i = 0; i < pScrPriv->nlayers; i++)
 	if (pWin->devPrivates[fbWinPrivateIndex].ptr ==
-	    (pointer) pScrPriv->layer[i].u.run.pixmap)
+	    (void *) pScrPriv->layer[i].u.run.pixmap)
 	    return i;
     return 0;
 }
@@ -119,7 +119,7 @@ fbOverlayCreateScreenResources(ScreenPtr pScreen)
     int			i;
     FbOverlayScrPrivPtr	pScrPriv = fbOverlayGetScrPriv(pScreen);
     PixmapPtr		pPixmap;
-    pointer		pbits;
+    void *		pbits;
     int			width;
     int			depth;
     BoxRec		box;
@@ -289,8 +289,8 @@ fbOverlayPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what)
 
 Bool
 fbOverlaySetupScreen(ScreenPtr	pScreen,
-		     pointer	pbits1,
-		     pointer	pbits2,
+		     void *	pbits1,
+		     void *	pbits2,
 		     int	xsize,
 		     int	ysize,
 		     int	dpix,
@@ -336,8 +336,8 @@ fb24_32OverlayCreateScreenResources(ScreenPtr pScreen)
 
 Bool
 fbOverlayFinishScreenInit(ScreenPtr	pScreen,
-			  pointer	pbits1,
-			  pointer	pbits2,
+			  void *	pbits1,
+			  void *	pbits2,
 			  int		xsize,
 			  int		ysize,
 			  int		dpix,
@@ -436,7 +436,7 @@ fbOverlayFinishScreenInit(ScreenPtr	pScreen,
     pScrPriv->layer[1].u.init.width = width2;
     pScrPriv->layer[1].u.init.depth = depth2;
     
-    pScreen->devPrivates[fbOverlayScreenPrivateIndex].ptr = (pointer) pScrPriv;
+    pScreen->devPrivates[fbOverlayScreenPrivateIndex].ptr = (void *) pScrPriv;
     
     /* overwrite miCloseScreen with our own */
     pScreen->CloseScreen = fbOverlayCloseScreen;

--- a/nx-X11/programs/Xserver/fb/fboverlay.h
+++ b/nx-X11/programs/Xserver/fb/fboverlay.h
@@ -39,7 +39,7 @@ typedef	void	(*fbOverlayPaintKeyProc) (DrawablePtr, RegionPtr, CARD32, int);
 typedef struct _fbOverlayLayer {
     union {
 	struct {
-	    pointer	pbits;
+	    void *	pbits;
 	    int		width;
 	    int		depth;
 	} init;
@@ -100,8 +100,8 @@ fbOverlayPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what);
 
 Bool
 fbOverlaySetupScreen(ScreenPtr	pScreen,
-		     pointer	pbits1,
-		     pointer	pbits2,
+		     void *	pbits1,
+		     void *	pbits2,
 		     int	xsize,
 		     int	ysize,
 		     int	dpix,
@@ -113,8 +113,8 @@ fbOverlaySetupScreen(ScreenPtr	pScreen,
 
 Bool
 fbOverlayFinishScreenInit(ScreenPtr	pScreen,
-			  pointer	pbits1,
-			  pointer	pbits2,
+			  void *	pbits1,
+			  void *	pbits2,
 			  int		xsize,
 			  int		ysize,
 			  int		dpix,

--- a/nx-X11/programs/Xserver/fb/fbpixmap.c
+++ b/nx-X11/programs/Xserver/fb/fbpixmap.c
@@ -73,7 +73,7 @@ fbCreatePixmapBpp (ScreenPtr pScreen, int width, int height, int depth, int bpp)
     pPixmap->drawable.height = height;
     pPixmap->devKind = paddedWidth;
     pPixmap->refcnt = 1;
-    pPixmap->devPrivate.ptr = (pointer) ((char *)pPixmap + base + adjust);
+    pPixmap->devPrivate.ptr = (void *) ((char *)pPixmap + base + adjust);
 #ifdef FB_DEBUG
     pPixmap->devPrivate.ptr = (void *) ((char *) pPixmap->devPrivate.ptr + paddedWidth);
     fbInitializeDrawable (&pPixmap->drawable);

--- a/nx-X11/programs/Xserver/fb/fbscreen.c
+++ b/nx-X11/programs/Xserver/fb/fbscreen.c
@@ -97,14 +97,14 @@ _fbSetWindowPixmap (WindowPtr pWindow, PixmapPtr pPixmap)
 #ifdef FB_NO_WINDOW_PIXMAPS
     FatalError ("Attempted to set window pixmap without fb support\n");
 #else
-    pWindow->devPrivates[fbWinPrivateIndex].ptr = (pointer) pPixmap;
+    pWindow->devPrivates[fbWinPrivateIndex].ptr = (void *) pPixmap;
 #endif
 }
 #endif
 
 Bool
 fbSetupScreen(ScreenPtr	pScreen, 
-	      pointer	pbits,		/* pointer to screen bitmap */
+	      void *	pbits,		/* pointer to screen bitmap */
 	      int	xsize, 		/* in pixels */
 	      int	ysize,
 	      int	dpix,		/* dots per inch */
@@ -160,7 +160,7 @@ fbSetupScreen(ScreenPtr	pScreen,
 
 Bool
 fbFinishScreenInit(ScreenPtr	pScreen,
-		   pointer	pbits,
+		   void *	pbits,
 		   int		xsize,
 		   int		ysize,
 		   int		dpix,
@@ -261,7 +261,7 @@ fbFinishScreenInit(ScreenPtr	pScreen,
 /* dts * (inch/dot) * (25.4 mm / inch) = mm */
 Bool
 fbScreenInit(ScreenPtr	pScreen,
-	     pointer	pbits,
+	     void *	pbits,
 	     int	xsize,
 	     int	ysize,
 	     int	dpix,

--- a/nx-X11/programs/Xserver/fb/fbwindow.c
+++ b/nx-X11/programs/Xserver/fb/fbwindow.c
@@ -38,7 +38,7 @@ fbCreateWindow(WindowPtr pWin)
 {
 #ifndef FB_NO_WINDOW_PIXMAPS
     pWin->devPrivates[fbWinPrivateIndex].ptr = 
-	(pointer) fbGetScreenPixmap(pWin->drawable.pScreen);
+	(void *) fbGetScreenPixmap(pWin->drawable.pScreen);
 #endif
 #ifdef FB_SCREEN_PRIVATE
     if (pWin->drawable.bitsPerPixel == 32)

--- a/nx-X11/programs/Xserver/hw/nxagent/Colormap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Colormap.c
@@ -77,7 +77,7 @@ Bool nxagentCreateColormap(ColormapPtr pCmap)
   pVisual = pCmap->pVisual;
   ncolors = pVisual->ColormapEntries;
 
-  pCmap->devPriv = (pointer)xalloc(sizeof(nxagentPrivColormap));
+  pCmap->devPriv = (void *)xalloc(sizeof(nxagentPrivColormap));
 
   if (((visual = nxagentVisual(pVisual))) == NULL)
   {
@@ -174,7 +174,7 @@ void nxagentDestroyColormap(ColormapPtr pCmap)
 #define SEARCH_PREDICATE \
   (nxagentWindow(pWin) != None && wColormap(pWin) == icws->cmapIDs[i])
 
-static int nxagentCountInstalledColormapWindows(WindowPtr pWin, pointer ptr)
+static int nxagentCountInstalledColormapWindows(WindowPtr pWin, void * ptr)
 {
   nxagentInstalledColormapWindows *icws = (nxagentInstalledColormapWindows *) ptr;
 
@@ -189,7 +189,7 @@ static int nxagentCountInstalledColormapWindows(WindowPtr pWin, pointer ptr)
   return WT_WALKCHILDREN;
 }
 
-static int nxagentGetInstalledColormapWindows(WindowPtr pWin, pointer ptr)
+static int nxagentGetInstalledColormapWindows(WindowPtr pWin, void * ptr)
 {
   nxagentInstalledColormapWindows *icws = (nxagentInstalledColormapWindows *)ptr;
   int i;
@@ -233,11 +233,11 @@ void nxagentSetInstalledColormapWindows(ScreenPtr pScreen)
 				    sizeof(Colormap));
   icws.numCmapIDs = nxagentListInstalledColormaps(pScreen, icws.cmapIDs);
   icws.numWindows = 0;
-  WalkTree(pScreen, nxagentCountInstalledColormapWindows, (pointer)&icws);
+  WalkTree(pScreen, nxagentCountInstalledColormapWindows, (void *)&icws);
   if (icws.numWindows) {
     icws.windows = (Window *)xalloc((icws.numWindows + 1) * sizeof(Window));
     icws.index = 0;
-    WalkTree(pScreen, nxagentGetInstalledColormapWindows, (pointer)&icws);
+    WalkTree(pScreen, nxagentGetInstalledColormapWindows, (void *)&icws);
     icws.windows[icws.numWindows] = nxagentDefaultWindows[pScreen->myNum];
     numWindows = icws.numWindows + 1;
   }
@@ -388,10 +388,10 @@ void nxagentInstallColormap(ColormapPtr pCmap)
 
       /* Uninstall pInstalledMap. Notify all interested parties. */
       if(pOldCmap != (ColormapPtr)None)
-	WalkTree(pCmap->pScreen, TellLostMap, (pointer)&pOldCmap->mid);
+	WalkTree(pCmap->pScreen, TellLostMap, (void *)&pOldCmap->mid);
 
       InstalledMaps[index] = pCmap;
-      WalkTree(pCmap->pScreen, TellGainedMap, (pointer)&pCmap->mid);
+      WalkTree(pCmap->pScreen, TellGainedMap, (void *)&pCmap->mid);
 
       nxagentSetInstalledColormapWindows(pCmap->pScreen);
       nxagentDirectInstallColormaps(pCmap->pScreen);
@@ -542,7 +542,7 @@ Bool nxagentCreateDefaultColormap(ScreenPtr pScreen)
   return True;
 }
 
-static void nxagentReconnectColormap(pointer p0, XID x1, pointer p2)
+static void nxagentReconnectColormap(void * p0, XID x1, void * p2)
 {
   ColormapPtr pCmap = (ColormapPtr)p0;
   Bool* pBool = (Bool*)p2;

--- a/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
@@ -231,7 +231,7 @@ Bool nxagentRealizeCursor(ScreenPtr pScreen, CursorPtr pCursor)
   bg_color.green = pCursor->backGreen;
   bg_color.blue = pCursor->backBlue;
 
-  pCursor->devPriv[pScreen->myNum] = (pointer) xalloc(sizeof(nxagentPrivCursor));
+  pCursor->devPriv[pScreen->myNum] = (void *) xalloc(sizeof(nxagentPrivCursor));
 
   nxagentCursorPriv(pCursor, pScreen)->cursor =
          XCreatePixmapCursor(nxagentDisplay, source, mask, &fg_color,
@@ -311,7 +311,7 @@ Bool nxagentSetCursorPosition(ScreenPtr pScreen, int x, int y,
   }
 }
 
-void nxagentReconnectCursor(pointer p0, XID x1, pointer p2)
+void nxagentReconnectCursor(void * p0, XID x1, void * p2)
 {
   Bool* pBool = (Bool*)p2;
   CursorPtr pCursor = (CursorPtr) p0;
@@ -433,7 +433,7 @@ Bool nxagentReconnectAllCursor(void *p0)
   return r;
 }
 
-void nxagentDisconnectCursor(pointer p0, XID x1, pointer p2)
+void nxagentDisconnectCursor(void * p0, XID x1, void * p2)
 {
   Bool* pBool = (Bool *) p2;
   CursorPtr pCursor = (CursorPtr) p0;

--- a/nx-X11/programs/Xserver/hw/nxagent/Cursor.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Cursor.h
@@ -100,8 +100,8 @@ Bool nxagentSetCursorPosition(ScreenPtr pScreen, int x, int y,
 extern Bool (*nxagentSetCursorPositionW)(ScreenPtr pScreen, int x, int y,
                                              Bool generateEvent);
 
-void nxagentDisconnectCursor(pointer p0, XID x1, pointer p2);
-void nxagentReconnectCursor(pointer p0, XID x1, pointer p2);
+void nxagentDisconnectCursor(void * p0, XID x1, void * p2);
+void nxagentReconnectCursor(void * p0, XID x1, void * p2);
 void nxagentReDisplayCurrentCursor(void);
 Bool nxagentReconnectAllCursor(void *p0);
 Bool nxagentDisconnectAllCursor(void);

--- a/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
@@ -106,7 +106,7 @@ void nxagentExposeBackgroundPredicate(void *p0, XID x1, void *p2);
  * Imported from NXresource.c
  */
 
-extern int nxagentFindClientResource(int, RESTYPE, pointer);
+extern int nxagentFindClientResource(int, RESTYPE, void *);
 
 unsigned long nxagentGetColor(DrawablePtr pDrawable, int xPixel, int yPixel);
 unsigned long nxagentGetDrawableColor(DrawablePtr pDrawable);
@@ -2391,7 +2391,7 @@ void nxagentFillRemoteRegion(DrawablePtr pDrawable, RegionPtr pRegion)
   }
 }
 
-int nxagentDestroyCorruptedWindowResource(pointer p, XID id)
+int nxagentDestroyCorruptedWindowResource(void * p, XID id)
 {
   #ifdef TEST
   fprintf(stderr, "nxagentDestroyCorruptedWindowResource: Removing corrupted window [%p] from resources.\n",
@@ -2403,7 +2403,7 @@ int nxagentDestroyCorruptedWindowResource(pointer p, XID id)
   return 1;
 }
 
-int nxagentDestroyCorruptedPixmapResource(pointer p, XID id)
+int nxagentDestroyCorruptedPixmapResource(void * p, XID id)
 {
   #ifdef TEST
   fprintf(stderr, "nxagentDestroyCorruptedPixmapResource: Removing corrupted pixmap [%p] from resources.\n",
@@ -2415,7 +2415,7 @@ int nxagentDestroyCorruptedPixmapResource(pointer p, XID id)
   return 1;
 }
 
-int nxagentDestroyCorruptedBackgroundResource(pointer p, XID id)
+int nxagentDestroyCorruptedBackgroundResource(void * p, XID id)
 {
   #ifdef TEST
   fprintf(stderr, "nxagentDestroyCorruptedBackgroundResource: Removing corrupted pixmap background [%p] from resources.\n",
@@ -2842,7 +2842,7 @@ void nxagentAllocateCorruptedResource(DrawablePtr pDrawable, RESTYPE type)
       nxagentWindowPriv((WindowPtr) pDrawable) -> corruptedId = FakeClientID(serverClient -> index);
 
       AddResource(nxagentWindowPriv((WindowPtr) pDrawable) -> corruptedId, RT_NX_CORR_WINDOW,
-                      (pointer) pDrawable);
+                      (void *) pDrawable);
     }
   }
   else if (type == RT_NX_CORR_BACKGROUND)
@@ -2869,7 +2869,7 @@ void nxagentAllocateCorruptedResource(DrawablePtr pDrawable, RESTYPE type)
       nxagentPixmapPriv(pRealPixmap) -> corruptedBackgroundId = FakeClientID(serverClient -> index);
 
       AddResource(nxagentPixmapPriv(pRealPixmap) -> corruptedBackgroundId, RT_NX_CORR_BACKGROUND,
-                      (pointer) pRealPixmap);
+                      (void *) pRealPixmap);
     }
   }
   else if (type == RT_NX_CORR_PIXMAP)
@@ -2896,7 +2896,7 @@ void nxagentAllocateCorruptedResource(DrawablePtr pDrawable, RESTYPE type)
         nxagentPixmapPriv(pRealPixmap) -> corruptedId = FakeClientID(serverClient -> index);
 
         AddResource(nxagentPixmapPriv(pRealPixmap) -> corruptedId, RT_NX_CORR_PIXMAP,
-                        (pointer) pRealPixmap);
+                        (void *) pRealPixmap);
       }
     }
   }
@@ -3204,7 +3204,7 @@ void nxagentExposeBackgroundPredicate(void *p0, XID x1, void *p2)
  * This function is similar to nxagentClipAndSendExpose().
  */
 
-int nxagentClipAndSendClearExpose(WindowPtr pWin, pointer ptr)
+int nxagentClipAndSendClearExpose(WindowPtr pWin, void * ptr)
 {
   RegionPtr exposeRgn;
   RegionPtr remoteExposeRgn;

--- a/nx-X11/programs/Xserver/hw/nxagent/Drawable.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Drawable.h
@@ -182,9 +182,9 @@ extern void nxagentFillRemoteRegion(DrawablePtr pDrawable, RegionPtr pRegion);
 
 extern void nxagentAllocateCorruptedResource(DrawablePtr pDrawable, RESTYPE type);
 extern void nxagentDestroyCorruptedResource(DrawablePtr pDrawable, RESTYPE type);
-extern int nxagentDestroyCorruptedBackgroundResource(pointer p, XID id);
-extern int nxagentDestroyCorruptedWindowResource(pointer p, XID id);
-extern int nxagentDestroyCorruptedPixmapResource(pointer p, XID id);
+extern int nxagentDestroyCorruptedBackgroundResource(void * p, XID id);
+extern int nxagentDestroyCorruptedWindowResource(void * p, XID id);
+extern int nxagentDestroyCorruptedPixmapResource(void * p, XID id);
 
 extern void nxagentCreateDrawableBitmap(DrawablePtr pDrawable);
 extern void nxagentDestroyDrawableBitmap(DrawablePtr pDrawable);

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -218,7 +218,7 @@ RegionPtr nxagentRemoteExposeRegion = NULL;
 
 static void nxagentForwardRemoteExpose(void);
 
-static int nxagentClipAndSendExpose(WindowPtr pWin, pointer ptr);
+static int nxagentClipAndSendExpose(WindowPtr pWin, void * ptr);
 
 /*
  * This is from NXproperty.c.
@@ -778,7 +778,7 @@ void nxagentGetEventMask(WindowPtr pWin, Mask *mask_return)
   *mask_return = mask;
 }
 
-static int nxagentChangeMapPrivate(WindowPtr pWin, pointer ptr)
+static int nxagentChangeMapPrivate(WindowPtr pWin, void * ptr)
 {
   if (pWin && nxagentWindowPriv(pWin))
   {
@@ -788,7 +788,7 @@ static int nxagentChangeMapPrivate(WindowPtr pWin, pointer ptr)
   return WT_WALKCHILDREN;
 }
 
-static int nxagentChangeVisibilityPrivate(WindowPtr pWin, pointer ptr)
+static int nxagentChangeVisibilityPrivate(WindowPtr pWin, void * ptr)
 {
   if (pWin && nxagentWindowPriv(pWin))
   {
@@ -4276,7 +4276,7 @@ void nxagentAddRectToRemoteExposeRegion(BoxPtr rect)
   REGION_UNINIT(nxagentDefaultScreen, &exposeRegion);
 }
 
-int nxagentClipAndSendExpose(WindowPtr pWin, pointer ptr)
+int nxagentClipAndSendExpose(WindowPtr pWin, void * ptr)
 {
   RegionPtr exposeRgn;
   RegionPtr remoteExposeRgn;

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -103,7 +103,7 @@ is" without express or implied warranty.
 static int reconnectFlexibility;
 
 static void nxagentCleanCacheAfterReconnect(void);
-static void nxagentFontReconnect(FontPtr, XID, pointer);
+static void nxagentFontReconnect(FontPtr, XID, void *);
 static XFontStruct *nxagentLoadBestQueryFont(Display* dpy, char *fontName, FontPtr pFont);
 static XFontStruct *nxagentLoadQueryFont(register Display *dpy , char *fontName , FontPtr pFont);
 int nxagentFreeFont(XFontStruct *fs);
@@ -486,7 +486,7 @@ Bool nxagentFontLookUp(const char *name)
 
 Bool nxagentRealizeFont(ScreenPtr pScreen, FontPtr pFont)
 {
-  pointer priv;
+  void * priv;
   Atom name_atom, value_atom;
   int nprops;
   FontPropPtr props;
@@ -538,7 +538,7 @@ Bool nxagentRealizeFont(ScreenPtr pScreen, FontPtr pFont)
      name = origName;
   }
 
-  priv = (pointer)xalloc(sizeof(nxagentPrivFont));
+  priv = (void *)xalloc(sizeof(nxagentPrivFont));
   FontSetPrivate(pFont, nxagentFontPrivateIndex, priv);
 
   nxagentFontPriv(pFont) -> mirrorID = 0;
@@ -693,7 +693,7 @@ Bool nxagentUnrealizeFont(ScreenPtr pScreen, FontPtr pFont)
   return True;
 }
 
-int nxagentDestroyNewFontResourceType(pointer p, XID id)
+int nxagentDestroyNewFontResourceType(void * p, XID id)
 {
   #ifdef TEST
   fprintf(stderr, "nxagentDestroyNewFontResourceType: Destroying mirror id [%ld] for font at [%p].\n",
@@ -858,7 +858,7 @@ static XFontStruct *nxagentLoadBestQueryFont(Display* dpy, char *fontName, FontP
   return fontStruct;
 }
 
-static void nxagentFontDisconnect(FontPtr pFont, XID param1, pointer param2)
+static void nxagentFontDisconnect(FontPtr pFont, XID param1, void * param2)
 {
   nxagentPrivFont *privFont;
   Bool *pBool = (Bool*)param2;
@@ -959,7 +959,7 @@ static void nxagentCollectFailedFont(FontPtr fpt, XID id)
   nxagentFailedToReconnectFonts.index++;
 }
 
-static void nxagentFontReconnect(FontPtr pFont, XID param1, pointer param2)
+static void nxagentFontReconnect(FontPtr pFont, XID param1, void * param2)
 {
   int i;
   nxagentPrivFont *privFont;
@@ -1164,7 +1164,7 @@ Bool nxagentReconnectAllFonts(void *p0)
   return fontSuccess;
 }
 
-static void nxagentFailedFontReconnect(FontPtr pFont, XID param1, pointer param2)
+static void nxagentFailedFontReconnect(FontPtr pFont, XID param1, void * param2)
 {
   int i;
   nxagentPrivFont *privFont;

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.h
@@ -65,7 +65,7 @@ int nxagentFontLookUp(const char *name);
 Bool nxagentFontFind(const char *name, int *pos);
 void nxagentListRemoteAddName(const char *name, int status);
 
-int nxagentDestroyNewFontResourceType(pointer p, XID id);
+int nxagentDestroyNewFontResourceType(void * p, XID id);
 
 Bool nxagentDisconnectAllFonts(void);
 Bool nxagentReconnectAllFonts(void *p0);

--- a/nx-X11/programs/Xserver/hw/nxagent/GC.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/GC.c
@@ -75,7 +75,7 @@ void nxagentDisconnectGraphicContexts(void);
 GCPtr nxagentCreateGraphicContext(int depth);
 
 static void nxagentReconnectGC(void*, XID, void*);
-static void nxagentReconnectClip(GCPtr, int, pointer, int);
+static void nxagentReconnectClip(GCPtr, int, void *, int);
 static int  nxagentCompareRegions(RegionPtr, RegionPtr);
 
 struct nxagentGCRec
@@ -198,7 +198,7 @@ Bool nxagentCreateGC(GCPtr pGC)
 
   nxagentGCPriv(pGC) -> pPixmap = NULL;
 
-  AddResource(nxagentGCPriv(pGC) -> mid, RT_NX_GC, (pointer) pGC);
+  AddResource(nxagentGCPriv(pGC) -> mid, RT_NX_GC, (void *) pGC);
 
   return True;
 }
@@ -602,7 +602,7 @@ void nxagentDestroyGC(GCPtr pGC)
   miDestroyGC(pGC);
 }
 
-void nxagentChangeClip(GCPtr pGC, int type, pointer pValue, int nRects)
+void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
 {
   int i, size;
   BoxPtr pBox;
@@ -699,7 +699,7 @@ void nxagentChangeClip(GCPtr pGC, int type, pointer pValue, int nRects)
                          nxagentPixmap((PixmapPtr)pValue));
       }
 
-      pGC->clientClip = (pointer) (*pGC->pScreen->BitmapToRegion)((PixmapPtr) pValue);
+      pGC->clientClip = (void *) (*pGC->pScreen->BitmapToRegion)((PixmapPtr) pValue);
 
       nxagentGCPriv(pGC)->pPixmap = (PixmapPtr)pValue;
 
@@ -768,7 +768,7 @@ void nxagentChangeClip(GCPtr pGC, int type, pointer pValue, int nRects)
        * CT_REGION client clips.
        */
 
-      pGC->clientClip = (pointer) RECTS_TO_REGION(pGC->pScreen, nRects,
+      pGC->clientClip = (void *) RECTS_TO_REGION(pGC->pScreen, nRects,
                                                   (xRectangle *)pValue, type);
       xfree(pValue);
 
@@ -987,7 +987,7 @@ static void nxagentRestoreGCList()
   }
 }
 
-int nxagentDestroyNewGCResourceType(pointer p, XID id)
+int nxagentDestroyNewGCResourceType(void * p, XID id)
 {
   /*
    * Address of the destructor is set in Init.c.
@@ -1003,7 +1003,7 @@ int nxagentDestroyNewGCResourceType(pointer p, XID id)
   return 1;
 }
 
-static void nxagentReconnectGC(void *param0, XID param1, pointer param2)
+static void nxagentReconnectGC(void *param0, XID param1, void * param2)
 {
   XGCValues values;
   unsigned long valuemask;
@@ -1188,7 +1188,7 @@ Bool nxagentReconnectAllGCs(void *p0)
   return GCSuccess;
 }
 
-void nxagentDisconnectGC(pointer p0, XID x1, pointer p2)
+void nxagentDisconnectGC(void * p0, XID x1, void * p2)
 {
   GCPtr pGC = (GCPtr) p0;
   Bool* pBool = (Bool*) p2;
@@ -1255,7 +1255,7 @@ Bool nxagentDisconnectAllGCs()
   return success;
 }
 
-static void nxagentReconnectClip(GCPtr pGC, int type, pointer pValue, int nRects)
+static void nxagentReconnectClip(GCPtr pGC, int type, void * pValue, int nRects)
 {
   int i, size;
   BoxPtr pBox;
@@ -1320,7 +1320,7 @@ static void nxagentReconnectClip(GCPtr pGC, int type, pointer pValue, int nRects
 
       XSetClipOrigin(nxagentDisplay, nxagentGC(pGC), pGC -> clipOrg.x, pGC -> clipOrg.y);
 
-      pGC->clientClip = (pointer) (*pGC->pScreen->BitmapToRegion)((PixmapPtr) pValue);
+      pGC->clientClip = (void *) (*pGC->pScreen->BitmapToRegion)((PixmapPtr) pValue);
 
       nxagentGCPriv(pGC)->pPixmap = (PixmapPtr)pValue;
 
@@ -1370,7 +1370,7 @@ static void nxagentReconnectClip(GCPtr pGC, int type, pointer pValue, int nRects
        * CT_PIXMAP and CT_REGION client clips.
        */
 
-      pGC->clientClip = (pointer) RECTS_TO_REGION(pGC->pScreen, nRects,
+      pGC->clientClip = (void *) RECTS_TO_REGION(pGC->pScreen, nRects,
                                                   (xRectangle *)pValue, type);
       xfree(pValue);
       pValue = pGC->clientClip;

--- a/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
@@ -2042,7 +2042,7 @@ void nxagentImageText16(DrawablePtr pDrawable, GCPtr pGC, int x,
 
 void nxagentImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
                               unsigned int nGlyphs, CharInfoPtr *pCharInfo,
-                                  pointer pGlyphBase)
+                                  void * pGlyphBase)
 {
   if ((pDrawable)->type == DRAWABLE_PIXMAP)
   {
@@ -2061,7 +2061,7 @@ void nxagentImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
 
 void nxagentPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
                              unsigned int nGlyphs, CharInfoPtr *pCharInfo,
-                                 pointer pGlyphBase)
+                                 void * pGlyphBase)
 {
   if ((pDrawable)->type == DRAWABLE_PIXMAP)
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/GCOps.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/GCOps.h
@@ -93,10 +93,10 @@ void nxagentImageText16(DrawablePtr pDrawable, GCPtr pGC, int x,
                             int y, int count, unsigned short *string);
 
 void nxagentImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
-                              unsigned int nGlyphs, CharInfoPtr *pCharInfo, pointer pGlyphBase);
+                              unsigned int nGlyphs, CharInfoPtr *pCharInfo, void * pGlyphBase);
 
 void nxagentPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
-                             unsigned int nGlyphs, CharInfoPtr *pCharInfo, pointer pGlyphBase);
+                             unsigned int nGlyphs, CharInfoPtr *pCharInfo, void * pGlyphBase);
 
 void nxagentPushPixels(GCPtr pGC, PixmapPtr pBitmap, DrawablePtr pDrawable,
                            int width, int height, int x, int y);

--- a/nx-X11/programs/Xserver/hw/nxagent/GCs.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/GCs.h
@@ -87,17 +87,17 @@ void nxagentValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr pDrawable);
 void nxagentChangeGC(GCPtr pGC, unsigned long mask);
 void nxagentCopyGC(GCPtr pGCSrc, unsigned long mask, GCPtr pGCDst);
 void nxagentDestroyGC(GCPtr pGC);
-void nxagentChangeClip(GCPtr pGC, int type, pointer pValue, int nRects);
+void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects);
 void nxagentDestroyClip(GCPtr pGC);
 void nxagentDestroyClipHelper(GCPtr pGC);
 void nxagentCopyClip(GCPtr pGCDst, GCPtr pGCSrc);
 
-void nxagentDisconnectGC(pointer p0, XID x1, pointer p2);
+void nxagentDisconnectGC(void * p0, XID x1, void * p2);
 Bool nxagentDisconnectAllGCs(void);
 
 Bool nxagentReconnectAllGCs(void *p0);
 
-int nxagentDestroyNewGCResourceType(pointer p, XID id);
+int nxagentDestroyNewGCResourceType(void * p, XID id);
 
 void nxagentFreeGCList(void);
 void nxagentInitGCSafeVector(void);

--- a/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
@@ -161,7 +161,7 @@ struct _DispatchRec nxagentDispatch = { UNDEFINED, 0, 0, 0 };
 
 extern int nxagentSkipImage;
 
-void nxagentBlockHandler(pointer data, struct timeval **timeout, pointer mask)
+void nxagentBlockHandler(void * data, struct timeval **timeout, void * mask)
 {
   /*
    * Zero timeout.
@@ -569,7 +569,7 @@ void nxagentBlockHandler(pointer data, struct timeval **timeout, pointer mask)
   #endif
 }
 
-void nxagentWakeupHandler(pointer data, int count, pointer mask)
+void nxagentWakeupHandler(void * data, int count, void * mask)
 {
   #ifdef BLOCKS
   fprintf(stderr, "[Begin wakeup]\n");
@@ -723,7 +723,7 @@ void nxagentWakeupHandler(pointer data, int count, pointer mask)
   #endif
 }
 
-void nxagentShadowBlockHandler(pointer data, struct timeval **timeout, pointer mask)
+void nxagentShadowBlockHandler(void * data, struct timeval **timeout, void * mask)
 {
   static struct timeval zero;
 
@@ -851,7 +851,7 @@ FIXME: Must queue multiple writes and handle
   #endif
 }
 
-void nxagentShadowWakeupHandler(pointer data, int count, pointer mask)
+void nxagentShadowWakeupHandler(void * data, int count, void * mask)
 {
   #ifdef BLOCKS
   fprintf(stderr, "[Begin wakeup]\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Handlers.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Handlers.h
@@ -100,8 +100,8 @@ extern struct _TokensRec nxagentTokens;
  * The agent's block and wakeup handlers.
  */
 
-void nxagentBlockHandler(pointer data, struct timeval **timeout, pointer mask);
-void nxagentWakeupHandler(pointer data, int count, pointer mask);
+void nxagentBlockHandler(void * data, struct timeval **timeout, void * mask);
+void nxagentWakeupHandler(void * data, int count, void * mask);
 
 /*
  * Executed after each request processed.
@@ -109,8 +109,8 @@ void nxagentWakeupHandler(pointer data, int count, pointer mask);
 
 void nxagentDispatchHandler(ClientPtr client, int in, int out);
 
-void nxagentShadowBlockHandler(pointer data, struct timeval **timeout, pointer mask);
-void nxagentShadowWakeupHandler(pointer data, int count, pointer mask);
+void nxagentShadowBlockHandler(void * data, struct timeval **timeout, void * mask);
+void nxagentShadowWakeupHandler(void * data, int count, void * mask);
 
 extern GCPtr nxagentShadowGCPtr;
 extern unsigned char nxagentShadowDepth;

--- a/nx-X11/programs/Xserver/hw/nxagent/Init.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Init.c
@@ -132,8 +132,8 @@ void OsVendorEndRedirectErrorFFunction();
  */
 
 
-static void nxagentGrabServerCallback(CallbackListPtr *callbacks, pointer data,
-                                   pointer args);
+static void nxagentGrabServerCallback(CallbackListPtr *callbacks, void *data,
+                                   void *args);
 
 void ddxInitGlobals(void)
 {
@@ -398,7 +398,7 @@ void InitInput(argc, argv)
      int argc;
      char *argv[];
 {
-  pointer ptr, kbd;
+  void *ptr, *kbd;
 
   ptr = AddInputDevice(nxagentPointerProc, True);
   kbd = AddInputDevice(nxagentKeyboardProc, True);
@@ -530,8 +530,8 @@ int SelectWaitTime = 10000; /* usec */
 
 ServerGrabInfoRec nxagentGrabServerInfo;
 
-static void nxagentGrabServerCallback(CallbackListPtr *callbacks, pointer data,
-                                   pointer args)
+static void nxagentGrabServerCallback(CallbackListPtr *callbacks, void *data,
+                                   void *args)
 {
     ServerGrabInfoRec *grab = (ServerGrabInfoRec*)args;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -571,7 +571,7 @@ static char *nxagentXkbGetRules()
   return XKB_DFLT_RULES_FILE;
 }
  
-void nxagentBell(int volume, DeviceIntPtr pDev, pointer ctrl, int cls)
+void nxagentBell(int volume, DeviceIntPtr pDev, void * ctrl, int cls)
 {
   XBell(nxagentDisplay, volume);
 }
@@ -978,7 +978,7 @@ XkbError:
           #endif
 
           XkbSetRulesDflts(rules, model, layout, variants, options);
-          XkbInitKeyboardDeviceStruct((pointer)pDev, &names, &keySyms, modmap,
+          XkbInitKeyboardDeviceStruct((void *)pDev, &names, &keySyms, modmap,
                                           nxagentBell, nxagentChangeKeyboardControl);
 
           if (!nxagentKeyboard ||
@@ -1068,7 +1068,7 @@ XkbError:
           #endif
 
           XkbSetRulesDflts(rules, model, layout, variants, options);
-          XkbInitKeyboardDeviceStruct((pointer)pDev, &names, &keySyms, modmap,
+          XkbInitKeyboardDeviceStruct((void *)pDev, &names, &keySyms, modmap,
                                           nxagentBell, nxagentChangeKeyboardControl);
 
           free(nxagentXkbConfigFilePath);
@@ -1087,9 +1087,9 @@ XkbError:
         #endif
 
         XkbSetRulesDflts(rules, model, layout, variants, options);
-        XkbInitKeyboardDeviceStruct((pointer)pDev, &names, &keySyms, modmap,
+        XkbInitKeyboardDeviceStruct((void *)pDev, &names, &keySyms, modmap,
                                     nxagentBell, nxagentChangeKeyboardControl);
-        XkbDDXChangeControls((pointer)pDev, xkb->ctrls, xkb->ctrls);
+        XkbDDXChangeControls((void *)pDev, xkb->ctrls, xkb->ctrls);
 
 XkbEnd:
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.h
@@ -89,7 +89,7 @@ extern char *nxagentKeyboard;
  * and utility functions.
  */
 
-void nxagentBell(int volume, DeviceIntPtr pDev, pointer ctrl, int cls);
+void nxagentBell(int volume, DeviceIntPtr pDev, void * ctrl, int cls);
 
 int nxagentKeyboardProc(DeviceIntPtr pDev, int onoff);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdamage.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdamage.c
@@ -344,7 +344,7 @@ static void damageValidateGC(GCPtr, unsigned long, DrawablePtr);
 static void damageChangeGC(GCPtr, unsigned long);
 static void damageCopyGC(GCPtr, unsigned long, GCPtr);
 static void damageDestroyGC(GCPtr);
-static void damageChangeClip(GCPtr, int, pointer, int);
+static void damageChangeClip(GCPtr, int, void *, int);
 static void damageDestroyClip(GCPtr);
 static void damageCopyClip(GCPtr, GCPtr);
 
@@ -457,7 +457,7 @@ damageCopyGC (GCPtr	    pGCSrc,
 static void
 damageChangeClip (GCPtr	    pGC,
 		  int	    type,
-		  pointer   pvalue,
+		  void      *pvalue,
 		  int	    nrects)
 {
     DAMAGE_GC_FUNC_PROLOGUE (pGC);
@@ -1560,7 +1560,7 @@ damageImageGlyphBlt(DrawablePtr	    pDrawable,
 		    int		    y,
 		    unsigned int    nglyph,
 		    CharInfoPtr	    *ppci,
-		    pointer	    pglyphBase)
+		    void	    *pglyphBase)
 {
     DAMAGE_GC_OP_PROLOGUE(pGC, pDrawable);
     damageDamageChars (pDrawable, pGC->font, x + pDrawable->x, y + pDrawable->y,
@@ -1577,7 +1577,7 @@ damagePolyGlyphBlt(DrawablePtr	pDrawable,
 		   int		y,
 		   unsigned int	nglyph,
 		   CharInfoPtr	*ppci,
-		   pointer	pglyphBase)
+		   void		*pglyphBase)
 {
     DAMAGE_GC_OP_PROLOGUE(pGC, pDrawable);
     damageDamageChars (pDrawable, pGC->font, x + pDrawable->x, y + pDrawable->y,
@@ -1908,7 +1908,7 @@ DamageSetup (ScreenPtr pScreen)
     }
 #endif
 
-    pScreen->devPrivates[damageScrPrivateIndex].ptr = (pointer) pScrPriv;
+    pScreen->devPrivates[damageScrPrivateIndex].ptr = (void *) pScrPriv;
     return TRUE;
 }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -245,7 +245,7 @@ extern WindowPtr nxagentViewportFrameBelow;
 
 extern int nxagentMaxAllowedResets;
 
-extern int nxagentFindClientResource(int, RESTYPE, pointer);
+extern int nxagentFindClientResource(int, RESTYPE, void *);
 
 static ClientPtr grabClient;
 #define GrabNone 0
@@ -883,7 +883,7 @@ ProcCreateWindow(ClientPtr client)
 	Mask mask = pWin->eventMask;
 
 	pWin->eventMask = 0; /* subterfuge in case AddResource fails */
-	if (!AddResource(stuff->wid, RT_WINDOW, (pointer)pWin))
+	if (!AddResource(stuff->wid, RT_WINDOW, (void *)pWin))
 	    return BadAlloc;
 	pWin->eventMask = mask;
     }
@@ -1573,7 +1573,7 @@ ProcGrabServer(register ClientPtr client)
 	ServerGrabInfoRec grabinfo;
 	grabinfo.client = client;
 	grabinfo.grabstate  = SERVER_GRABBED;
-	CallCallbacks(&ServerGrabCallback, (pointer)&grabinfo);
+	CallCallbacks(&ServerGrabCallback, (void *)&grabinfo);
     }
 
     return(client->noClientException);
@@ -1602,7 +1602,7 @@ UngrabServer(ClientPtr client)
 	ServerGrabInfoRec grabinfo;
 	grabinfo.client = client;
 	grabinfo.grabstate  = SERVER_UNGRABBED;
-	CallCallbacks(&ServerGrabCallback, (pointer)&grabinfo);
+	CallCallbacks(&ServerGrabCallback, (void *)&grabinfo);
     }
 }
 
@@ -1966,7 +1966,7 @@ ProcListFontsWithInfo(register ClientPtr client)
  *  \param value must conform to DeleteType
  */
 int
-dixDestroyPixmap(pointer value, XID pid)
+dixDestroyPixmap(void * value, XID pid)
 {
     PixmapPtr pPixmap = (PixmapPtr)value;
     return (*pPixmap->drawable.pScreen->DestroyPixmap)(pPixmap);
@@ -2025,7 +2025,7 @@ CreatePmap:
     {
 	pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	pMap->drawable.id = stuff->pid;
-	if (AddResource(stuff->pid, RT_PIXMAP, (pointer)pMap))
+	if (AddResource(stuff->pid, RT_PIXMAP, (void *)pMap))
 	    return(client->noClientException);
     }
     return (BadAlloc);
@@ -2108,7 +2108,7 @@ ProcCreateGC(register ClientPtr client)
 			 (XID *) &stuff[1], &error);
     if (error != Success)
         return error;
-    if (!AddResource(stuff->gc, RT_GC, (pointer)pGC))
+    if (!AddResource(stuff->gc, RT_GC, (void *)pGC))
 	return (BadAlloc);
     return(client->noClientException);
 }
@@ -2798,7 +2798,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 				         nlines,
 				         format,
 				         planemask,
-				         (pointer) pBuf);
+				         (void *) pBuf);
 #ifdef XCSECURITY
 	    if (pVisibleRegion)
 		SecurityCensorImage(client, pVisibleRegion, widthBytesLine,
@@ -2839,7 +2839,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 				                 nlines,
 				                 format,
 				                 plane,
-				                 (pointer)pBuf);
+				                 (void *)pBuf);
 #ifdef XCSECURITY
 		    if (pVisibleRegion)
 			SecurityCensorImage(client, pVisibleRegion,
@@ -3669,7 +3669,7 @@ ProcCreateCursor (register ClientPtr client)
     /* zeroing the (pad) bits helps some ddx cursor handling */
     bzero((char *)srcbits, n);
     (* src->drawable.pScreen->GetImage)( (DrawablePtr)src, 0, 0, width, height,
-					 XYPixmap, 1, (pointer)srcbits);
+					 XYPixmap, 1, (void *)srcbits);
     if ( msk == (PixmapPtr)NULL)
     {
 	register unsigned char *bits = mskbits;
@@ -3681,7 +3681,7 @@ ProcCreateCursor (register ClientPtr client)
 	/* zeroing the (pad) bits helps some ddx cursor handling */
 	bzero((char *)mskbits, n);
 	(* msk->drawable.pScreen->GetImage)( (DrawablePtr)msk, 0, 0, width,
-					height, XYPixmap, 1, (pointer)mskbits);
+					height, XYPixmap, 1, (void *)mskbits);
     }
     cm.width = width;
     cm.height = height;
@@ -3691,7 +3691,7 @@ ProcCreateCursor (register ClientPtr client)
 	    stuff->foreRed, stuff->foreGreen, stuff->foreBlue,
 	    stuff->backRed, stuff->backGreen, stuff->backBlue);
 
-    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
     {
         #ifdef TEST
         fprintf(stderr, "ProcCreateCursor: Created cursor at [%p].\n", (void *) pCursor);
@@ -3721,7 +3721,7 @@ ProcCreateGlyphCursor (register ClientPtr client)
 			   &pCursor, client);
     if (res != Success)
 	return res;
-    if (AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
 	return client->noClientException;
     return BadAlloc;
 }
@@ -3908,10 +3908,10 @@ ProcChangeHosts(register ClientPtr client)
 
     if(stuff->mode == HostInsert)
 	result = AddHost(client, (int)stuff->hostFamily,
-			 stuff->hostLength, (pointer)&stuff[1]);
+			 stuff->hostLength, (void *)&stuff[1]);
     else if (stuff->mode == HostDelete)
 	result = RemoveHost(client, (int)stuff->hostFamily, 
-			    stuff->hostLength, (pointer)&stuff[1]);  
+			    stuff->hostLength, (void *)&stuff[1]);  
     else
     {
 	client->errorValue = stuff->mode;
@@ -3927,7 +3927,7 @@ ProcListHosts(register ClientPtr client)
 {
     xListHostsReply reply;
     int	len, nHosts, result;
-    pointer	pdata;
+    void *	pdata;
     /* REQUEST(xListHostsReq); */
 
     REQUEST_SIZE_MATCH(xListHostsReq);
@@ -4222,7 +4222,7 @@ CloseDownClient(register ClientPtr client)
 		clientinfo.client = client; 
 		clientinfo.prefix = (xConnSetupPrefix *)NULL;  
 		clientinfo.setup = (xConnSetup *) NULL;
-		CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+		CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
             } 
 	}
 	client->clientGone = TRUE;  /* so events aren't sent to client */
@@ -4259,7 +4259,7 @@ CloseDownClient(register ClientPtr client)
 	    clientinfo.client = client; 
 	    clientinfo.prefix = (xConnSetupPrefix *)NULL;  
 	    clientinfo.setup = (xConnSetup *) NULL;
-	    CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	    CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
 	} 	    
 	FreeClientResources(client);
 	if (client->index < nextFreeClientID)
@@ -4309,7 +4309,7 @@ CloseDownRetainedResources()
     }
 }
 
-void InitClient(ClientPtr client, int i, pointer ospriv)
+void InitClient(ClientPtr client, int i, void * ospriv)
 {
     client->index = i;
     client->sequence = 0; 
@@ -4399,11 +4399,11 @@ InitClientPrivates(ClientPtr client)
     {
 	if ( (size = *sizes) )
 	{
-	    ppriv->ptr = (pointer)ptr;
+	    ppriv->ptr = (void *)ptr;
 	    ptr += size;
 	}
 	else
-	    ppriv->ptr = (pointer)NULL;
+	    ppriv->ptr = (void *)NULL;
     }
 
     /*
@@ -4422,7 +4422,7 @@ InitClientPrivates(ClientPtr client)
  * Returns NULL if there are no free clients.
  *************************/
 
-ClientPtr NextAvailableClient(pointer ospriv)
+ClientPtr NextAvailableClient(void * ospriv)
 {
     register int i;
     register ClientPtr client;
@@ -4460,7 +4460,7 @@ ClientPtr NextAvailableClient(pointer ospriv)
         clientinfo.client = client; 
         clientinfo.prefix = (xConnSetupPrefix *)NULL;  
         clientinfo.setup = (xConnSetup *) NULL;
-	CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
     } 	
     return(client);
 }
@@ -4595,7 +4595,7 @@ SendConnSetup(register ClientPtr client, char *reason)
         clientinfo.client = client; 
         clientinfo.prefix = lconnSetupPrefix;  
         clientinfo.setup = (xConnSetup *)lConnectionInfo;
-	CallCallbacks((&ClientStateCallback), (pointer)&clientinfo);
+	CallCallbacks((&ClientStateCallback), (void *)&clientinfo);
     } 	
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
@@ -177,7 +177,7 @@ _NXGetFontPathError:
 
 #define QUERYCHARINFO(pci, pr)  *(pr) = (pci)->metrics
 
-extern pointer fosNaturalParams;
+extern void * fosNaturalParams;
 extern FontPtr defaultFont;
 
 static FontPathElementPtr *font_path_elements = (FontPathElementPtr *) 0;
@@ -291,7 +291,7 @@ RemoveFontWakeup(FontPathElementPtr fpe)
 }
 
 void
-FontWakeup(pointer data, int count, pointer LastSelectMask)
+FontWakeup(void * data, int count, void * LastSelectMask)
 {
     int         i;
     FontPathElementPtr fpe;
@@ -381,7 +381,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	if (c->current_fpe < c->num_fpes)
 	{
 	    fpe = c->fpe_list[c->current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -389,7 +389,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
     while (c->current_fpe < c->num_fpes) {
 	fpe = c->fpe_list[c->current_fpe];
 	err = (*fpe_functions[fpe->type].open_font)
-	    ((pointer) client, fpe, c->flags,
+	    ((void *) client, fpe, c->flags,
 	     c->fontname, c->fnamelen, FontFormat,
 	     BitmapFormatMaskByte |
 	     BitmapFormatMaskBit |
@@ -423,7 +423,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	if (err == Suspended) {
 	    if (!c->slept) {
 		c->slept = TRUE;
-		ClientSleep(client, (ClientSleepProcPtr)doOpenFont, (pointer) c);
+		ClientSleep(client, (ClientSleepProcPtr)doOpenFont, (void *) c);
 #ifdef NXAGENT_DEBUG
                 fprintf(stderr, " NXdixfonts: doOpenFont: client [%lx] sleeping.\n", client);
 #endif
@@ -469,7 +469,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
 	    }
 	}
     }
-    if (!AddResource(c->fontid, RT_FONT, (pointer) pfont)) {
+    if (!AddResource(c->fontid, RT_FONT, (void *) pfont)) {
 	err = AllocError;
 	goto bail;
     }
@@ -478,7 +478,7 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
       extern RESTYPE RT_NX_FONT;
 
       nxagentFontPriv(pfont) -> mirrorID = FakeClientID(0);
-      if (!AddResource(nxagentFontPriv(pfont) -> mirrorID, RT_NX_FONT, (pointer) pfont)) {
+      if (!AddResource(nxagentFontPriv(pfont) -> mirrorID, RT_NX_FONT, (void *) pfont)) {
         FreeResource(c->fontid, RT_NONE);
         err = AllocError;
         goto bail;
@@ -548,7 +548,7 @@ OpenFont(ClientPtr client, XID fid, Mask flags, unsigned lenfname, char *pfontna
 	cached = FindCachedFontPattern(patternCache, pfontname, lenfname);
 	if (cached && cached->info.cachable)
 	{
-	    if (!AddResource(fid, RT_FONT, (pointer) cached))
+	    if (!AddResource(fid, RT_FONT, (void *) cached))
 		return BadAlloc;
 	    cached->refcnt++;
 	    return Success;
@@ -599,7 +599,7 @@ OpenFont(ClientPtr client, XID fid, Mask flags, unsigned lenfname, char *pfontna
  *  \param value must conform to DeleteType
  */
 int
-CloseFont(pointer value, XID fid)
+CloseFont(void * value, XID fid)
 {
     int         nscr;
     ScreenPtr   pscr;
@@ -730,7 +730,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 	if (c->current.current_fpe < c->num_fpes)
 	{
 	    fpe = c->fpe_list[c->current.current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -748,7 +748,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 	    /* This FPE doesn't support/require list_fonts_and_aliases */
 
 	    err = (*fpe_functions[fpe->type].list_fonts)
-		((pointer) c->client, fpe, c->current.pattern,
+		((void *) c->client, fpe, c->current.pattern,
 		 c->current.patlen, c->current.max_names - c->names->nnames,
 		 c->names);
 
@@ -757,7 +757,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 		    c->slept = TRUE;
 		    ClientSleep(client,
 			(ClientSleepProcPtr)doListFontsAndAliases,
-			(pointer) c);
+			(void *) c);
 #ifdef NXAGENT_DEBUG
                     fprintf(stderr, " NXdixfonts: doListFont (1): client [%lx] sleeping.\n", client);
 #endif
@@ -780,14 +780,14 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 
 	    if (!c->current.list_started) {
 		err = (*fpe_functions[fpe->type].start_list_fonts_and_aliases)
-		    ((pointer) c->client, fpe, c->current.pattern,
+		    ((void *) c->client, fpe, c->current.pattern,
 		     c->current.patlen, c->current.max_names - c->names->nnames,
 		     &c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)doListFontsAndAliases,
-				    (pointer) c);
+				    (void *) c);
 			c->slept = TRUE;
 		    }
 		    return TRUE;
@@ -799,13 +799,13 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 		char    *tmpname;
 		name = 0;
 		err = (*fpe_functions[fpe->type].list_next_font_or_alias)
-		    ((pointer) c->client, fpe, &name, &namelen, &tmpname,
+		    ((void *) c->client, fpe, &name, &namelen, &tmpname,
 		     &resolvedlen, c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)doListFontsAndAliases,
-				    (pointer) c);
+				    (void *) c);
 			c->slept = TRUE;
 #ifdef NXAGENT_DEBUG
                         fprintf(stderr, " NXdixfonts: doListFont (2): client [%lx] sleeping.\n", client);
@@ -859,7 +859,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
 
 		    tmpname = 0;
 		    (void) (*fpe_functions[fpe->type].list_next_font_or_alias)
-			((pointer) c->client, fpe, &tmpname, &tmpnamelen,
+			((void *) c->client, fpe, &tmpname, &tmpnamelen,
 			 &tmpname, &tmpnamelen, c->current.private);
 		    if (--aliascount <= 0)
 		    {
@@ -1070,7 +1070,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
 	if (c->current.current_fpe < c->num_fpes)
  	{
 	    fpe = c->fpe_list[c->current.current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -1361,7 +1361,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
     if (client->clientGone)
     {
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 
 	if (c->slept)
 	{
@@ -1389,7 +1389,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
 	   the FPE code to clean up after client and avoid further
 	   rendering while we clean up after ourself.  */
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	c->pDraw = (DrawablePtr)0;
     }
 
@@ -1558,7 +1558,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
 		    c->slept = TRUE;
 		    ClientSleep(client,
 		    	     (ClientSleepProcPtr)doPolyText,
-			     (pointer) c);
+			     (void *) c);
 #ifdef NXAGENT_DEBUG
                     fprintf(stderr, " NXdixfonts: doPolyText (1): client [%lx] sleeping.\n", client);
 #endif
@@ -1670,7 +1670,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
     if (client->clientGone)
     {
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	err = Success;
 	goto bail;
     }
@@ -1684,7 +1684,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
 	/* Our drawable has disappeared.  Treat like client died... ask
 	   the FPE code to clean up after client. */
 	fpe = c->pGC->font->fpe;
-	(*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	(*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	err = Success;
 	goto bail;
     }
@@ -1756,7 +1756,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
 	    ValidateGC(c->pDraw, c->pGC);
 
 	    c->slept = TRUE;
-            ClientSleep(client, (ClientSleepProcPtr)doImageText, (pointer) c);
+            ClientSleep(client, (ClientSleepProcPtr)doImageText, (void *) c);
 #ifdef NXAGENT_DEBUG
             fprintf(stderr, " NXdixfonts: doImageText (1): client [%lx] sleeping.\n", client);
 #endif
@@ -2115,7 +2115,7 @@ DeleteClientFontStuff(ClientPtr client)
     {
 	fpe = font_path_elements[i];
 	if (fpe_functions[fpe->type].client_died)
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
     }
 }
 
@@ -2255,7 +2255,7 @@ GetNewFontClientID()
 int
 StoreFontClientFont(FontPtr pfont, Font id)
 {
-    return AddResource(id, RT_NONE, (pointer) pfont);
+    return AddResource(id, RT_NONE, (void *) pfont);
 }
 
 void
@@ -2288,7 +2288,7 @@ init_fs_handlers(FontPathElementPtr fpe, BlockHandlerProcPtr block_handler)
 #endif
 
 	if (!RegisterBlockAndWakeupHandlers(block_handler,
-					    FontWakeup, (pointer) 0))
+					    FontWakeup, (void *) 0))
 	    return AllocError;
 	fs_handlers_installed++;
     }
@@ -2308,7 +2308,7 @@ remove_fs_handlers(FontPathElementPtr fpe, BlockHandlerProcPtr block_handler, Bo
 #endif
 
 	    RemoveBlockAndWakeupHandlers(block_handler, FontWakeup,
-					 (pointer) 0);
+					 (void *) 0);
 	}
     }
     RemoveFontWakeup(fpe);
@@ -2339,7 +2339,7 @@ dump_char_ascii(CharInfoPtr cip)
 
     bpr = GLYPH_SIZE(cip, 4);
     for (r = 0; r < (cip->metrics.ascent + cip->metrics.descent); r++) {
-	pointer     row = (pointer) cip->bits + r * bpr;
+	void *     row = (void *) cip->bits + r * bpr;
 
 	byte = 0;
 	for (l = 0; l <= (cip->metrics.rightSideBearing -
@@ -2386,7 +2386,7 @@ nxdoListFontsAndAliases(client, fss)
 	if (c->current.current_fpe < c->num_fpes)
 	{
 	    fpe = c->fpe_list[c->current.current_fpe];
-	    (*fpe_functions[fpe->type].client_died) ((pointer) client, fpe);
+	    (*fpe_functions[fpe->type].client_died) ((void *) client, fpe);
 	}
 	err = Successful;
 	goto bail;
@@ -2404,7 +2404,7 @@ nxdoListFontsAndAliases(client, fss)
 	    /* This FPE doesn't support/require list_fonts_and_aliases */
 
 	    err = (*fpe_functions[fpe->type].list_fonts)
-		((pointer) c->client, fpe, c->current.pattern,
+		((void *) c->client, fpe, c->current.pattern,
 		 c->current.patlen, c->current.max_names - c->names->nnames,
 		 c->names);
 
@@ -2413,7 +2413,7 @@ nxdoListFontsAndAliases(client, fss)
 		    c->slept = TRUE;
 		    ClientSleep(client,
 			(ClientSleepProcPtr)nxdoListFontsAndAliases,
-			(pointer) fss);
+			(void *) fss);
 #ifdef NXAGENT_DEBUG
                     fprintf(stderr, " NXdixfonts: nxdoListFont (1): client [%lx] sleeping.\n", client);
 #endif
@@ -2436,14 +2436,14 @@ nxdoListFontsAndAliases(client, fss)
 
 	    if (!c->current.list_started) {
 		err = (*fpe_functions[fpe->type].start_list_fonts_and_aliases)
-		    ((pointer) c->client, fpe, c->current.pattern,
+		    ((void *) c->client, fpe, c->current.pattern,
 		     c->current.patlen, c->current.max_names - c->names->nnames,
 		     &c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)nxdoListFontsAndAliases,
-				    (pointer) fss);
+				    (void *) fss);
 			c->slept = TRUE;
 #ifdef NXAGENT_DEBUG
                         fprintf(stderr, " NXdixfonts: nxdoListFont (2): client [%lx] sleeping.\n", client);
@@ -2458,13 +2458,13 @@ nxdoListFontsAndAliases(client, fss)
 		char    *tmpname;
 		name = 0;
 		err = (*fpe_functions[fpe->type].list_next_font_or_alias)
-		    ((pointer) c->client, fpe, &name, &namelen, &tmpname,
+		    ((void *) c->client, fpe, &name, &namelen, &tmpname,
 		     &resolvedlen, c->current.private);
 		if (err == Suspended) {
 		    if (!c->slept) {
 			ClientSleep(client,
 				    (ClientSleepProcPtr)nxdoListFontsAndAliases,
-				    (pointer) fss);
+				    (void *) fss);
 			c->slept = TRUE;
 #ifdef NXAGENT_DEBUG
                         fprintf(stderr, " NXdixfonts: nxdoListFont (3): client [%lx] sleeping.\n", client);
@@ -2529,7 +2529,7 @@ nxdoListFontsAndAliases(client, fss)
 
 		    tmpname = 0;
 		    (void) (*fpe_functions[fpe->type].list_next_font_or_alias)
-			((pointer) c->client, fpe, &tmpname, &tmpnamelen,
+			((void *) c->client, fpe, &tmpname, &tmpnamelen,
 			 &tmpname, &tmpnamelen, c->current.private);
 		    if (--aliascount <= 0)
 		    {
@@ -2694,7 +2694,7 @@ nxOpenFont(client, fid, flags, lenfname, pfontname)
 	cached = FindCachedFontPattern(patternCache, pfontname, lenfname);
 	if (cached && cached->info.cachable)
 	{
-	    if (!AddResource(fid, RT_FONT, (pointer) cached))
+	    if (!AddResource(fid, RT_FONT, (void *) cached))
 		return BadAlloc;
 	    cached->refcnt++;
 	    return Success;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -1112,7 +1112,7 @@ EnqueueEvent(xEvent *xE, DeviceIntPtr device, int count)
 		WindowTable[sprite.hotPhys.pScreen->myNum]->drawable.id;
 	eventinfo.events = xE;
 	eventinfo.count = count;
-	CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
     }
     if (xE->u.u.type == MotionNotify)
     {
@@ -2783,7 +2783,7 @@ CheckPassiveGrabsOnWindow(
 a passive grab to be activated.  If the event is a keyboard event, the
 ancestors of the focus window are traced down and tried to see if they have
 any passive grabs to be activated.  If the focus window itself is reached and
-it's descendants contain they pointer, the ancestors of the window that the
+its descendants contain the pointer, the ancestors of the window that the
 pointer is in are then traced down starting at the focus window, otherwise no
 grabs are activated.  If the event is a pointer event, the ancestors of the
 window that the pointer is in are traced down starting at the root until
@@ -3008,7 +3008,7 @@ drawable.id:0;
 	    DeviceEventInfoRec eventinfo;
 	    eventinfo.events = xE;
 	    eventinfo.count = count;
-	    CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	    CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
 	}
     }
 #ifdef XEVIE
@@ -3212,7 +3212,7 @@ ProcessPointerEvent (register xEvent *xE, register DeviceIntPtr mouse, int count
 		    WindowTable[sprite.hotPhys.pScreen->myNum]->drawable.id;
 	    eventinfo.events = xE;
 	    eventinfo.count = count;
-	    CallCallbacks(&DeviceEventCallback, (pointer)&eventinfo);
+	    CallCallbacks(&DeviceEventCallback, (void *)&eventinfo);
 	}
     }
     if (xE->u.u.type != MotionNotify)
@@ -3402,7 +3402,7 @@ RecalculateDeliverableEvents(pWin)
  *  \param value must conform to DeleteType
  */
 int
-OtherClientGone(pointer value, XID id)
+OtherClientGone(void * value, XID id)
 {
     register OtherClientsPtr other, prev;
     register WindowPtr pWin = (WindowPtr)value;
@@ -3497,7 +3497,7 @@ EventSelectForWindow(register WindowPtr pWin, register ClientPtr client, Mask ma
 	others->resource = FakeClientID(client->index);
 	others->next = pWin->optional->otherClients;
 	pWin->optional->otherClients = others;
-	if (!AddResource(others->resource, RT_OTHERCLIENT, (pointer)pWin))
+	if (!AddResource(others->resource, RT_OTHERCLIENT, (void *)pWin))
 	    return BadAlloc;
     }
 maskSet: 
@@ -5029,7 +5029,7 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 	eventinfo.client = pClient;
 	eventinfo.events = events;
 	eventinfo.count = count;
-	CallCallbacks(&EventCallback, (pointer)&eventinfo);
+	CallCallbacks(&EventCallback, (void *)&eventinfo);
     }
     if(pClient->swapped)
     {

--- a/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
@@ -442,7 +442,7 @@ static int __glXDispatch(ClientPtr client)
 	** with the client so we will be notified when the client dies.
 	*/
 	XID xid = FakeClientID(client->index);
-	if (!AddResource( xid, __glXClientRes, (pointer)(long)client->index)) {
+	if (!AddResource( xid, __glXClientRes, (void *)(long)client->index)) {
 	    return BadAlloc;
 	}
 	ResetClientState(client->index);
@@ -520,7 +520,7 @@ static int __glXSwapDispatch(ClientPtr client)
 	** with the client so we will be notified when the client dies.
 	*/
 	XID xid = FakeClientID(client->index);
-	if (!AddResource( xid, __glXClientRes, (pointer)(long)client->index)) {
+	if (!AddResource( xid, __glXClientRes, (void *)(long)client->index)) {
 	    return BadAlloc;
 	}
 	ResetClientState(client->index);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXglyph.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXglyph.c
@@ -147,30 +147,30 @@ ResetGlyphSetPrivateIndex (void)
 }
 
 Bool
-_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, pointer ptr)
+_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, void * ptr)
 {
-    pointer *new;
+    void **new;
 
     if (n > glyphSet->maxPrivate) {
 	if (glyphSet->devPrivates &&
-	    glyphSet->devPrivates != (pointer)(&glyphSet[1])) {
-	    new = (pointer *) xrealloc (glyphSet->devPrivates,
-					(n + 1) * sizeof (pointer));
+	    glyphSet->devPrivates != (void *)(&glyphSet[1])) {
+	    new = (void **) xrealloc (glyphSet->devPrivates,
+					(n + 1) * sizeof (void *));
 	    if (!new)
 		return FALSE;
 	} else {
-	    new = (pointer *) xalloc ((n + 1) * sizeof (pointer));
+	    new = (void **) xalloc ((n + 1) * sizeof (void *));
 	    if (!new)
 		return FALSE;
 	    if (glyphSet->devPrivates)
 		memcpy (new,
 			glyphSet->devPrivates,
-			(glyphSet->maxPrivate + 1) * sizeof (pointer));
+			(glyphSet->maxPrivate + 1) * sizeof (void *));
 	}
 	glyphSet->devPrivates = new;
 	/* Zero out new, uninitialize privates */
 	while (++glyphSet->maxPrivate < n)
-	    glyphSet->devPrivates[glyphSet->maxPrivate] = (pointer)0;
+	    glyphSet->devPrivates[glyphSet->maxPrivate] = (void *)0;
     }
     glyphSet->devPrivates[n] = ptr;
     return TRUE;
@@ -522,14 +522,14 @@ AllocateGlyphSet (int fdepth, PictFormatPtr format)
     }
 
     size = (sizeof (GlyphSetRec) +
-	    (sizeof (pointer) * _GlyphSetPrivateAllocateIndex));
+	    (sizeof (void *) * _GlyphSetPrivateAllocateIndex));
     glyphSet = xalloc (size);
     if (!glyphSet)
 	return FALSE;
     bzero((char *)glyphSet, size);
     glyphSet->maxPrivate = _GlyphSetPrivateAllocateIndex - 1;
     if (_GlyphSetPrivateAllocateIndex)
-	glyphSet->devPrivates = (pointer)(&glyphSet[1]);
+	glyphSet->devPrivates = (void *)(&glyphSet[1]);
 
     if (!AllocateGlyphHash (&glyphSet->hash, &glyphHashSets[0]))
     {
@@ -543,7 +543,7 @@ AllocateGlyphSet (int fdepth, PictFormatPtr format)
 }
 
 int
-FreeGlyphSet (pointer	value,
+FreeGlyphSet (void *	value,
 	      XID       gid)
 {
     GlyphSetPtr	glyphSet = (GlyphSetPtr) value;
@@ -571,7 +571,7 @@ FreeGlyphSet (pointer	value,
 	xfree (table);
 
 	if (glyphSet->devPrivates &&
-	    glyphSet->devPrivates != (pointer)(&glyphSet[1]))
+	    glyphSet->devPrivates != (void *)(&glyphSet[1]))
 	    xfree(glyphSet->devPrivates);
 
 	xfree (glyphSet);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXglyphstr.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXglyphstr.h
@@ -94,13 +94,13 @@ typedef struct _GlyphSet {
     int		    fdepth;
     GlyphHashRec    hash;
     int             maxPrivate;
-    pointer         *devPrivates;
+    void            **devPrivates;
     CARD32          remoteID;
 } GlyphSetRec, *GlyphSetPtr;
 
 #define GlyphSetGetPrivate(pGlyphSet,n)					\
 	((n) > (pGlyphSet)->maxPrivate ?				\
-	 (pointer) 0 :							\
+	 (void *) 0 :							\
 	 (pGlyphSet)->devPrivates[n])
 
 #define GlyphSetSetPrivate(pGlyphSet,n,ptr)				\
@@ -127,7 +127,7 @@ void
 ResetGlyphSetPrivateIndex (void);
 
 Bool
-_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, pointer ptr);
+_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, void * ptr);
 
 Bool
 GlyphInit (ScreenPtr pScreen);
@@ -166,7 +166,7 @@ GlyphSetPtr
 AllocateGlyphSet (int fdepth, PictFormatPtr format);
 
 int
-FreeGlyphSet (pointer   value,
+FreeGlyphSet (void      *value,
 	      XID       gid);
 
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
@@ -672,7 +672,7 @@ static GCPtr	screenContext[MAXSCREENS];
 /*ARGSUSED*/
 static int
 tossGC (
-    pointer value,
+    void * value,
     XID id)
 {
     GCPtr pGC = (GCPtr)value;
@@ -757,7 +757,7 @@ int what;
 	    gcmask |= GCForeground | GCFillStyle;
 	    break;
 	case BackgroundPixmap:
-	    newValues[TILE].ptr = (pointer)pWin->background.pixmap;
+	    newValues[TILE].ptr = (void *)pWin->background.pixmap;
 	    newValues[FILLSTYLE].val = FillTiled;
 	    gcmask |= GCTile | GCFillStyle | GCTileStipXOrigin | GCTileStipYOrigin;
 	    break;
@@ -773,7 +773,7 @@ int what;
 	}
 	else
 	{
-	    newValues[TILE].ptr = (pointer)pWin->border.pixmap;
+	    newValues[TILE].ptr = (void *)pWin->border.pixmap;
 	    newValues[FILLSTYLE].val = FillTiled;
 	    gcmask |= GCTile | GCFillStyle | GCTileStipXOrigin | GCTileStipYOrigin;
 	}
@@ -846,7 +846,7 @@ int what;
 		return;
 	    numGCs++;
 	    if (!AddResource(FakeClientID(0), ResType,
-			     (pointer)screenContext[i]))
+			     (void *)screenContext[i]))
 	        return;
 	}
 	pGC = screenContext[i];

--- a/nx-X11/programs/Xserver/hw/nxagent/NXmiglyph.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXmiglyph.c
@@ -225,7 +225,7 @@ miGlyphs (CARD8		op,
 		pPixmap = GetScratchPixmapHeader (pScreen, glyph->info.width, glyph->info.height, 
 						  list->format->depth,
 						  list->format->depth, 
-						  0, (pointer) (glyph + 1));
+						  0, (void *) (glyph + 1));
 		if (!pPixmap)
 		    return;
 		component_alpha = NeedsComponent(list->format->format);
@@ -240,7 +240,7 @@ miGlyphs (CARD8		op,
 	    }
 	    (*pScreen->ModifyPixmapHeader) (pPixmap, 
 					    glyph->info.width, glyph->info.height,
-					    0, 0, -1, (pointer) (glyph + 1));
+					    0, 0, -1, (void *) (glyph + 1));
 
             #ifdef NXAGENT_SERVER
 
@@ -292,7 +292,7 @@ miGlyphs (CARD8		op,
 	if (pPicture)
 	{
 	    FreeScratchPixmapHeader (pPixmap);
-	    FreePicture ((pointer) pPicture, 0);
+	    FreePicture ((void *) pPicture, 0);
 	    pPicture = 0;
 	    pPixmap = 0;
 	}
@@ -311,7 +311,7 @@ miGlyphs (CARD8		op,
 			  x, y,
 			  width, height);
 
-	FreePicture ((pointer) pMask, (XID) 0);
+	FreePicture ((void *) pMask, (XID) 0);
 	(*pScreen->DestroyPixmap) (pMaskPixmap);
     }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXmiwindow.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXmiwindow.c
@@ -596,7 +596,7 @@ miMoveWindow(pWin, x, y, pNextSib, kind)
 static int
 miRecomputeExposures (
     register WindowPtr	pWin,
-    pointer		value) /* must conform to VisitWindowProcPtr */
+    void *		value) /* must conform to VisitWindowProcPtr */
 {
     register ScreenPtr	pScreen;
     RegionPtr	pValid = (RegionPtr)value;
@@ -927,7 +927,7 @@ miSlideAndSizeWindow(pWin, x, y, w, h, pSib)
 		    continue;
 		REGION_INTERSECT(pScreen, pRegion,
 				       &pChild->borderClip, gravitate[g]);
-		TraverseTree (pChild, miRecomputeExposures, (pointer)pRegion);
+		TraverseTree (pChild, miRecomputeExposures, (void *)pRegion);
 	    }
 
 	    /*

--- a/nx-X11/programs/Xserver/hw/nxagent/NXpicture.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXpicture.c
@@ -152,7 +152,7 @@ PictureDestroyWindow (WindowPtr pWindow)
 	SetPictureWindow(pWindow, pPicture->pNext);
 	if (pPicture->id)
 	    FreeResource (pPicture->id, PictureType);
-	FreePicture ((pointer) pPicture, pPicture->id);
+	FreePicture ((void *) pPicture, pPicture->id);
     }
     pScreen->DestroyWindow = ps->DestroyWindow;
     ret = (*pScreen->DestroyWindow) (pWindow);
@@ -731,7 +731,7 @@ PictureInit (ScreenPtr pScreen, PictFormatPtr formats, int nformats)
     }
     for (n = 0; n < nformats; n++)
     {
-	if (!AddResource (formats[n].id, PictFormatType, (pointer) (formats+n)))
+	if (!AddResource (formats[n].id, PictFormatType, (void *) (formats+n)))
 	{
 	    xfree (formats);
 	    return FALSE;
@@ -867,11 +867,11 @@ AllocatePicture (ScreenPtr  pScreen)
     {
 	if ( (size = *sizes) )
 	{
-	    ppriv->ptr = (pointer)ptr;
+	    ppriv->ptr = (void *)ptr;
 	    ptr += size;
 	}
 	else
-	    ppriv->ptr = (pointer)NULL;
+	    ppriv->ptr = (void *)NULL;
     }
 
     nxagentPicturePriv(pPicture) -> picture = 0;
@@ -1103,7 +1103,7 @@ static PicturePtr createSourcePicture(void)
 
       privPictureRecAddr = (char *) &ppriv[picturePrivateCount];
 
-      ppriv[nxagentPicturePrivateIndex].ptr = (pointer) privPictureRecAddr;
+      ppriv[nxagentPicturePrivateIndex].ptr = (void *) privPictureRecAddr;
 
       pPicture -> devPrivates = ppriv;
 
@@ -1364,7 +1364,7 @@ ChangePicture (PicturePtr	pPicture,
 		    if (pAlpha && pAlpha->pDrawable->type == DRAWABLE_PIXMAP)
 			pAlpha->refcnt++;
 		    if (pPicture->alphaMap)
-			FreePicture ((pointer) pPicture->alphaMap, (XID) 0);
+			FreePicture ((void *) pPicture->alphaMap, (XID) 0);
 		    pPicture->alphaMap = pAlpha;
 		}
 	    }
@@ -1442,7 +1442,7 @@ ChangePicture (PicturePtr	pPicture,
                 #endif
 
 		error = (*ps->ChangePictureClip)(pPicture, clipType,
-						 (pointer)pPixmap, 0);
+						 (void *)pPixmap, 0);
 		break;
 	    }
 	case CPGraphicsExposure:
@@ -1542,7 +1542,7 @@ SetPictureClipRects (PicturePtr	pPicture,
     if (!clientClip)
 	return BadAlloc;
     result =(*ps->ChangePictureClip) (pPicture, CT_REGION, 
-				      (pointer) clientClip, 0);
+				      (void *) clientClip, 0);
     if (result == Success)
     {
 	pPicture->clipOrigin.x = xOrigin;
@@ -1586,7 +1586,7 @@ SetPictureClipRegion (PicturePtr    pPicture,
     }
 
     result =(*ps->ChangePictureClip) (pPicture, type,
-                                      (pointer) clientClip, 0);
+                                      (void *) clientClip, 0);
     if (result == Success)
     {
         pPicture->clipOrigin.x = xOrigin;
@@ -1658,7 +1658,7 @@ CopyPicture (PicturePtr	pSrc,
 	    if (pSrc->alphaMap && pSrc->alphaMap->pDrawable->type == DRAWABLE_PIXMAP)
 		pSrc->alphaMap->refcnt++;
 	    if (pDst->alphaMap)
-		FreePicture ((pointer) pDst->alphaMap, (XID) 0);
+		FreePicture ((void *) pDst->alphaMap, (XID) 0);
 	    pDst->alphaMap = pSrc->alphaMap;
 	    break;
 	case CPAlphaXOrigin:
@@ -1740,7 +1740,7 @@ ValidatePicture(PicturePtr pPicture)
 }
 
 int
-FreePicture (pointer	value,
+FreePicture (void *	value,
 	     XID	pid)
 {
     PicturePtr	pPicture = (PicturePtr) value;
@@ -1764,7 +1764,7 @@ FreePicture (pointer	value,
             PictureScreenPtr    ps = GetPictureScreen(pScreen);
 	
             if (pPicture->alphaMap)
-                FreePicture ((pointer) pPicture->alphaMap, (XID) 0);
+                FreePicture ((void *) pPicture->alphaMap, (XID) 0);
             (*ps->DestroyPicture) (pPicture);
             (*ps->DestroyPictureClip) (pPicture);
             if (pPicture->pDrawable->type == DRAWABLE_WINDOW)
@@ -1794,7 +1794,7 @@ FreePicture (pointer	value,
 }
 
 int
-FreePictFormat (pointer	pPictFormat,
+FreePictFormat (void *	pPictFormat,
 		XID     pid)
 {
     return Success;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXpicturestr.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXpicturestr.h
@@ -174,7 +174,7 @@ typedef struct _Picture {
     DDXPointRec	    alphaOrigin;
 
     DDXPointRec	    clipOrigin;
-    pointer	    clientClip;
+    void *	    clientClip;
 
     Atom	    dither;
 
@@ -220,7 +220,7 @@ typedef int	(*CreatePictureProcPtr)	    (PicturePtr pPicture);
 typedef void	(*DestroyPictureProcPtr)    (PicturePtr pPicture);
 typedef int	(*ChangePictureClipProcPtr) (PicturePtr	pPicture,
 					     int	clipType,
-					     pointer    value,
+					     void       *value,
 					     int	n);
 typedef void	(*DestroyPictureClipProcPtr)(PicturePtr	pPicture);
 
@@ -393,9 +393,9 @@ extern RESTYPE		GlyphSetType;
 
 #define GetPictureScreen(s) ((PictureScreenPtr) ((s)->devPrivates[PictureScreenPrivateIndex].ptr))
 #define GetPictureScreenIfSet(s) ((PictureScreenPrivateIndex != -1) ? GetPictureScreen(s) : NULL)
-#define SetPictureScreen(s,p) ((s)->devPrivates[PictureScreenPrivateIndex].ptr = (pointer) (p))
+#define SetPictureScreen(s,p) ((s)->devPrivates[PictureScreenPrivateIndex].ptr = (void *) (p))
 #define GetPictureWindow(w) ((PicturePtr) ((w)->devPrivates[PictureWindowPrivateIndex].ptr))
-#define SetPictureWindow(w,p) ((w)->devPrivates[PictureWindowPrivateIndex].ptr = (pointer) (p))
+#define SetPictureWindow(w,p) ((w)->devPrivates[PictureWindowPrivateIndex].ptr = (void *) (p))
 
 #define VERIFY_PICTURE(pPicture, pid, client, mode, err) {\
     pPicture = SecurityLookupIDByType(client, pid, PictureType, mode);\
@@ -535,11 +535,11 @@ void
 ValidatePicture(PicturePtr pPicture);
 
 int
-FreePicture (pointer	pPicture,
+FreePicture (void *	pPicture,
 	     XID	pid);
 
 int
-FreePictFormat (pointer	pPictFormat,
+FreePictFormat (void *	pPictFormat,
 		XID     pid);
 
 void

--- a/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
@@ -317,10 +317,10 @@ ProcChangeProperty(ClientPtr client)
 
 #ifdef LBX
     err = LbxChangeWindowProperty(client, pWin, stuff->property, stuff->type,
-	 (int)format, (int)mode, len, TRUE, (pointer)&stuff[1], TRUE, NULL);
+	 (int)format, (int)mode, len, TRUE, (void *)&stuff[1], TRUE, NULL);
 #else
     err = ChangeWindowProperty(pWin, stuff->property, stuff->type, (int)format,
-			       (int)mode, len, (pointer)&stuff[1], TRUE);
+			       (int)mode, len, (void *)&stuff[1], TRUE);
 #endif
     if (err != Success)
 	return err;
@@ -329,7 +329,7 @@ ProcChangeProperty(ClientPtr client)
       if (nxagentOption(Rootless) == 1)
       {
         nxagentExportProperty(pWin, stuff->property, stuff->type, (int) format,
-                                  (int) mode, len, (pointer) &stuff[1]);
+                                  (int) mode, len, (void *) &stuff[1]);
       }
 
       nxagentGuessClientHint(client, stuff->property, (char *) &stuff[1]);
@@ -346,7 +346,7 @@ ProcChangeProperty(ClientPtr client)
 
 int
 ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format, 
-                     int mode, unsigned long len, pointer value, 
+                     int mode, unsigned long len, void * value, 
                      Bool sendevent)
 {
 #ifdef LBX
@@ -358,7 +358,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
     xEvent event;
     int sizeInBytes;
     int totalSize;
-    pointer data;
+    void * data;
     int copySize;
 
     sizeInBytes = format>>3;
@@ -392,7 +392,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
         pProp = (PropertyPtr)xalloc(sizeof(PropertyRec));
 	if (!pProp)
 	    return(BadAlloc);
-        data = (pointer)xalloc(totalSize);
+        data = (void *)xalloc(totalSize);
 	if (!data && len)
 	{
 	    xfree(pProp);
@@ -423,7 +423,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
         {
 	    if (totalSize != pProp->size * (pProp->format >> 3))
 	    {
-	    	data = (pointer)xrealloc(pProp->data, totalSize);
+	    	data = (void *)xrealloc(pProp->data, totalSize);
 	    	if (!data && len)
 		    return(BadAlloc);
             	pProp->data = data;
@@ -440,7 +440,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
 	}
         else if (mode == PropModeAppend)
         {
-	    data = (pointer)xrealloc(pProp->data,
+	    data = (void *)xrealloc(pProp->data,
 				     sizeInBytes * (len + pProp->size));
 	    if (!data)
 		return(BadAlloc);
@@ -452,7 +452,7 @@ ChangeWindowProperty(WindowPtr pWin, Atom property, Atom type, int format,
 	}
         else if (mode == PropModePrepend)
         {
-            data = (pointer)xalloc(sizeInBytes * (len + pProp->size));
+            data = (void *)xalloc(sizeInBytes * (len + pProp->size));
 	    if (!data)
 		return(BadAlloc);
 	    memmove(&((char *)data)[totalSize], (char *)pProp->data, 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -125,9 +125,9 @@ void nxagentCreateGlyphSet(GlyphSetPtr glyphSet);
 void nxagentReferenceGlyphSet(GlyphSetPtr glyphSet);
 void nxagentFreeGlyphs(GlyphSetPtr glyphSet, CARD32 *gids, int nglyph);
 void nxagentFreeGlyphSet(GlyphSetPtr glyphSet);
-void nxagentSetPictureTransform(PicturePtr pPicture, pointer transform);
+void nxagentSetPictureTransform(PicturePtr pPicture, void * transform);
 void nxagentSetPictureFilter(PicturePtr pPicture, char *filter, int name_size,
-                                 pointer params, int nparams);
+                                 void * params, int nparams);
 void nxagentTrapezoids(CARD8 op, PicturePtr pSrc, PicturePtr pDst, PictFormatPtr maskFormat,
                            INT16 xSrc, INT16 ySrc, int ntrap, xTrapezoid *traps);
 
@@ -334,8 +334,8 @@ typedef struct _RenderClient {
 
 static void
 RenderClientCallback (CallbackListPtr	*list,
-		      pointer		closure,
-		      pointer		data)
+		      void *		closure,
+		      void *		data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;
@@ -767,7 +767,7 @@ ProcRenderCreatePicture (ClientPtr client)
 	return error;
     nxagentCreatePicture(pPicture, stuff -> mask);
 
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -1341,7 +1341,7 @@ ProcRenderCreateGlyphSet (ClientPtr client)
     glyphSet = AllocateGlyphSet (f, format);
     if (!glyphSet)
 	return BadAlloc;
-    if (!AddResource (stuff->gsid, GlyphSetType, (pointer)glyphSet))
+    if (!AddResource (stuff->gsid, GlyphSetType, (void *)glyphSet))
 	return BadAlloc;
 
     nxagentCreateGlyphSet(glyphSet);
@@ -1372,7 +1372,7 @@ ProcRenderReferenceGlyphSet (ClientPtr client)
 
     nxagentReferenceGlyphSet(glyphSet);
 
-    if (!AddResource (stuff->gsid, GlyphSetType, (pointer)glyphSet))
+    if (!AddResource (stuff->gsid, GlyphSetType, (void *)glyphSet))
 	return BadAlloc;
     return client->noClientException;
 }
@@ -1953,7 +1953,7 @@ ProcRenderCreateCursor (ClientPtr client)
     {
 	(*pScreen->GetImage) (pSrc->pDrawable,
 			      0, 0, width, height, ZPixmap,
-			      0xffffffff, (pointer) argbbits);
+			      0xffffffff, (void *) argbbits);
     }
     else
     {
@@ -1993,7 +1993,7 @@ ProcRenderCreateCursor (ClientPtr client)
 			  0, 0, 0, 0, 0, 0, width, height);
 	(*pScreen->GetImage) (pPicture->pDrawable,
 			      0, 0, width, height, ZPixmap,
-			      0xffffffff, (pointer) argbbits);
+			      0xffffffff, (void *) argbbits);
 	FreePicture (pPicture, 0);
     }
     /*
@@ -2120,7 +2120,7 @@ ProcRenderCreateCursor (ClientPtr client)
 
     nxagentRenderRealizeCursor(pScreen, pCursor);
 
-    if (AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
 	return (client->noClientException);
     return BadAlloc;
 }
@@ -2324,7 +2324,7 @@ ProcRenderCreateAnimCursor (ClientPtr client)
       pCursor -> devPriv[i] = NULL;
     }
 
-    if (AddResource (stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (AddResource (stuff->cid, RT_CURSOR, (void *)pCursor))
 	return client->noClientException;
     return BadAlloc;
 }
@@ -2370,7 +2370,7 @@ static int ProcRenderCreateSolidFill(ClientPtr client)
     nxagentRenderCreateSolidFill(pPicture, &stuff -> color);
 
     /* AGENT SERVER */
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -2407,7 +2407,7 @@ static int ProcRenderCreateLinearGradient (ClientPtr client)
                                           stuff->nStops, stops, colors);
 
     /* AGENT SERVER */
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -2445,7 +2445,7 @@ static int ProcRenderCreateRadialGradient (ClientPtr client)
                                                   stuff->nStops, stops, colors);
 
     /* AGENT SERVER */
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -2481,7 +2481,7 @@ static int ProcRenderCreateConicalGradient (ClientPtr client)
                                                colors);
 
     /* AGENT SERVER */
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXresource.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXresource.c
@@ -170,7 +170,7 @@ typedef struct _Resource {
     struct _Resource	*next;
     XID			id;
     RESTYPE		type;
-    pointer		value;
+    void *		value;
 } ResourceRec, *ResourcePtr;
 #define NullResource ((ResourcePtr)NULL)
 
@@ -459,7 +459,7 @@ FakeClientID(register int client)
 
 #ifdef NXAGENT_SERVER
 
-int nxagentFindClientResource(int client, RESTYPE type, pointer value)
+int nxagentFindClientResource(int client, RESTYPE type, void * value)
 {
   ResourcePtr pResource;
   ResourcePtr *resources;
@@ -488,7 +488,7 @@ int nxagentFindClientResource(int client, RESTYPE type, pointer value)
   return 0;
 }
 
-int nxagentSwitchResourceType(int client, RESTYPE type, pointer value)
+int nxagentSwitchResourceType(int client, RESTYPE type, void * value)
 {
   ResourcePtr pResource;
   ResourcePtr *resources;
@@ -552,7 +552,7 @@ int nxagentSwitchResourceType(int client, RESTYPE type, pointer value)
 #endif
 
 Bool
-AddResource(XID id, RESTYPE type, pointer value)
+AddResource(XID id, RESTYPE type, void * value)
 {
     int client;
     register ClientResourceRec *rrec;
@@ -753,7 +753,7 @@ FreeResourceByType(XID id, RESTYPE type, Bool skipFree)
  */
 
 Bool
-ChangeResourceValue (XID id, RESTYPE rtype, pointer value)
+ChangeResourceValue (XID id, RESTYPE rtype, void * value)
 {
     int    cid;
     register    ResourcePtr res;
@@ -785,7 +785,7 @@ FindClientResourcesByType(
     ClientPtr client,
     RESTYPE type,
     FindResType func,
-    pointer cdata
+    void * cdata
 ){
     register ResourcePtr *resources;
     register ResourcePtr this, next;
@@ -870,7 +870,7 @@ void
 FindAllClientResources(
     ClientPtr client,
     FindAllRes func,
-    pointer cdata
+    void * cdata
 ){
     register ResourcePtr *resources;
     register ResourcePtr this, next;
@@ -950,12 +950,12 @@ RestartLoop:
 }
 
 
-pointer
+void *
 LookupClientResourceComplex(
     ClientPtr client,
     RESTYPE type,
     FindComplexResType func,
-    pointer cdata
+    void * cdata
 ){
     ResourcePtr *resources;
     ResourcePtr this;
@@ -1126,12 +1126,12 @@ LegalNewID(XID id, register ClientPtr client)
  * else NULL is returned.
  */
 
-pointer
+void *
 SecurityLookupIDByType(ClientPtr client, XID id, RESTYPE rtype, Mask mode)
 {
     int    cid;
     register    ResourcePtr res;
-    pointer retval = NULL;
+    void * retval = NULL;
 
     assert(client == NullClient ||
      (client->index <= currentMaxClients && clients[client->index] == client));
@@ -1155,12 +1155,12 @@ SecurityLookupIDByType(ClientPtr client, XID id, RESTYPE rtype, Mask mode)
 }
 
 
-pointer
+void *
 SecurityLookupIDByClass(ClientPtr client, XID id, RESTYPE classes, Mask mode)
 {
     int    cid;
     register ResourcePtr res = NULL;
-    pointer retval = NULL;
+    void * retval = NULL;
 
     assert(client == NullClient ||
      (client->index <= currentMaxClients && clients[client->index] == client));
@@ -1187,14 +1187,14 @@ SecurityLookupIDByClass(ClientPtr client, XID id, RESTYPE classes, Mask mode)
  * macros because of compatibility with loadable servers.
  */
 
-pointer
+void *
 LookupIDByType(XID id, RESTYPE rtype)
 {
     return SecurityLookupIDByType(NullClient, id, rtype,
 				  SecurityUnknownAccess);
 }
 
-pointer
+void *
 LookupIDByClass(XID id, RESTYPE classes)
 {
     return SecurityLookupIDByClass(NullClient, id, classes,
@@ -1206,7 +1206,7 @@ LookupIDByClass(XID id, RESTYPE classes)
 /*
  *  LookupIDByType returns the object with the given id and type, else NULL.
  */ 
-pointer
+void *
 LookupIDByType(XID id, RESTYPE rtype)
 {
     int    cid;
@@ -1221,14 +1221,14 @@ LookupIDByType(XID id, RESTYPE rtype)
 	    if ((res->id == id) && (res->type == rtype))
 		return res->value;
     }
-    return (pointer)NULL;
+    return (void *)NULL;
 }
 
 /*
  *  LookupIDByClass returns the object with the given id and any one of the
  *  given classes, else NULL.
  */ 
-pointer
+void *
 LookupIDByClass(XID id, RESTYPE classes)
 {
     int    cid;
@@ -1243,7 +1243,7 @@ LookupIDByClass(XID id, RESTYPE classes)
 	    if ((res->id == id) && (res->type & classes))
 		return res->value;
     }
-    return (pointer)NULL;
+    return (void *)NULL;
 }
 
 #endif /* XCSECURITY */

--- a/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
@@ -128,7 +128,7 @@ static void miShmPutImage(XSHM_PUT_IMAGE_ARGS);
 static void fbShmPutImage(XSHM_PUT_IMAGE_ARGS);
 static PixmapPtr fbShmCreatePixmap(XSHM_CREATE_PIXMAP_ARGS);
 static int ShmDetachSegment(
-    pointer		/* value */,
+    void *		/* value */,
     XID			/* shmseg */
     );
 static void ShmResetProc(
@@ -361,7 +361,7 @@ ShmDestroyPixmap (PixmapPtr pPixmap)
 #else
 	char	*base = (char *) pPixmap->devPrivate.ptr;
 	
-	if (base != (pointer) (pPixmap + 1))
+	if (base != (void *) (pPixmap + 1))
 	{
 	    for (shmdesc = Shmsegs; shmdesc; shmdesc = shmdesc->next)
 	    {
@@ -373,7 +373,7 @@ ShmDestroyPixmap (PixmapPtr pPixmap)
 	    shmdesc = 0;
 #endif
 	if (shmdesc)
-	    ShmDetachSegment ((pointer) shmdesc, pPixmap->drawable.id);
+	    ShmDetachSegment ((void *) shmdesc, pPixmap->drawable.id);
     }
     
     pScreen->DestroyPixmap = destroyPixmap[pScreen->myNum];
@@ -520,7 +520,7 @@ ProcShmAttach(client)
 	shmdesc->next = Shmsegs;
 	Shmsegs = shmdesc;
     }
-    if (!AddResource(stuff->shmseg, ShmSegType, (pointer)shmdesc))
+    if (!AddResource(stuff->shmseg, ShmSegType, (void *)shmdesc))
 	return BadAlloc;
     return(client->noClientException);
 }
@@ -528,7 +528,7 @@ ProcShmAttach(client)
 /*ARGSUSED*/
 static int
 ShmDetachSegment(value, shmseg)
-    pointer value; /* must conform to DeleteType */
+    void * value; /* must conform to DeleteType */
     XID shmseg;
 {
     ShmDescPtr shmdesc = (ShmDescPtr)value;
@@ -618,7 +618,7 @@ fbShmPutImage(dst, pGC, depth, format, w, h, sx, sy, sw, sh, dx, dy, data)
 	PixmapPtr pPixmap;
 
 	pPixmap = GetScratchPixmapHeader(dst->pScreen, w, h, depth,
-		BitsPerPixel(depth), PixmapBytePad(w, depth), (pointer)data);
+		BitsPerPixel(depth), PixmapBytePad(w, depth), (void *)data);
 	if (!pPixmap)
 	    return;
 	if (format == XYBitmap)
@@ -898,12 +898,12 @@ CreatePmap:
 
 	if (pMap) {
 #ifdef PIXPRIV
-            pMap->devPrivates[shmPixmapPrivate].ptr = (pointer) shmdesc;
+            pMap->devPrivates[shmPixmapPrivate].ptr = (void *) shmdesc;
 #endif
             shmdesc->refcnt++;
 	    pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	    pMap->drawable.id = newPix->info[j].id;
-	    if (!AddResource(newPix->info[j].id, RT_PIXMAP, (pointer)pMap)) {
+	    if (!AddResource(newPix->info[j].id, RT_PIXMAP, (void *)pMap)) {
 		(*pScreen->DestroyPixmap)(pMap);
 		result = BadAlloc;
 		break;
@@ -1173,7 +1173,7 @@ fbShmCreatePixmap (pScreen, width, height, depth, addr)
     #endif
 
     if (!(*pScreen->ModifyPixmapHeader)(pPixmap, width, height, depth,
-	    BitsPerPixel(depth), PixmapBytePad(width, depth), (pointer)addr)) 
+	    BitsPerPixel(depth), PixmapBytePad(width, depth), (void *)addr)) 
     {
       #ifdef WARNING
       fprintf(stderr,"fbShmCreatePixmap: Return Null Pixmap.\n");
@@ -1251,12 +1251,12 @@ CreatePmap:
     if (pMap)
     {
 #ifdef PIXPRIV
-	pMap->devPrivates[shmPixmapPrivate].ptr = (pointer) shmdesc;
+	pMap->devPrivates[shmPixmapPrivate].ptr = (void *) shmdesc;
 #endif
 	shmdesc->refcnt++;
 	pMap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	pMap->drawable.id = stuff->pid;
-	if (AddResource(stuff->pid, RT_PIXMAP, (pointer)pMap))
+	if (AddResource(stuff->pid, RT_PIXMAP, (void *)pMap))
 	{
 	    return(client->noClientException);
 	}

--- a/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
@@ -249,7 +249,7 @@ PrintWindowTree()
 #endif
 
 int
-TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, pointer data)
+TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, void * data)
 {
     register int result;
     register WindowPtr pChild;
@@ -284,7 +284,7 @@ TraverseTree(register WindowPtr pWin, VisitWindowProcPtr func, pointer data)
  *****/
 
 int
-WalkTree(ScreenPtr pScreen, VisitWindowProcPtr func, pointer data)
+WalkTree(ScreenPtr pScreen, VisitWindowProcPtr func, void * data)
 {
     return(TraverseTree(WindowTable[pScreen->myNum], func, data));
 }
@@ -310,7 +310,7 @@ SetWindowToDefaults(register WindowPtr pWin)
 
     pWin->backingStore = NotUseful;
     pWin->DIXsaveUnder = FALSE;
-    pWin->backStorage = (pointer) NULL;
+    pWin->backStorage = (void *) NULL;
 
     pWin->mapped = FALSE;	    /* off */
     pWin->realized = FALSE;	/* off */
@@ -430,11 +430,11 @@ AllocateWindow(ScreenPtr pScreen)
 	{
 	    if ( (size = *sizes) )
 	    {
-		ppriv->ptr = (pointer)ptr;
+		ppriv->ptr = (void *)ptr;
 		ptr += size;
 	    }
 	    else
-		ppriv->ptr = (pointer)NULL;
+		ppriv->ptr = (void *)NULL;
 	}
     }
     return pWin;
@@ -528,7 +528,7 @@ CreateRootWindow(ScreenPtr pScreen)
     pWin->border.pixel = pScreen->blackPixel;
     pWin->borderWidth = 0;
 
-    if (!AddResource(pWin->drawable.id, RT_WINDOW, (pointer)pWin))
+    if (!AddResource(pWin->drawable.id, RT_WINDOW, (void *)pWin))
 	return FALSE;
 
     if (disableBackingStore)
@@ -1065,7 +1065,7 @@ CrushTree(WindowPtr pWin)
  *****/
 
 int
-DeleteWindow(pointer value, XID wid)
+DeleteWindow(void * value, XID wid)
  {
     register WindowPtr pParent;
     register WindowPtr pWin = (WindowPtr)value;
@@ -2798,7 +2798,7 @@ CirculateWindow(WindowPtr pParent, int direction, ClientPtr client)
 static int
 CompareWIDs(
     WindowPtr pWin,
-    pointer   value) /* must conform to VisitWindowProcPtr */
+    void      *value) /* must conform to VisitWindowProcPtr */
 {
     Window *wid = (Window *)value;
 
@@ -2823,7 +2823,7 @@ ReparentWindow(register WindowPtr pWin, register WindowPtr pParent,
     register ScreenPtr pScreen;
 
     pScreen = pWin->drawable.pScreen;
-    if (TraverseTree(pWin, CompareWIDs, (pointer)&pParent->drawable.id) == WT_STOPWALKING)
+    if (TraverseTree(pWin, CompareWIDs, (void *)&pParent->drawable.id) == WT_STOPWALKING)
 	return(BadMatch);		
     if (!MakeWindowOptional(pWin))
 	return(BadAlloc);
@@ -3791,7 +3791,7 @@ TileScreenSaver(int i, int kind)
 	if (cursor)
 	{
 	    cursorID = FakeClientID(0);
-	    if (AddResource (cursorID, RT_CURSOR, (pointer) cursor))
+	    if (AddResource (cursorID, RT_CURSOR, (void *) cursor))
 	    {
 		attributes[attri] = cursorID;
 		mask |= CWCursor;
@@ -3822,7 +3822,7 @@ TileScreenSaver(int i, int kind)
 	return FALSE;
 
     if (!AddResource(pWin->drawable.id, RT_WINDOW,
-		     (pointer)savedScreenInfo[i].pWindow))
+		     (void *)savedScreenInfo[i].pWindow))
 	return FALSE;
 
     if (mask & CWBackPixmap)

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
@@ -534,7 +534,7 @@ RegionPtr nxagentPixmapToRegion(PixmapPtr pPixmap)
 }
 
 Bool nxagentModifyPixmapHeader(PixmapPtr pPixmap, int width, int height, int depth,
-                                   int bitsPerPixel, int devKind, pointer pPixData)
+                                   int bitsPerPixel, int devKind, void * pPixData)
 {
   PixmapPtr pVirtualPixmap;
 
@@ -732,7 +732,7 @@ PixmapPtr nxagentPixmapPtr(Pixmap pixmap)
  * Reconnection stuff.
  */
 
-int nxagentDestroyNewPixmapResourceType(pointer p, XID id)
+int nxagentDestroyNewPixmapResourceType(void * p, XID id)
 {
   /*
    * Address of the destructor is set in Init.c.

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixmaps.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixmaps.h
@@ -115,7 +115,7 @@ Bool nxagentDestroyPixmap(PixmapPtr pPixmap);
 RegionPtr nxagentPixmapToRegion(PixmapPtr pPixmap);
 
 Bool nxagentModifyPixmapHeader(PixmapPtr pPixmap, int width, int height, int depth,
-                                   int bitsPerPixel, int devKind, pointer pPixData);
+                                   int bitsPerPixel, int devKind, void * pPixData);
 
 RegionPtr nxagentCreateRegion(DrawablePtr pDrawable, GCPtr pGC, int x, int y,
                                   int width, int height);
@@ -125,7 +125,7 @@ Bool nxagentReconnectAllPixmaps(void *p0);
 void nxagentDisconnectPixmap(void *p0, XID x1, void* p2);
 Bool nxagentDisconnectAllPixmaps(void);
 
-int nxagentDestroyNewPixmapResourceType(pointer p, XID id);
+int nxagentDestroyNewPixmapResourceType(void * p, XID id);
 
 void nxagentSynchronizeShmPixmap(DrawablePtr pDrawable, int xPict, int yPict,
                                      int wPict, int hPict);

--- a/nx-X11/programs/Xserver/hw/nxagent/Render.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.c
@@ -188,10 +188,10 @@ void nxagentFreeGlyphs(GlyphSetPtr glyphSet, CARD32 *gids, int nglyph);
 
 void nxagentFreeGlyphSet(GlyphSetPtr glyphSet);
 
-void nxagentSetPictureTransform(PicturePtr pPicture, pointer transform);
+void nxagentSetPictureTransform(PicturePtr pPicture, void * transform);
 
 void nxagentSetPictureFilter(PicturePtr pPicture, char *filter, int name_size,
-                                 pointer params, int nparams);
+                                 void * params, int nparams);
 
 Bool nxagentReconnectAllGlyphSet(void *p);
 
@@ -2337,7 +2337,7 @@ void nxagentFreeGlyphs(GlyphSetPtr glyphSet, CARD32 *gids, int nglyph)
   }
 }
 
-void nxagentSetPictureTransform(PicturePtr pPicture, pointer transform)
+void nxagentSetPictureTransform(PicturePtr pPicture, void * transform)
 {
   #ifdef TEST
   fprintf(stderr, "nxagentSetPictureTransform: Going to set transform [%p] to picture at [%p].\n",
@@ -2358,7 +2358,7 @@ FIXME: Is this useful or just a waste of bandwidth?
 }
 
 void nxagentSetPictureFilter(PicturePtr pPicture, char *filter, int name_size,
-                                 pointer params, int nparams)
+                                 void * params, int nparams)
 {
   char *szFilter = Xmalloc(name_size + 1);
 
@@ -2561,7 +2561,7 @@ Bool nxagentReconnectAllGlyphSet(void *p)
   return success;
 }
 
-void nxagentReconnectPicture(pointer p0, XID x1, void *p2)
+void nxagentReconnectPicture(void * p0, XID x1, void *p2)
 {
   PicturePtr pPicture = (PicturePtr) p0;
   Bool *pBool = (Bool *) p2;
@@ -2737,7 +2737,7 @@ Bool nxagentReconnectAllPicture(void *p)
   return True;
 }
 
-void nxagentDisconnectPicture(pointer p0, XID x1, void* p2)
+void nxagentDisconnectPicture(void * p0, XID x1, void* p2)
 {
   PicturePtr pPicture = (PicturePtr) p0;
   Bool *pBool = (Bool *) p2;

--- a/nx-X11/programs/Xserver/hw/nxagent/Render.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.h
@@ -100,8 +100,8 @@ int nxagentRenderRealizeCursor(ScreenPtr pScreen, CursorPtr pCursor);
 void nxagentAddGlyphs(GlyphSetPtr glyphSet, Glyph *gids, xGlyphInfo *gi,
                                   int nglyphs, CARD8 *images, int sizeImages);
 
-void nxagentReconnectPicture(pointer p0, XID x1, void *p2);
-void nxagentDisconnectPicture(pointer p0, XID x1, void* p2);
+void nxagentReconnectPicture(void * p0, XID x1, void *p2);
+void nxagentDisconnectPicture(void * p0, XID x1, void* p2);
 
 void nxagentReconnectGlyphSet(void* p0, XID x1, void *p2);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -444,7 +444,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     Atom        property, type;
     int         format, mode;
     unsigned long nUnits;
-    pointer     value;
+    void        *value;
 {
   char *propertyS, *typeS;
   Atom propertyX, typeX;

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.h
@@ -63,7 +63,7 @@ void nxagentRootlessRestack(unsigned long *toplevel, unsigned int ntoplevel);
 int nxagentExportAllProperty(WindowPtr pWin);
 
 int nxagentExportProperty(WindowPtr pWin, Atom property, Atom type, int format,
-                              int mode, unsigned long nUnits, pointer value);
+                              int mode, unsigned long nUnits, void * value);
 
 #define MAX_RETRIEVED_PROPERTY_SIZE 256 * 1024
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -211,7 +211,7 @@ RegionRec nxagentShadowUpdateRegion;
  * but we need it here.
  */
 
-int TellChanged(WindowPtr pWin, pointer value);
+int TellChanged(WindowPtr pWin, void * value);
 
 int nxagentBitsPerPixel(int depth)
 {
@@ -664,7 +664,7 @@ void nxagentInitViewportFrame(ScreenPtr pScreen, WindowPtr pRootWin)
                                                       pRootWin -> drawable.depth,
                                                           serverClient, visual, &error);
 
-  AddResource(xid, RT_WINDOW, (pointer) nxagentViewportFrameLeft);
+  AddResource(xid, RT_WINDOW, (void *) nxagentViewportFrameLeft);
 
   if (error != Success)
   {
@@ -689,7 +689,7 @@ void nxagentInitViewportFrame(ScreenPtr pScreen, WindowPtr pRootWin)
                                                                serverClient, visual,
                                                                    &error);
 
-  AddResource(xid, RT_WINDOW, (pointer) nxagentViewportFrameRight);
+  AddResource(xid, RT_WINDOW, (void *) nxagentViewportFrameRight);
 
   if (error != Success)
   {
@@ -714,7 +714,7 @@ void nxagentInitViewportFrame(ScreenPtr pScreen, WindowPtr pRootWin)
                                                                serverClient, visual,
                                                                    &error);
 
-  AddResource(xid, RT_WINDOW, (pointer) nxagentViewportFrameAbove);
+  AddResource(xid, RT_WINDOW, (void *) nxagentViewportFrameAbove);
 
   if (error != Success)
   {
@@ -739,7 +739,7 @@ void nxagentInitViewportFrame(ScreenPtr pScreen, WindowPtr pRootWin)
                                                                pRootWin -> drawable.depth,
                                                                    serverClient, visual, &error);
 
-  AddResource(xid, RT_WINDOW, (pointer) nxagentViewportFrameBelow);
+  AddResource(xid, RT_WINDOW, (void *) nxagentViewportFrameBelow);
 
   if (error != Success)
   {
@@ -835,7 +835,7 @@ Bool nxagentOpenScreen(int index, ScreenPtr pScreen,
   VisualID defaultVisual;
   int rootDepth;
 
-  pointer pFrameBufferBits;
+  void * pFrameBufferBits;
   int bitsPerPixel;
   int sizeInBytes;
 
@@ -2423,7 +2423,7 @@ FIXME: We should try to restore the previously
   nxagentMoveViewport(pScreen, 0, 0);
 
   /*
-   * Update pointer bounds.
+   * Update void * bounds.
    */
 
   ScreenRestructured(pScreen);
@@ -2773,11 +2773,11 @@ int nxagentShadowInit(ScreenPtr pScreen, WindowPtr pWin)
 
   accessPixmapID = FakeClientID(serverClient -> index);
 
-  AddResource(accessPixmapID, RT_PIXMAP, (pointer)nxagentShadowPixmapPtr);
+  AddResource(accessPixmapID, RT_PIXMAP, (void *)nxagentShadowPixmapPtr);
 
   accessWindowID = FakeClientID(serverClient -> index);
 
-  AddResource(accessWindowID, RT_WINDOW, (pointer)nxagentShadowWindowPtr);
+  AddResource(accessWindowID, RT_WINDOW, (void *)nxagentShadowWindowPtr);
 
   nxagentResizeScreen(pScreen, nxagentShadowWidth, nxagentShadowHeight, pScreen -> mmWidth, pScreen -> mmHeight);
 
@@ -2847,7 +2847,7 @@ int nxagentShadowCreateMainWindow(ScreenPtr pScreen, WindowPtr pWin, int width, 
 
   if (nxagentShadowPixmapPtr)
   {
-    ChangeResourceValue(accessPixmapID, RT_PIXMAP, (pointer) nxagentShadowPixmapPtr);
+    ChangeResourceValue(accessPixmapID, RT_PIXMAP, (void *) nxagentShadowPixmapPtr);
     nxagentShadowPixmapPtr -> drawable.id = accessPixmapID;
 
     #ifdef TEST
@@ -2933,7 +2933,7 @@ int nxagentShadowCreateMainWindow(ScreenPtr pScreen, WindowPtr pWin, int width, 
 
     #endif
 
-    ChangeResourceValue(accessWindowID, RT_WINDOW, (pointer) nxagentShadowWindowPtr);
+    ChangeResourceValue(accessWindowID, RT_WINDOW, (void *) nxagentShadowWindowPtr);
   }
   else
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -162,19 +162,19 @@ static Bool nxagentSomeWindowsAreMapped(void);
 
 static void nxagentFrameBufferPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what);
 
-static void nxagentTraverseWindow(WindowPtr, void(*)(pointer, XID, pointer), pointer);
+static void nxagentTraverseWindow(WindowPtr, void(*)(void *, XID, void *), void *);
 
-static void nxagentDisconnectWindow(pointer, XID, pointer);
+static void nxagentDisconnectWindow(void *, XID, void *);
 
-static Bool nxagentLoopOverWindows(void(*)(pointer, XID, pointer));
+static Bool nxagentLoopOverWindows(void(*)(void *, XID, void *));
 
-static void nxagentReconfigureWindowCursor(pointer, XID, pointer);
+static void nxagentReconfigureWindowCursor(void *, XID, void *);
 
-static void nxagentReconnectWindow(pointer, XID, pointer);
+static void nxagentReconnectWindow(void *, XID, void *);
 
-static void nxagentReconfigureWindow(pointer, XID, pointer);
+static void nxagentReconfigureWindow(void *, XID, void *);
 
-static int nxagentForceExposure(WindowPtr pWin, pointer ptr);
+static int nxagentForceExposure(WindowPtr pWin, void * ptr);
 
 /* by dimbor */
 typedef struct
@@ -218,7 +218,7 @@ WindowPtr nxagentGetWindowFromID(Window id)
   return NULL;
 }
 
-static int nxagentFindWindowMatch(WindowPtr pWin, pointer ptr)
+static int nxagentFindWindowMatch(WindowPtr pWin, void * ptr)
 {
   WindowMatchRec *match = (WindowMatchRec *) ptr;
 
@@ -245,7 +245,7 @@ WindowPtr nxagentWindowPtr(Window window)
 
   for (i = 0; i < nxagentNumScreens; i++)
   {
-    WalkTree(screenInfo.screens[i], nxagentFindWindowMatch, (pointer) &match);
+    WalkTree(screenInfo.screens[i], nxagentFindWindowMatch, (void *) &match);
 
     if (match.pWin) break;
   }
@@ -2437,7 +2437,7 @@ void nxagentShapeWindow(WindowPtr pWin)
 }
 #endif /* SHAPE */
 
-static int nxagentForceExposure(WindowPtr pWin, pointer ptr)
+static int nxagentForceExposure(WindowPtr pWin, void * ptr)
 {
   RegionPtr exposedRgn;
   BoxRec Box;
@@ -2623,12 +2623,12 @@ Bool nxagentDisconnectAllWindows(void)
 }
 
 /*
- * FIXME: We are giving up reconnecting those pointer
+ * FIXME: We are giving up reconnecting those void *
  * that are not resource, and we are just disconnecting them.
  * perhaps we could do better and reconnect them.
  */
 
-void nxagentDisconnectWindow(pointer p0, XID x1, pointer p2)
+void nxagentDisconnectWindow(void * p0, XID x1, void * p2)
 {
   WindowPtr pWin = (WindowPtr)p0;
   Bool*     pBool = (Bool*)p2;
@@ -2828,8 +2828,8 @@ Bool nxagentSetWindowCursors(void *p0)
 
 static void nxagentTraverseWindow(
   WindowPtr pWin,
-  void (*pF)(pointer, XID, pointer),
-  pointer p)
+  void (*pF)(void *, XID, void *),
+  void * p)
 {
   pF(pWin, 0, p);
 
@@ -2844,7 +2844,7 @@ static void nxagentTraverseWindow(
   }
 }
 
-static Bool nxagentLoopOverWindows(void (*pF)(pointer, XID, pointer))
+static Bool nxagentLoopOverWindows(void (*pF)(void *, XID, void *))
 {
   int i;
   Bool windowSuccess = True;
@@ -2859,7 +2859,7 @@ static Bool nxagentLoopOverWindows(void (*pF)(pointer, XID, pointer))
   return windowSuccess;
 }
 
-static void nxagentReconnectWindow(pointer param0, XID param1, pointer data_buffer)
+static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer)
 {
   WindowPtr pWin = (WindowPtr)param0;
   Bool *pBool = (Bool*)data_buffer;
@@ -3113,7 +3113,7 @@ FIXME: Do we need to set save unders attribute here?
   }
 }
 
-static void nxagentReconfigureWindowCursor(pointer param0, XID param1, pointer data_buffer)
+static void nxagentReconfigureWindowCursor(void * param0, XID param1, void * data_buffer)
 {
   WindowPtr pWin = (WindowPtr)param0;
   Bool *pBool = (Bool*)data_buffer;
@@ -3164,7 +3164,7 @@ static void nxagentReconfigureWindowCursor(pointer param0, XID param1, pointer d
   }
 }
 
-static void nxagentReconfigureWindow(pointer param0, XID param1, pointer data_buffer)
+static void nxagentReconfigureWindow(void * param0, XID param1, void * data_buffer)
 {
   WindowPtr pWin = (WindowPtr)param0;
   unsigned long mask = 0;
@@ -3732,7 +3732,7 @@ StaticResizedWindowStruct *nxagentFindStaticResizedWindow(unsigned long sequence
   return ret;
 }
 
-void nxagentEmptyBackingStoreRegion(pointer param0, XID param1, pointer data_buffer)
+void nxagentEmptyBackingStoreRegion(void * param0, XID param1, void * data_buffer)
 {
   WindowPtr pWin = (WindowPtr) param0;
 

--- a/nx-X11/programs/Xserver/hw/xfree86/os-support/xf86_ansic.h
+++ b/nx-X11/programs/Xserver/hw/xfree86/os-support/xf86_ansic.h
@@ -268,7 +268,7 @@ extern int xf86vsnprintf(char*,xf86size_t,const char*,va_list);
 extern int xf86open(const char*, int,...);
 extern int xf86close(int);
 extern long xf86lseek(int, long, int);
-extern int xf86ioctl(int, unsigned long, pointer);
+extern int xf86ioctl(int, unsigned long, void *);
 extern xf86ssize_t xf86read(int, void *, xf86size_t);
 extern xf86ssize_t xf86write(int, const void *, xf86size_t);
 extern void* xf86mmap(void*, xf86size_t, int, int, int, xf86size_t /* off_t */);
@@ -306,7 +306,7 @@ unsigned int xf86sleep(unsigned int seconds);
 extern int xf86shmget(xf86key_t key, int size, int xf86shmflg);
 extern char * xf86shmat(int id, char *addr, int xf86shmflg);
 extern int xf86shmdt(char *addr);
-extern int xf86shmctl(int id, int xf86cmd, pointer buf);
+extern int xf86shmctl(int id, int xf86cmd, void * buf);
 
 extern int xf86setjmp(xf86jmp_buf env);
 extern int xf86setjmp0(xf86jmp_buf env);

--- a/nx-X11/programs/Xserver/include/closestr.h
+++ b/nx-X11/programs/Xserver/include/closestr.h
@@ -69,7 +69,7 @@ typedef struct _LFWIstate {
     int		current_fpe;
     int		max_names;
     Bool	list_started;
-    pointer	private;
+    void *	private;
 } LFWIstateRec, *LFWIstatePtr;
 
 typedef struct _LFWIclosure {

--- a/nx-X11/programs/Xserver/include/colormap.h
+++ b/nx-X11/programs/Xserver/include/colormap.h
@@ -87,16 +87,16 @@ extern int CreateColormap(
     int /*client*/);
 
 extern int FreeColormap(
-    pointer /*pmap*/,
+    void * /*pmap*/,
     XID /*mid*/);
 
 extern int TellLostMap(
     WindowPtr /*pwin*/,
-    pointer /* Colormap *pmid */);
+    void * /* Colormap *pmid */);
 
 extern int TellGainedMap(
     WindowPtr /*pwin*/,
-    pointer /* Colormap *pmid */);
+    void * /* Colormap *pmid */);
 
 extern int CopyColormapAndFree(
     Colormap /*mid*/,
@@ -140,7 +140,7 @@ extern int QueryColors(
     xrgb* /*prgbList*/);
 
 extern int FreeClientPixels(
-    pointer /*pcr*/,
+    void * /*pcr*/,
     XID /*fakeid*/);
 
 extern int AllocColorCells(

--- a/nx-X11/programs/Xserver/include/colormapst.h
+++ b/nx-X11/programs/Xserver/include/colormapst.h
@@ -113,7 +113,7 @@ typedef struct _ColormapRec
     Entry	*red;
     Entry 	*green;
     Entry	*blue;
-    pointer	devPriv;
+    void *	devPriv;
     DevUnion	*devPrivates;	/* dynamic devPrivates added after devPriv
 				   already existed - must keep devPriv */
 } ColormapRec;

--- a/nx-X11/programs/Xserver/include/cursor.h
+++ b/nx-X11/programs/Xserver/include/cursor.h
@@ -68,7 +68,7 @@ typedef struct _CursorMetric *CursorMetricPtr;
 extern CursorPtr rootCursor;
 
 extern int FreeCursor(
-    pointer /*pCurs*/,
+    void * /*pCurs*/,
     XID /*cid*/);
 
 /* Quartz support on Mac OS X pulls in the QuickDraw

--- a/nx-X11/programs/Xserver/include/cursorstr.h
+++ b/nx-X11/programs/Xserver/include/cursorstr.h
@@ -65,7 +65,7 @@ typedef struct _CursorBits {
     Bool emptyMask;				/* all zeros mask */
     unsigned short width, height, xhot, yhot;	/* metrics */
     int refcnt;					/* can be shared */
-    pointer devPriv[MAXSCREENS];		/* set by pScr->RealizeCursor*/
+    void * devPriv[MAXSCREENS];		/* set by pScr->RealizeCursor*/
 #ifdef ARGB_CURSOR
     CARD32 *argb;				/* full-color alpha blended */
 #endif
@@ -76,7 +76,7 @@ typedef struct _Cursor {
     unsigned short foreRed, foreGreen, foreBlue; /* device-independent color */
     unsigned short backRed, backGreen, backBlue; /* device-independent color */
     int refcnt;
-    pointer devPriv[MAXSCREENS];		/* set by pScr->RealizeCursor*/
+    void * devPriv[MAXSCREENS];		/* set by pScr->RealizeCursor*/
 #ifdef XFIXES
     CARD32 serialNumber;
     Atom name;

--- a/nx-X11/programs/Xserver/include/dix.h
+++ b/nx-X11/programs/Xserver/include/dix.h
@@ -330,7 +330,7 @@ extern void InitSelections(void);
 extern void FlushClientCaches(XID /*id*/);
 
 extern int dixDestroyPixmap(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*pid*/);
 
 extern void CloseDownRetainedResources(void);
@@ -338,10 +338,10 @@ extern void CloseDownRetainedResources(void);
 extern void InitClient(
     ClientPtr /*client*/,
     int /*i*/,
-    pointer /*ospriv*/);
+    void * /*ospriv*/);
 
 extern ClientPtr NextAvailableClient(
-    pointer /*ospriv*/);
+    void * /*ospriv*/);
 
 extern void SendErrorToClient(
     ClientPtr /*client*/,
@@ -403,7 +403,7 @@ extern WindowPtr SecurityLookupWindow(
     ClientPtr /*client*/,
     Mask /*access_mode*/);
 
-extern pointer SecurityLookupDrawable(
+extern void * SecurityLookupDrawable(
     XID /*rid*/,
     ClientPtr /*client*/,
     Mask /*access_mode*/);
@@ -412,7 +412,7 @@ extern WindowPtr LookupWindow(
     XID /*rid*/,
     ClientPtr /*client*/);
 
-extern pointer LookupDrawable(
+extern void * LookupDrawable(
     XID /*rid*/,
     ClientPtr /*client*/);
 
@@ -422,7 +422,7 @@ extern WindowPtr LookupWindow(
     XID /*rid*/,
     ClientPtr /*client*/);
 
-extern pointer LookupDrawable(
+extern void * LookupDrawable(
     XID /*rid*/,
     ClientPtr /*client*/);
 
@@ -451,27 +451,27 @@ extern void DeleteWindowFromAnySaveSet(
     WindowPtr /*pWin*/);
 
 extern void BlockHandler(
-    pointer /*pTimeout*/,
-    pointer /*pReadmask*/);
+    void * /*pTimeout*/,
+    void * /*pReadmask*/);
 
 extern void WakeupHandler(
     int /*result*/,
-    pointer /*pReadmask*/);
+    void * /*pReadmask*/);
 
 typedef void (* WakeupHandlerProcPtr)(
-    pointer /* blockData */,
+    void * /* blockData */,
     int /* result */,
-    pointer /* pReadmask */);
+    void * /* pReadmask */);
 
 extern Bool RegisterBlockAndWakeupHandlers(
     BlockHandlerProcPtr /*blockHandler*/,
     WakeupHandlerProcPtr /*wakeupHandler*/,
-    pointer /*blockData*/);
+    void * /*blockData*/);
 
 extern void RemoveBlockAndWakeupHandlers(
     BlockHandlerProcPtr /*blockHandler*/,
     WakeupHandlerProcPtr /*wakeupHandler*/,
-    pointer /*blockData*/);
+    void * /*blockData*/);
 
 extern void InitBlockAndWakeupHandlers(void);
 
@@ -482,19 +482,19 @@ extern void ProcessWorkQueueZombies(void);
 extern Bool QueueWorkProc(
     Bool (* /*function*/)(
         ClientPtr /*clientUnused*/,
-        pointer /*closure*/),
+        void * /*closure*/),
     ClientPtr /*client*/,
-    pointer /*closure*/
+    void * /*closure*/
 );
 
 typedef Bool (* ClientSleepProcPtr)(
     ClientPtr /*client*/,
-    pointer /*closure*/);
+    void * /*closure*/);
 
 extern Bool ClientSleep(
     ClientPtr /*client*/,
     ClientSleepProcPtr /* function */,
-    pointer /*closure*/);
+    void * /*closure*/);
 
 #ifndef ___CLIENTSIGNAL_DEFINED___
 #define ___CLIENTSIGNAL_DEFINED___
@@ -634,7 +634,7 @@ extern void RecalculateDeliverableEvents(
     WindowPtr /* pWin */);
 
 extern int OtherClientGone(
-    pointer /* value */,
+    void * /* value */,
     XID /* id */);
 
 extern void DoFocusEvents(
@@ -723,16 +723,16 @@ typedef struct _CallbackList *CallbackListPtr; /* also in misc.h */
 #endif
 
 typedef void (*CallbackProcPtr) (
-    CallbackListPtr *, pointer, pointer);
+    CallbackListPtr *, void *, void *);
 
 typedef Bool (*AddCallbackProcPtr) (
-    CallbackListPtr *, CallbackProcPtr, pointer);
+    CallbackListPtr *, CallbackProcPtr, void *);
 
 typedef Bool (*DeleteCallbackProcPtr) (
-    CallbackListPtr *, CallbackProcPtr, pointer);
+    CallbackListPtr *, CallbackProcPtr, void *);
 
 typedef void (*CallCallbacksProcPtr) (
-    CallbackListPtr *, pointer);
+    CallbackListPtr *, void *);
 
 typedef void (*DeleteCallbackListProcPtr) (
     CallbackListPtr *);
@@ -751,16 +751,16 @@ extern Bool CreateCallbackList(
 extern Bool AddCallback(
     CallbackListPtr * /*pcbl*/,
     CallbackProcPtr /*callback*/,
-    pointer /*data*/);
+    void * /*data*/);
 
 extern Bool DeleteCallback(
     CallbackListPtr * /*pcbl*/,
     CallbackProcPtr /*callback*/,
-    pointer /*data*/);
+    void * /*data*/);
 
 extern void CallCallbacks(
     CallbackListPtr * /*pcbl*/,
-    pointer /*call_data*/);
+    void * /*call_data*/);
 
 extern void DeleteCallbackList(
     CallbackListPtr * /*pcbl*/);

--- a/nx-X11/programs/Xserver/include/dixfont.h
+++ b/nx-X11/programs/Xserver/include/dixfont.h
@@ -45,9 +45,9 @@ extern void QueueFontWakeup(FontPathElementPtr /*fpe*/);
 
 extern void RemoveFontWakeup(FontPathElementPtr /*fpe*/);
 
-extern void FontWakeup(pointer /*data*/,
+extern void FontWakeup(void * /*data*/,
 		       int /*count*/,
-		       pointer /*LastSelectMask*/);
+		       void * /*LastSelectMask*/);
 
 extern int OpenFont(ClientPtr /*client*/,
 		    XID /*fid*/,
@@ -55,7 +55,7 @@ extern int OpenFont(ClientPtr /*client*/,
 		    unsigned /*lenfname*/,
 		    char * /*pfontname*/);
 
-extern int CloseFont(pointer /*pfont*/,
+extern int CloseFont(void * /*pfont*/,
 		     XID /*fid*/);
 
 typedef struct _xQueryFontReply *xQueryFontReplyPtr;

--- a/nx-X11/programs/Xserver/include/dixgrabs.h
+++ b/nx-X11/programs/Xserver/include/dixgrabs.h
@@ -43,7 +43,7 @@ extern GrabPtr CreateGrab(
 	CursorPtr /* cursor */);
 
 extern int DeletePassiveGrab(
-	pointer /* value */,
+	void * /* value */,
 	XID /* id */);
 
 extern Bool GrabMatchesSecond(

--- a/nx-X11/programs/Xserver/include/dixstruct.h
+++ b/nx-X11/programs/Xserver/include/dixstruct.h
@@ -93,8 +93,8 @@ typedef struct _Window *SaveSetElt;
 typedef struct _Client {
     int         index;
     Mask        clientAsMask;
-    pointer     requestBuffer;
-    pointer     osPrivate;	/* for OS layer, including scheduler */
+    void        *requestBuffer;
+    void        *osPrivate;	/* for OS layer, including scheduler */
     Bool        swapped;
     ReplySwapPtr pSwapReplyFunc;
     XID         errorValue;
@@ -109,7 +109,7 @@ typedef struct _Client {
     GContext    lastGCID;
     SaveSetElt	*saveSet;
     int         numSaved;
-    pointer     screenPrivate[MAXSCREENS];
+    void        *screenPrivate[MAXSCREENS];
     int         (**requestVector) (
 		ClientPtr /* pClient */);
     CARD32	req_len;		/* length of current request */
@@ -136,12 +136,12 @@ typedef struct _Client {
 #ifdef XCSECURITY
     XID		authId;
     unsigned int trustLevel;
-    pointer (* CheckAccess)(
+    void * (* CheckAccess)(
 	    ClientPtr /*pClient*/,
 	    XID /*id*/,
 	    RESTYPE /*classes*/,
 	    Mask /*access_mode*/,
-	    pointer /*resourceval*/);
+	    void * /*resourceval*/);
 #endif
 #ifdef XAPPGROUP
     struct _AppGroupRec*	appgroup;
@@ -187,10 +187,10 @@ typedef struct _WorkQueue {
     struct _WorkQueue *next;
     Bool        (*function) (
 		ClientPtr	/* pClient */,
-		pointer		/* closure */
+		void *		/* closure */
 );
     ClientPtr   client;
-    pointer     closure;
+    void        *closure;
 }           WorkQueueRec;
 
 extern TimeStamp currentTime;
@@ -204,7 +204,7 @@ extern TimeStamp ClientTimeToServerTime(CARD32 /*c*/);
 
 typedef struct _CallbackRec {
   CallbackProcPtr proc;
-  pointer data;
+  void * data;
   Bool deleted;
   struct _CallbackRec *next;
 } CallbackRec, *CallbackPtr;

--- a/nx-X11/programs/Xserver/include/extnsionst.h
+++ b/nx-X11/programs/Xserver/include/extnsionst.h
@@ -67,7 +67,7 @@ typedef struct _ExtensionEntry {
     int errorLast;
     int num_aliases;
     char **aliases;
-    pointer extPrivate;
+    void * extPrivate;
     unsigned short (* MinorOpcode)(	/* called for errors */
 	ClientPtr /* client */);
 #ifdef XCSECURITY

--- a/nx-X11/programs/Xserver/include/gc.h
+++ b/nx-X11/programs/Xserver/include/gc.h
@@ -51,7 +51,13 @@ SOFTWARE.
 #define GC_H 
 
 #include <X11/X.h>	/* for GContext, Mask */
+
+#ifndef _XTYPEDEF_POINTER
+/* Don't let Xdefs.h define 'pointer' */
+#define _XTYPEDEF_POINTER       1
+#endif /* _XTYPEDEF_POINTER */
 #include <X11/Xdefs.h>	/* for Bool */
+
 #include <X11/Xproto.h>
 #include "screenint.h"	/* for ScreenPtr */
 #include "pixmap.h"	/* for DrawablePtr */
@@ -103,7 +109,7 @@ extern int DoChangeGC(
 
 typedef union {
     CARD32 val;
-    pointer ptr;
+    void * ptr;
 } ChangeGCVal, *ChangeGCValPtr;
 
 extern int dixChangeGC(
@@ -125,7 +131,7 @@ extern int CopyGC(
     BITS32 /*mask*/);
 
 extern int FreeGC(
-    pointer /*pGC*/,
+    void * /*pGC*/,
     XID /*gid*/);
 
 extern void SetGCMask(

--- a/nx-X11/programs/Xserver/include/gcstruct.h
+++ b/nx-X11/programs/Xserver/include/gcstruct.h
@@ -85,7 +85,7 @@ typedef struct _GCFuncs {
     void	(* ChangeClip)(
 		GCPtr /*pGC*/,
 		int /*type*/,
-		pointer /*pvalue*/,
+		void * /*pvalue*/,
 		int /*nrects*/);
 
     void	(* DestroyClip)(
@@ -244,7 +244,7 @@ typedef struct _GCOps {
 		int /*y*/,
 		unsigned int /*nglyph*/,
 		CharInfoPtr * /*ppci*/,
-		pointer /*pglyphBase*/);
+		void * /*pglyphBase*/);
 
     void	(* PolyGlyphBlt)(
 		DrawablePtr /*pDrawable*/,
@@ -253,7 +253,7 @@ typedef struct _GCOps {
 		int /*y*/,
 		unsigned int /*nglyph*/,
 		CharInfoPtr * /*ppci*/,
-		pointer /*pglyphBase*/);
+		void * /*pglyphBase*/);
 
     void	(* PushPixels)(
 		GCPtr /*pGC*/,
@@ -309,7 +309,7 @@ typedef struct _GC {
     struct _Font	*font;
     DDXPointRec		clipOrg;
     DDXPointRec		lastWinOrg;	/* position of window last validated */
-    pointer		clientClip;
+    void *		clientClip;
     unsigned long	stateChanges;	/* masked with GC_<kind> */
     unsigned long       serialNumber;
     GCFuncs		*funcs;

--- a/nx-X11/programs/Xserver/include/input.h
+++ b/nx-X11/programs/Xserver/include/input.h
@@ -104,7 +104,7 @@ typedef void (*DeviceUnwrapProc)(
     );
 
 typedef struct _DeviceRec {
-    pointer	devicePrivate;
+    void *	devicePrivate;
     ProcessInputProc processInputProc;	/* current */
     ProcessInputProc realInputProc;	/* deliver */
     ProcessInputProc enqueueInputProc;	/* enqueue */
@@ -255,7 +255,7 @@ extern Bool InitFocusClassDeviceStruct(
 typedef void (*BellProcPtr)(
     int /*percent*/,
     DeviceIntPtr /*device*/,
-    pointer /*ctrl*/,
+    void * /*ctrl*/,
     int);
 
 typedef void (*KbdCtrlProcPtr)(

--- a/nx-X11/programs/Xserver/include/misc.h
+++ b/nx-X11/programs/Xserver/include/misc.h
@@ -81,6 +81,11 @@ extern unsigned long serverGeneration;
 #include <X11/Xfuncproto.h>
 #include <X11/Xmd.h>
 #include <X11/X.h>
+
+#ifndef _XTYPEDEF_POINTER
+/* Don't let Xdefs.h define 'pointer' */
+#define _XTYPEDEF_POINTER       1
+#endif /* _XTYPEDEF_POINTER */
 #include <X11/Xdefs.h>
 
 #ifndef IN_MODULE

--- a/nx-X11/programs/Xserver/include/miscstruct.h
+++ b/nx-X11/programs/Xserver/include/miscstruct.h
@@ -61,7 +61,7 @@ typedef struct _Box {
 } BoxRec;
 
 typedef union _DevUnion {
-    pointer		ptr;
+    void *		ptr;
     long		val;
     unsigned long	uval;
     RegionPtr   	(*fptr)(

--- a/nx-X11/programs/Xserver/include/os.h
+++ b/nx-X11/programs/Xserver/include/os.h
@@ -53,7 +53,7 @@ SOFTWARE.
 
 #include "misc.h"
 #define ALLOCATE_LOCAL_FALLBACK(_size) Xalloc((unsigned long)(_size))
-#define DEALLOCATE_LOCAL_FALLBACK(_ptr) Xfree((pointer)(_ptr))
+#define DEALLOCATE_LOCAL_FALLBACK(_ptr) Xfree((void *)(_ptr))
 #include <X11/Xalloca.h>
 #ifndef IN_MODULE
 #include <stdarg.h>
@@ -75,19 +75,19 @@ SOFTWARE.
 #define MAX_BIG_REQUEST_SIZE 4194303
 #endif
 
-typedef pointer	FID;
+typedef void *	FID;
 typedef struct _FontPathRec *FontPathPtr;
 typedef struct _NewClientRec *NewClientPtr;
 
 #ifndef xalloc
 #define xnfalloc(size) XNFalloc((unsigned long)(size))
 #define xnfcalloc(_num, _size) XNFcalloc((unsigned long)(_num)*(unsigned long)(_size))
-#define xnfrealloc(ptr, size) XNFrealloc((pointer)(ptr), (unsigned long)(size))
+#define xnfrealloc(ptr, size) XNFrealloc((void *)(ptr), (unsigned long)(size))
 
 #define xalloc(size) Xalloc((unsigned long)(size))
 #define xcalloc(_num, _size) Xcalloc((unsigned long)(_num)*(unsigned long)(_size))
-#define xrealloc(ptr, size) Xrealloc((pointer)(ptr), (unsigned long)(size))
-#define xfree(ptr) Xfree((pointer)(ptr))
+#define xrealloc(ptr, size) Xrealloc((void *)(ptr), (unsigned long)(size))
+#define xfree(ptr) Xfree((void *)(ptr))
 #define xstrdup(s) Xstrdup(s)
 #define xnfstrdup(s) XNFstrdup(s)
 #endif
@@ -158,7 +158,7 @@ extern char *ClientAuthorized(
 
 extern Bool EstablishNewConnections(
     ClientPtr /*clientUnused*/,
-    pointer /*closure*/);
+    void * /*closure*/);
 
 extern void CheckConnections(void);
 
@@ -189,7 +189,7 @@ extern void AvailableClientInput(ClientPtr /* client */);
 extern CARD32 GetTimeInMillis(void);
 
 extern void AdjustWaitForDelay(
-    pointer /*waitTime*/,
+    void * /*waitTime*/,
     unsigned long /*newdelay*/);
 
 typedef	struct _OsTimerRec *OsTimerPtr;
@@ -197,7 +197,7 @@ typedef	struct _OsTimerRec *OsTimerPtr;
 typedef CARD32 (*OsTimerCallback)(
     OsTimerPtr /* timer */,
     CARD32 /* time */,
-    pointer /* arg */);
+    void * /* arg */);
 
 extern void TimerInit(void);
 
@@ -211,7 +211,7 @@ extern OsTimerPtr TimerSet(
     int /* flags */,
     CARD32 /* millis */,
     OsTimerCallback /* func */,
-    pointer /* arg */);
+    void * /* arg */);
 
 extern void TimerCheck(void);
 extern void TimerCancel(OsTimerPtr /* pTimer */);
@@ -238,19 +238,19 @@ extern void ProcessCommandLine(int /*argc*/, char* /*argv*/[]);
 extern int set_font_authorizations(
     char ** /* authorizations */, 
     int * /*authlen */, 
-    pointer /* client */);
+    void * /* client */);
 
 #ifndef _HAVE_XALLOC_DECLS
 #define _HAVE_XALLOC_DECLS
-extern pointer Xalloc(unsigned long /*amount*/);
-extern pointer Xcalloc(unsigned long /*amount*/);
-extern pointer Xrealloc(pointer /*ptr*/, unsigned long /*amount*/);
-extern void Xfree(pointer /*ptr*/);
+extern void * Xalloc(unsigned long /*amount*/);
+extern void * Xcalloc(unsigned long /*amount*/);
+extern void * Xrealloc(void * /*ptr*/, unsigned long /*amount*/);
+extern void Xfree(void * /*ptr*/);
 #endif
 
-extern pointer XNFalloc(unsigned long /*amount*/);
-extern pointer XNFcalloc(unsigned long /*amount*/);
-extern pointer XNFrealloc(pointer /*ptr*/, unsigned long /*amount*/);
+extern void * XNFalloc(unsigned long /*amount*/);
+extern void * XNFcalloc(unsigned long /*amount*/);
+extern void * XNFrealloc(void * /*ptr*/, unsigned long /*amount*/);
 
 extern void OsInitAllocator(void);
 
@@ -296,10 +296,10 @@ void OsReleaseSignals (void);
 
 #if !defined(WIN32) && !defined(__UNIXOS2__)
 extern int System(char *);
-extern pointer Popen(char *, char *);
-extern int Pclose(pointer);
-extern pointer Fopen(char *, char *);
-extern int Fclose(pointer);
+extern void * Popen(char *, char *);
+extern int Pclose(void *);
+extern void * Fopen(char *, char *);
+extern int Fclose(void *);
 #else
 #define System(a) system(a)
 #define Popen(a,b) popen(a,b)
@@ -315,24 +315,24 @@ extern int AddHost(
     ClientPtr	/*client*/,
     int         /*family*/,
     unsigned    /*length*/,
-    pointer     /*pAddr*/);
+    void *     /*pAddr*/);
 
 extern Bool ForEachHostInFamily (
     int	    /*family*/,
     Bool    (* /*func*/ )(
             unsigned char * /* addr */,
             short           /* len */,
-            pointer         /* closure */),
-    pointer /*closure*/);
+            void *         /* closure */),
+    void * /*closure*/);
 
 extern int RemoveHost(
     ClientPtr	/*client*/,
     int         /*family*/,
     unsigned    /*length*/,
-    pointer     /*pAddr*/);
+    void *     /*pAddr*/);
 
 extern int GetHosts(
-    pointer * /*data*/,
+    void ** /*data*/,
     int	    * /*pnHosts*/,
     int	    * /*pLen*/,
     BOOL    * /*pEnabled*/);
@@ -362,7 +362,7 @@ extern void AccessUsingXdmcp(void);
 
 extern void DefineSelf(int /*fd*/);
 
-extern void AugmentSelf(pointer /*from*/, int /*len*/);
+extern void AugmentSelf(void * /*from*/, int /*len*/);
 
 extern void InitAuthorization(char * /*filename*/);
 
@@ -467,7 +467,7 @@ typedef struct {
 extern CallbackListPtr ReplyCallback;
 typedef struct {
     ClientPtr client;
-    pointer replyData;
+    void * replyData;
     unsigned long dataLenBytes;
     unsigned long bytesRemaining;
     Bool startOfReply;

--- a/nx-X11/programs/Xserver/include/pixmap.h
+++ b/nx-X11/programs/Xserver/include/pixmap.h
@@ -92,7 +92,7 @@ extern PixmapPtr GetScratchPixmapHeader(
     int /*depth*/,
     int /*bitsPerPixel*/,
     int /*devKind*/,
-    pointer /*pPixData*/);
+    void * /*pPixData*/);
 
 extern void FreeScratchPixmapHeader(
     PixmapPtr /*pPixmap*/);

--- a/nx-X11/programs/Xserver/include/property.h
+++ b/nx-X11/programs/Xserver/include/property.h
@@ -61,7 +61,7 @@ extern int ChangeWindowProperty(
     int /*format*/,
     int /*mode*/,
     unsigned long /*len*/,
-    pointer /*value*/,
+    void * /*value*/,
     Bool /*sendevent*/);
 
 extern int DeleteProperty(

--- a/nx-X11/programs/Xserver/include/propertyst.h
+++ b/nx-X11/programs/Xserver/include/propertyst.h
@@ -61,7 +61,7 @@ typedef struct _Property {
 	ATOM		type;       /* ignored by server */
 	short		format;     /* format of data for swapping - 8,16,32 */
 	long		size;       /* size of data in (format/8) bytes */
-	pointer         data;       /* private to client */
+	void            *data;       /* private to client */
 #if defined(LBX) || defined(LBX_COMPAT)
 	/*  If space is at a premium and binary compatibility is not
 	 *  an issue, you may want to put the owner_pid next to format

--- a/nx-X11/programs/Xserver/include/resource.h
+++ b/nx-X11/programs/Xserver/include/resource.h
@@ -123,24 +123,24 @@ typedef unsigned long RESTYPE;
 #define BAD_RESOURCE 0xe0000000
 
 typedef int (*DeleteType)(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*id*/);
 
 typedef void (*FindResType)(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*id*/,
-    pointer /*cdata*/);
+    void * /*cdata*/);
 
 typedef void (*FindAllRes)(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*id*/,
     RESTYPE /*type*/,
-    pointer /*cdata*/);
+    void * /*cdata*/);
 
 typedef Bool (*FindComplexResType)(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*id*/,
-    pointer /*cdata*/);
+    void * /*cdata*/);
 
 extern RESTYPE CreateNewResourceType(
     DeleteType /*deleteFunc*/);
@@ -161,7 +161,7 @@ extern XID FakeClientID(
 extern Bool AddResource(
     XID /*id*/,
     RESTYPE /*type*/,
-    pointer /*value*/);
+    void * /*value*/);
 
 extern void FreeResource(
     XID /*id*/,
@@ -175,18 +175,18 @@ extern void FreeResourceByType(
 extern Bool ChangeResourceValue(
     XID /*id*/,
     RESTYPE /*rtype*/,
-    pointer /*value*/);
+    void * /*value*/);
 
 extern void FindClientResourcesByType(
     ClientPtr /*client*/,
     RESTYPE /*type*/,
     FindResType /*func*/,
-    pointer /*cdata*/);
+    void * /*cdata*/);
 
 extern void FindAllClientResources(
     ClientPtr /*client*/,
     FindAllRes /*func*/,
-    pointer /*cdata*/);
+    void * /*cdata*/);
 
 extern void FreeClientNeverRetainResources(
     ClientPtr /*client*/);
@@ -200,19 +200,19 @@ extern Bool LegalNewID(
     XID /*id*/,
     ClientPtr /*client*/);
 
-extern pointer LookupIDByType(
+extern void * LookupIDByType(
     XID /*id*/,
     RESTYPE /*rtype*/);
 
-extern pointer LookupIDByClass(
+extern void * LookupIDByClass(
     XID /*id*/,
     RESTYPE /*classes*/);
 
-extern pointer LookupClientResourceComplex(
+extern void * LookupClientResourceComplex(
     ClientPtr client,
     RESTYPE type,
     FindComplexResType func,
-    pointer cdata);
+    void * cdata);
 
 /* These are the access modes that can be passed in the last parameter
  * to SecurityLookupIDByType/Class.  The Security extension doesn't
@@ -229,13 +229,13 @@ extern pointer LookupClientResourceComplex(
 
 #ifdef XCSECURITY
 
-extern pointer SecurityLookupIDByType(
+extern void * SecurityLookupIDByType(
     ClientPtr /*client*/,
     XID /*id*/,
     RESTYPE /*rtype*/,
     Mask /*access_mode*/);
 
-extern pointer SecurityLookupIDByClass(
+extern void * SecurityLookupIDByClass(
     ClientPtr /*client*/,
     XID /*id*/,
     RESTYPE /*classes*/,

--- a/nx-X11/programs/Xserver/include/scrnintstr.h
+++ b/nx-X11/programs/Xserver/include/scrnintstr.h
@@ -85,8 +85,8 @@ typedef struct _Depth {
 
 
 /*
- *  There is a typedef for each screen function pointer so that code that
- *  needs to declare a screen function pointer (e.g. in a screen private
+ *  There is a typedef for each screen function void * so that code that
+ *  needs to declare a screen function void * (e.g. in a screen private
  *  or as a local variable) can easily do so and retain full type checking.
  */
 
@@ -431,15 +431,15 @@ typedef    void (* SendGraphicsExposeProcPtr)(
 
 typedef    void (* ScreenBlockHandlerProcPtr)(
 	int /*screenNum*/,
-	pointer /*blockData*/,
-	pointer /*pTimeout*/,
-	pointer /*pReadmask*/);
+	void * /*blockData*/,
+	void * /*pTimeout*/,
+	void * /*pReadmask*/);
 
 typedef    void (* ScreenWakeupHandlerProcPtr)(
 	 int /*screenNum*/,
-	 pointer /*wakeupData*/,
+	 void * /*wakeupData*/,
 	 unsigned long /*result*/,
-	 pointer /*pReadMask*/);
+	 void * /*pReadMask*/);
 
 typedef    Bool (* CreateScreenResourcesProcPtr)(
 	ScreenPtr /*pScreen*/);
@@ -451,7 +451,7 @@ typedef    Bool (* ModifyPixmapHeaderProcPtr)(
 	int /*depth*/,
 	int /*bitsPerPixel*/,
 	int /*devKind*/,
-	pointer /*pPixData*/);
+	void * /*pPixData*/);
 
 typedef    PixmapPtr (* GetWindowPixmapProcPtr)(
 	WindowPtr /*pWin*/);
@@ -546,7 +546,7 @@ typedef struct _Screen {
 			   a standard one.
 			*/
     PixmapPtr		PixmapPerDepth[1];
-    pointer		devPrivate;
+    void *		devPrivate;
     short       	numVisuals;
     VisualPtr		visuals;
     int			WindowPrivateLen;
@@ -668,8 +668,8 @@ typedef struct _Screen {
     ScreenBlockHandlerProcPtr	BlockHandler;
     ScreenWakeupHandlerProcPtr	WakeupHandler;
 
-    pointer blockData;
-    pointer wakeupData;
+    void * blockData;
+    void * wakeupData;
 
     /* anybody can get a piece of this array */
     DevUnion	*devPrivates;

--- a/nx-X11/programs/Xserver/include/window.h
+++ b/nx-X11/programs/Xserver/include/window.h
@@ -73,17 +73,17 @@ typedef struct _Window *WindowPtr;
 
 typedef int (*VisitWindowProcPtr)(
     WindowPtr /*pWin*/,
-    pointer /*data*/);
+    void * /*data*/);
 
 extern int TraverseTree(
     WindowPtr /*pWin*/,
     VisitWindowProcPtr /*func*/,
-    pointer /*data*/);
+    void * /*data*/);
 
 extern int WalkTree(
     ScreenPtr /*pScreen*/,
     VisitWindowProcPtr /*func*/,
-    pointer /*data*/);
+    void * /*data*/);
 
 extern WindowPtr AllocateWindow(
     ScreenPtr /*pScreen*/);
@@ -122,7 +122,7 @@ extern WindowPtr CreateWindow(
     int* /*error*/);
 
 extern int DeleteWindow(
-    pointer /*pWin*/,
+    void * /*pWin*/,
     XID /*wid*/);
 
 extern void DestroySubwindows(

--- a/nx-X11/programs/Xserver/include/windowstr.h
+++ b/nx-X11/programs/Xserver/include/windowstr.h
@@ -114,7 +114,7 @@ typedef struct _Window {
     Mask		eventMask;
     PixUnion		background;
     PixUnion		border;
-    pointer		backStorage;	/* null when BS disabled */
+    void *		backStorage;	/* null when BS disabled */
     WindowOptPtr	optional;
     unsigned		backgroundState:2; /* None, Relative, Pixel, Pixmap */
     unsigned		borderIsPixel:1;

--- a/nx-X11/programs/Xserver/mfb/maskbits.h
+++ b/nx-X11/programs/Xserver/mfb/maskbits.h
@@ -534,7 +534,7 @@ extern PixelType mfbGetmask(int);
 #endif
 
 #if GETLEFTBITS_ALIGNMENT == 1
-#define getleftbits(psrc, w, dst)	dst = *((CARD32 *)(pointer) psrc)
+#define getleftbits(psrc, w, dst)	dst = *((CARD32 *)(void *) psrc)
 #endif /* GETLEFTBITS_ALIGNMENT == 1 */
 
 #if GETLEFTBITS_ALIGNMENT == 2

--- a/nx-X11/programs/Xserver/mi/mi.h
+++ b/nx-X11/programs/Xserver/mi/mi.h
@@ -263,7 +263,7 @@ extern void miPolyGlyphBlt(
     int /*y*/,
     unsigned int /*nglyph*/,
     CharInfoPtr * /*ppci*/,
-    pointer /*pglyphBase*/
+    void * /*pglyphBase*/
 );
 
 extern void miImageGlyphBlt(
@@ -273,7 +273,7 @@ extern void miImageGlyphBlt(
     int /*y*/,
     unsigned int /*nglyph*/,
     CharInfoPtr * /*ppci*/,
-    pointer /*pglyphBase*/
+    void * /*pglyphBase*/
 );
 
 /* mipoly.c */
@@ -438,7 +438,7 @@ extern Bool miModifyPixmapHeader(
     int /*depth*/,
     int /*bitsPerPixel*/,
     int /*devKind*/,
-    pointer /*pPixData*/
+    void * /*pPixData*/
 );
 
 extern Bool miCloseScreen(
@@ -453,12 +453,12 @@ extern Bool miCreateScreenResources(
 extern Bool miScreenDevPrivateInit(
     ScreenPtr /*pScreen*/,
     int /*width*/,
-    pointer /*pbits*/
+    void * /*pbits*/
 );
 
 extern Bool miScreenInit(
     ScreenPtr /*pScreen*/,
-    pointer /*pbits*/,
+    void * /*pbits*/,
     int /*xsize*/,
     int /*ysize*/,
     int /*dpix*/,

--- a/nx-X11/programs/Xserver/mi/miarc.c
+++ b/nx-X11/programs/Xserver/mi/miarc.c
@@ -435,7 +435,7 @@ static RESTYPE cacheType;
 /*ARGSUSED*/
 int
 miFreeArcCache (data, id)
-    pointer	    data;
+    void *	    data;
     XID		    id;
 {
     int k;
@@ -1691,7 +1691,7 @@ miGetArcPts(
     count++;
 
     cdt = 2 * miDcos(dt);
-    if (!(poly = (SppPointPtr) xrealloc((pointer)*ppPts,
+    if (!(poly = (SppPointPtr) xrealloc((void *)*ppPts,
 					(cpt + count) * sizeof(SppPointRec))))
 	return(0);
     *ppPts = poly;

--- a/nx-X11/programs/Xserver/mi/mibank.c
+++ b/nx-X11/programs/Xserver/mi/mibank.c
@@ -111,7 +111,7 @@ typedef struct _miBankScreen
     int           nBanks, maxRects;
     RegionPtr     *pBanks;
 
-    pointer       pbits;
+    void          *pbits;
 
     /*
      * Screen Wrappers
@@ -192,11 +192,11 @@ static unsigned long miBankGeneration = 0;
 #define BANK_GCPRIVATE(pGC) ((miBankGCPtr)(BANK_GCPRIVLVAL(pGC)))
 
 #define PIXMAP_STATUS(_pPix) \
-    pointer pbits = (_pPix)->devPrivate.ptr
+    void * pbits = (_pPix)->devPrivate.ptr
 
 #define PIXMAP_SAVE(_pPix) \
     PIXMAP_STATUS(_pPix); \
-    if (pbits == (pointer)pScreenPriv) \
+    if (pbits == (void *)pScreenPriv) \
         (_pPix)->devPrivate.ptr = pScreenPriv->pbits
 
 #define PIXMAP_RESTORE(_pPix) \
@@ -247,7 +247,7 @@ static unsigned long miBankGeneration = 0;
     (pGC)->funcs          = pGCPriv->unwrappedFuncs
 
 #define IS_BANKED(pDrawable) \
-    ((pbits == (pointer)pScreenPriv) && \
+    ((pbits == (void *)pScreenPriv) && \
      (((DrawablePtr)(pDrawable))->type == DRAWABLE_WINDOW))
 
 #define CLIP_SAVE \
@@ -1267,7 +1267,7 @@ miBankImageGlyphBlt(
     int          y,
     unsigned int nArray,
     CharInfoPtr  *ppci,
-    pointer      pglyphBase
+    void         *pglyphBase
 )
 {
     GCOP_SIMPLE((*pGC->ops->ImageGlyphBlt)(pDrawable, pGC,
@@ -1282,7 +1282,7 @@ miBankPolyGlyphBlt(
     int          y,
     unsigned int nArray,
     CharInfoPtr  *ppci,
-    pointer      pglyphBase
+    void         *pglyphBase
 )
 {
     GCOP_SIMPLE((*pGC->ops->PolyGlyphBlt)(pDrawable, pGC,
@@ -1539,7 +1539,7 @@ static void
 miBankChangeClip(
     GCPtr   pGC,
     int     type,
-    pointer pvalue,
+    void * pvalue,
     int     nrects
 )
 {
@@ -1608,7 +1608,7 @@ miBankCreateScreenResources(
         /* Set screen buffer address to something recognizable */
         pScreenPriv->pScreenPixmap = (*pScreen->GetScreenPixmap)(pScreen);
         pScreenPriv->pbits = pScreenPriv->pScreenPixmap->devPrivate.ptr;
-        pScreenPriv->pScreenPixmap->devPrivate.ptr = (pointer)pScreenPriv;
+        pScreenPriv->pScreenPixmap->devPrivate.ptr = (void *)pScreenPriv;
 
         /* Get shadow pixmap;  width & height of 0 means no pixmap data */
         pScreenPriv->pBankPixmap = (*pScreen->CreatePixmap)(pScreen, 0, 0,
@@ -1657,7 +1657,7 @@ miBankModifyPixmapHeader(
     int       depth,
     int       bitsPerPixel,
     int       devKind,
-    pointer   pPixData
+    void      *pPixData
 )
 {
     Bool retval = FALSE;
@@ -1675,7 +1675,7 @@ miBankModifyPixmapHeader(
 
         SCREEN_WRAP(ModifyPixmapHeader, miBankModifyPixmapHeader);
 
-        if (pbits == (pointer)pScreenPriv)
+        if (pbits == (void *)pScreenPriv)
         {
             pScreenPriv->pbits = pPixmap->devPrivate.ptr;
             pPixmap->devPrivate.ptr = pbits;
@@ -2395,7 +2395,7 @@ miInitializeBanking(
     pScreen->BackingStoreFuncs.SetClipmaskRgn = miBankSetClipmaskRgn;
     ?????????????????????????????????????????????????????????????? */
 
-    BANK_SCRPRIVLVAL = (pointer)pScreenPriv;
+    BANK_SCRPRIVLVAL = (void *)pScreenPriv;
 
     return TRUE;
 }
@@ -2405,7 +2405,7 @@ miInitializeBanking(
 static int
 miBankNewSerialNumber(
     WindowPtr pWin,
-    pointer   unused
+    void      *unused
 )
 {
     pWin->drawable.serialNumber = NEXT_SERIAL_NUMBER;

--- a/nx-X11/programs/Xserver/mi/mibank.h
+++ b/nx-X11/programs/Xserver/mi/mibank.h
@@ -70,8 +70,8 @@ typedef struct _miBankInfo
     miBankProcPtr SetDestinationBank;           /* Set pBankB bank number */
     miBankProcPtr SetSourceAndDestinationBanks; /* Set both bank numbers */
 
-    pointer pBankA;     /* First aperture location */
-    pointer pBankB;     /* First or second aperture location */
+    void * pBankA;     /* First aperture location */
+    void * pBankB;     /* First or second aperture location */
 
     /*
      * BankSize is in units of sizeof(char) and is the size of each bank.

--- a/nx-X11/programs/Xserver/mi/mibstore.c
+++ b/nx-X11/programs/Xserver/mi/mibstore.c
@@ -228,7 +228,7 @@ static void miBSValidateGC(GCPtr pGC, unsigned long stateChanges,
 static void miBSCopyGC(GCPtr pGCSrc, unsigned long mask, GCPtr pGCDst);
 static void miBSDestroyGC(GCPtr pGC);
 static void miBSChangeGC(GCPtr pGC, unsigned long mask);
-static void miBSChangeClip(GCPtr pGC, int type, pointer pvalue, int nrects);
+static void miBSChangeClip(GCPtr pGC, int type, void * pvalue, int nrects);
 static void miBSDestroyClip(GCPtr pGC);
 static void miBSCopyClip(GCPtr pgcDst, GCPtr pgcSrc);
 
@@ -286,10 +286,10 @@ static void	    miBSImageText16(DrawablePtr pDrawable, GCPtr pGC,
 				    unsigned short *chars);
 static void	    miBSImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
 				      int x, int y, unsigned int nglyph,
-				      CharInfoPtr *ppci, pointer pglyphBase);
+				      CharInfoPtr *ppci, void * pglyphBase);
 static void	    miBSPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC,
 				     int x, int y, unsigned int nglyph,
-				     CharInfoPtr *ppci, pointer pglyphBase);
+				     CharInfoPtr *ppci, void * pglyphBase);
 static void	    miBSPushPixels(GCPtr pGC, PixmapPtr pBitMap,
 				   DrawablePtr pDst, int w, int h,
 				   int x, int y);
@@ -330,7 +330,7 @@ static void miBSCheapValidateGC(GCPtr pGC, unsigned long stateChanges,
 static void miBSCheapCopyGC(GCPtr pGCSrc, unsigned long mask, GCPtr pGCDst);
 static void miBSCheapDestroyGC(GCPtr pGC);
 static void miBSCheapChangeGC(GCPtr pGC, unsigned long mask);
-static void miBSCheapChangeClip(GCPtr pGC, int type, pointer pvalue,
+static void miBSCheapChangeClip(GCPtr pGC, int type, void * pvalue,
 				int nrects);
 static void miBSCheapDestroyClip(GCPtr pGC);
 static void miBSCheapCopyClip(GCPtr pgcDst, GCPtr pgcSrc);
@@ -398,7 +398,7 @@ miInitializeBackingStore (pScreen)
     pScreen->ClearBackingStore = miBSClearBackingStore;
     pScreen->DrawGuarantee = miBSDrawGuarantee;
 
-    pScreen->devPrivates[miBSScreenIndex].ptr = (pointer) pScreenPriv;
+    pScreen->devPrivates[miBSScreenIndex].ptr = (void *) pScreenPriv;
 }
 
 /*
@@ -433,7 +433,7 @@ miBSCloseScreen (i, pScreen)
     pScreen->ChangeWindowAttributes = pScreenPriv->ChangeWindowAttributes;
     pScreen->CreateGC = pScreenPriv->CreateGC;
 
-    xfree ((pointer) pScreenPriv);
+    xfree ((void *) pScreenPriv);
 
     return (*pScreen->CloseScreen) (i, pScreen);
 }
@@ -765,7 +765,7 @@ miBSCreateGC (pGC)
     
     if ( (ret = (*pScreen->CreateGC) (pGC)) )
     {
-    	pGC->devPrivates[miBSGCIndex].ptr = (pointer) pGC->funcs;
+	pGC->devPrivates[miBSGCIndex].ptr = (void *) pGC->funcs;
     	pGC->funcs = &miBSCheapGCFuncs;
     }
 
@@ -816,7 +816,7 @@ miBSCheapValidateGC (pGC, stateChanges, pDrawable)
 	(*pGC->funcs->ValidateGC) (pGC, stateChanges, pDrawable);
 
 	/* rewrap funcs as Validate may have changed them */
-	pGC->devPrivates[miBSGCIndex].ptr = (pointer) pGC->funcs;
+	pGC->devPrivates[miBSGCIndex].ptr = (void *) pGC->funcs;
 
 	CHEAP_FUNC_EPILOGUE (pGC);
     }
@@ -861,7 +861,7 @@ static void
 miBSCheapChangeClip (pGC, type, pvalue, nrects)
     GCPtr   pGC;
     int		type;
-    pointer	pvalue;
+    void *	pvalue;
     int		nrects;
 {
     CHEAP_FUNC_PROLOGUE (pGC);
@@ -914,7 +914,7 @@ miBSCreateGCPrivate (pGC)
     pPriv->wrapFuncs = pGC->funcs;
     pGC->funcs = &miBSGCFuncs;
     pGC->ops = &miBSGCOps;
-    pGC->devPrivates[miBSGCIndex].ptr = (pointer) pPriv;
+    pGC->devPrivates[miBSGCIndex].ptr = (void *) pPriv;
     return TRUE;
 }
 
@@ -926,12 +926,12 @@ miBSDestroyGCPrivate (GCPtr pGC)
     pPriv = (miBSGCRec *) pGC->devPrivates[miBSGCIndex].ptr;
     if (pPriv)
     {
-	pGC->devPrivates[miBSGCIndex].ptr = (pointer) pPriv->wrapFuncs;
+	pGC->devPrivates[miBSGCIndex].ptr = (void *) pPriv->wrapFuncs;
 	pGC->funcs = &miBSCheapGCFuncs;
 	pGC->ops = pPriv->wrapOps;
 	if (pPriv->pBackingGC)
 	    FreeGC (pPriv->pBackingGC, (GContext) 0);
-	xfree ((pointer) pPriv);
+	xfree ((void *) pPriv);
     }
 }
 
@@ -2157,7 +2157,7 @@ miBSImageGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
     int 	x, y;
     unsigned int nglyph;
     CharInfoPtr *ppci;		/* array of character info */
-    pointer 	pglyphBase;	/* start of array of glyphs */
+    void * 	pglyphBase;	/* start of array of glyphs */
 {
     SETUP_BACKING (pDrawable, pGC);
     PROLOGUE(pGC);
@@ -2189,7 +2189,7 @@ miBSPolyGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
     int 	x, y;
     unsigned int nglyph;
     CharInfoPtr *ppci;		/* array of character info */
-    pointer	pglyphBase;	/* start of array of glyphs */
+    void *	pglyphBase;	/* start of array of glyphs */
 {
     SETUP_BACKING (pDrawable, pGC);
     PROLOGUE(pGC);
@@ -2287,7 +2287,7 @@ miBSClearBackingStore(pWin, x, y, w, h, generateExposures)
     GCPtr   	  	pGC;
     int	    	  	ts_x_origin,
 			ts_y_origin;
-    pointer    	  	gcvalues[4];
+    void    	  	*gcvalues[4];
     unsigned long 	gcmask;
     xRectangle	  	*rects;
     BoxPtr  	  	pBox;
@@ -2373,18 +2373,18 @@ miBSClearBackingStore(pWin, x, y, w, h, generateExposures)
 	    
 		if (backgroundState == BackgroundPixel)
 		{
-		    gcvalues[0] = (pointer) background.pixel;
-		    gcvalues[1] = (pointer)FillSolid;
+		    gcvalues[0] = (void *) background.pixel;
+		    gcvalues[1] = (void *)FillSolid;
 		    gcmask = GCForeground|GCFillStyle;
 		}
 		else
 		{
-		    gcvalues[0] = (pointer)FillTiled;
-		    gcvalues[1] = (pointer) background.pixmap;
+		    gcvalues[0] = (void *)FillTiled;
+		    gcvalues[1] = (void *) background.pixmap;
 		    gcmask = GCFillStyle|GCTile;
 		}
-		gcvalues[2] = (pointer)(long)(ts_x_origin - pBackingStore->x);
-		gcvalues[3] = (pointer)(long)(ts_y_origin - pBackingStore->y);
+		gcvalues[2] = (void *)(long)(ts_x_origin - pBackingStore->x);
+		gcvalues[3] = (void *)(long)(ts_y_origin - pBackingStore->y);
 		gcmask |= GCTileStipXOrigin|GCTileStipYOrigin;
 		DoChangeGC(pGC, gcmask, (XID *)gcvalues, TRUE);
 		ValidateGC((DrawablePtr)pBackingStore->pBackingPixmap, pGC);
@@ -2477,7 +2477,7 @@ miBSFillVirtualBits (pDrawable, pGC, pRgn, x, y, state, pixunion, planeMask)
 {
     int		i;
     BITS32	gcmask;
-    pointer	gcval[5];
+    void *	gcval[5];
     xRectangle	*pRect;
     BoxPtr	pBox;
     WindowPtr	pWin;
@@ -2498,18 +2498,18 @@ miBSFillVirtualBits (pDrawable, pGC, pRgn, x, y, state, pixunion, planeMask)
     }
     i = 0;
     gcmask = 0;
-    gcval[i++] = (pointer)planeMask;
+    gcval[i++] = (void *)planeMask;
     gcmask |= GCPlaneMask;
     if (state == BackgroundPixel)
     {
 	if (pGC->fgPixel != pixunion.pixel)
 	{
-	    gcval[i++] = (pointer)pixunion.pixel;
+	    gcval[i++] = (void *)pixunion.pixel;
 	    gcmask |= GCForeground;
 	}
 	if (pGC->fillStyle != FillSolid)
 	{
-	    gcval[i++] = (pointer)FillSolid;
+	    gcval[i++] = (void *)FillSolid;
 	    gcmask |= GCFillStyle;
 	}
     }
@@ -2517,22 +2517,22 @@ miBSFillVirtualBits (pDrawable, pGC, pRgn, x, y, state, pixunion, planeMask)
     {
 	if (pGC->fillStyle != FillTiled)
 	{
-	    gcval[i++] = (pointer)FillTiled;
+	    gcval[i++] = (void *)FillTiled;
 	    gcmask |= GCFillStyle;
 	}
 	if (pGC->tileIsPixel || pGC->tile.pixmap != pixunion.pixmap)
 	{
-	    gcval[i++] = (pointer)pixunion.pixmap;
+	    gcval[i++] = (void *)pixunion.pixmap;
 	    gcmask |= GCTile;
 	}
 	if (pGC->patOrg.x != x)
 	{
-	    gcval[i++] = (pointer)(long)x;
+	    gcval[i++] = (void *)(long)x;
 	    gcmask |= GCTileStipXOrigin;
 	}
 	if (pGC->patOrg.y != y)
 	{
-	    gcval[i++] = (pointer)(long)y;
+	    gcval[i++] = (void *)(long)y;
 	    gcmask |= GCTileStipYOrigin;
 	}
     }
@@ -2592,7 +2592,7 @@ miBSAllocate(pWin)
 	pBackingStore->viewable = (char)pWin->viewable;
 	pBackingStore->status = StatusNoPixmap;
 	pBackingStore->backgroundState = None;
-	pWin->backStorage = (pointer) pBackingStore;
+	pWin->backStorage = (void *) pBackingStore;
     }
 	
     /*
@@ -3622,7 +3622,7 @@ static void
 miBSChangeClip(pGC, type, pvalue, nrects)
     GCPtr	pGC;
     int		type;
-    pointer	pvalue;
+    void *	pvalue;
     int		nrects;
 {
     miBSGCPtr	pPriv = (miBSGCPtr) (pGC)->devPrivates[miBSGCIndex].ptr;

--- a/nx-X11/programs/Xserver/mi/midispcur.c
+++ b/nx-X11/programs/Xserver/mi/midispcur.c
@@ -151,11 +151,11 @@ miDCInitialize (pScreen, screenFuncs)
     pScreenPriv->CloseScreen = pScreen->CloseScreen;
     pScreen->CloseScreen = miDCCloseScreen;
     
-    pScreen->devPrivates[miDCScreenIndex].ptr = (pointer) pScreenPriv;
+    pScreen->devPrivates[miDCScreenIndex].ptr = (void *) pScreenPriv;
 
     if (!miSpriteInitialize (pScreen, &miDCFuncs, screenFuncs))
     {
-	xfree ((pointer) pScreenPriv);
+	xfree ((void *) pScreenPriv);
 	return FALSE;
     }
     return TRUE;
@@ -187,7 +187,7 @@ miDCCloseScreen (index, pScreen)
     tossPict (pScreenPriv->pRootPicture);
     tossPict (pScreenPriv->pTempPicture);
 #endif
-    xfree ((pointer) pScreenPriv);
+    xfree ((void *) pScreenPriv);
     return (*pScreen->CloseScreen) (index, pScreen);
 }
 
@@ -197,7 +197,7 @@ miDCRealizeCursor (pScreen, pCursor)
     CursorPtr	pCursor;
 {
     if (pCursor->bits->refcnt <= 1)
-	pCursor->bits->devPriv[pScreen->myNum] = (pointer)NULL;
+	pCursor->bits->devPriv[pScreen->myNum] = (void *)NULL;
     return TRUE;
 }
 
@@ -263,7 +263,7 @@ miDCRealize (
 	pFormat = PictureMatchFormat (pScreen, 32, PICT_a8r8g8b8);
 	if (!pFormat)
 	{
-	    xfree ((pointer) pPriv);
+	    xfree ((void *) pPriv);
 	    return (miDCCursorPtr)NULL;
 	}
 	
@@ -273,14 +273,14 @@ miDCRealize (
 					    pCursor->bits->height, 32);
 	if (!pPixmap)
 	{
-	    xfree ((pointer) pPriv);
+	    xfree ((void *) pPriv);
 	    return (miDCCursorPtr)NULL;
 	}
 	pGC = GetScratchGC (32, pScreen);
 	if (!pGC)
 	{
 	    (*pScreen->DestroyPixmap) (pPixmap);
-	    xfree ((pointer) pPriv);
+	    xfree ((void *) pPriv);
 	    return (miDCCursorPtr)NULL;
 	}
 	ValidateGC (&pPixmap->drawable, pGC);
@@ -294,10 +294,10 @@ miDCRealize (
         (*pScreen->DestroyPixmap) (pPixmap);
 	if (!pPriv->pPicture)
 	{
-	    xfree ((pointer) pPriv);
+	    xfree ((void *) pPriv);
 	    return (miDCCursorPtr)NULL;
 	}
-	pCursor->bits->devPriv[pScreen->myNum] = (pointer) pPriv;
+	pCursor->bits->devPriv[pScreen->myNum] = (void *) pPriv;
 	return pPriv;
     }
     pPriv->pPicture = 0;
@@ -305,17 +305,17 @@ miDCRealize (
     pPriv->sourceBits = (*pScreen->CreatePixmap) (pScreen, pCursor->bits->width, pCursor->bits->height, 1);
     if (!pPriv->sourceBits)
     {
-	xfree ((pointer) pPriv);
+	xfree ((void *) pPriv);
 	return (miDCCursorPtr)NULL;
     }
     pPriv->maskBits =  (*pScreen->CreatePixmap) (pScreen, pCursor->bits->width, pCursor->bits->height, 1);
     if (!pPriv->maskBits)
     {
 	(*pScreen->DestroyPixmap) (pPriv->sourceBits);
-	xfree ((pointer) pPriv);
+	xfree ((void *) pPriv);
 	return (miDCCursorPtr)NULL;
     }
-    pCursor->bits->devPriv[pScreen->myNum] = (pointer) pPriv;
+    pCursor->bits->devPriv[pScreen->myNum] = (void *) pPriv;
 
     /* create the two sets of bits, clipping as appropriate */
 
@@ -372,8 +372,8 @@ miDCUnrealizeCursor (pScreen, pCursor)
 	if (pPriv->pPicture)
 	    FreePicture (pPriv->pPicture, 0);
 #endif
-	xfree ((pointer) pPriv);
-	pCursor->bits->devPriv[pScreen->myNum] = (pointer)NULL;
+	xfree ((void *) pPriv);
+	pCursor->bits->devPriv[pScreen->myNum] = (void *)NULL;
     }
     return TRUE;
 }

--- a/nx-X11/programs/Xserver/mi/miexpose.c
+++ b/nx-X11/programs/Xserver/mi/miexpose.c
@@ -618,7 +618,7 @@ static GCPtr	screenContext[MAXSCREENS];
 /*ARGSUSED*/
 static int
 tossGC (
-    pointer value,
+    void * value,
     XID id)
 {
     GCPtr pGC = (GCPtr)value;
@@ -684,7 +684,7 @@ int what;
 	    gcmask |= GCForeground | GCFillStyle;
 	    break;
 	case BackgroundPixmap:
-	    newValues[TILE].ptr = (pointer)pWin->background.pixmap;
+	    newValues[TILE].ptr = (void *)pWin->background.pixmap;
 	    newValues[FILLSTYLE].val = FillTiled;
 	    gcmask |= GCTile | GCFillStyle | GCTileStipXOrigin | GCTileStipYOrigin;
 	    break;
@@ -700,7 +700,7 @@ int what;
 	}
 	else
 	{
-	    newValues[TILE].ptr = (pointer)pWin->border.pixmap;
+	    newValues[TILE].ptr = (void *)pWin->border.pixmap;
 	    newValues[FILLSTYLE].val = FillTiled;
 	    gcmask |= GCTile | GCFillStyle | GCTileStipXOrigin | GCTileStipYOrigin;
 	}
@@ -773,7 +773,7 @@ int what;
 		return;
 	    numGCs++;
 	    if (!AddResource(FakeClientID(0), ResType,
-			     (pointer)screenContext[i]))
+			     (void *)screenContext[i]))
 	        return;
 	}
 	pGC = screenContext[i];

--- a/nx-X11/programs/Xserver/mi/mifillarc.h
+++ b/nx-X11/programs/Xserver/mi/mifillarc.h
@@ -179,7 +179,7 @@ typedef struct _miArcSlice {
 			       ((slw > 1) || (ine != inxk)))
 
 extern int miFreeArcCache(
-    pointer /*data*/,
+    void * /*data*/,
     XID /*id*/
 );
 

--- a/nx-X11/programs/Xserver/mi/migc.c
+++ b/nx-X11/programs/Xserver/mi/migc.c
@@ -114,14 +114,14 @@ void
 miChangeClip(pGC, type, pvalue, nrects)
     GCPtr           pGC;
     int             type;
-    pointer         pvalue;
+    void            *pvalue;
     int             nrects;
 {
     (*pGC->funcs->DestroyClip) (pGC);
     if (type == CT_PIXMAP)
     {
 	/* convert the pixmap to a region */
-	pGC->clientClip = (pointer) BITMAP_TO_REGION(pGC->pScreen,
+	pGC->clientClip = (void *) BITMAP_TO_REGION(pGC->pScreen,
 							(PixmapPtr) pvalue);
 	(*pGC->pScreen->DestroyPixmap) (pvalue);
     }
@@ -132,7 +132,7 @@ miChangeClip(pGC, type, pvalue, nrects)
     }
     else if (type != CT_NONE)
     {
-	pGC->clientClip = (pointer) RECTS_TO_REGION(pGC->pScreen, nrects,
+	pGC->clientClip = (void *) RECTS_TO_REGION(pGC->pScreen, nrects,
 						      (xRectangle *) pvalue,
 								    type);
 	xfree(pvalue);
@@ -160,7 +160,7 @@ miCopyClip(pgcDst, pgcSrc)
 	prgnNew = REGION_CREATE(pgcSrc->pScreen, NULL, 1);
 	REGION_COPY(pgcDst->pScreen, prgnNew,
 					(RegionPtr) (pgcSrc->clientClip));
-	(*pgcDst->funcs->ChangeClip) (pgcDst, CT_REGION, (pointer) prgnNew, 0);
+	(*pgcDst->funcs->ChangeClip) (pgcDst, CT_REGION, (void *) prgnNew, 0);
 	break;
     }
 }

--- a/nx-X11/programs/Xserver/mi/migc.h
+++ b/nx-X11/programs/Xserver/mi/migc.h
@@ -53,7 +53,7 @@ extern void miDestroyClip(
 extern void miChangeClip(
     GCPtr   /*pGC*/,
     int     /*type*/,
-    pointer /*pvalue*/,
+    void * /*pvalue*/,
     int     /*nrects*/
 );
 

--- a/nx-X11/programs/Xserver/mi/miglblt.c
+++ b/nx-X11/programs/Xserver/mi/miglblt.c
@@ -90,7 +90,7 @@ miPolyGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
     int 	 x, y;
     unsigned int nglyph;
     CharInfoPtr *ppci;		/* array of character info */
-    pointer      pglyphBase;	/* start of array of glyphs */
+    void        *pglyphBase;	/* start of array of glyphs */
 {
     int width, height;
     PixmapPtr pPixmap;
@@ -203,7 +203,7 @@ miImageGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
     int 	 x, y;
     unsigned int nglyph;
     CharInfoPtr *ppci;		/* array of character info */
-    pointer      pglyphBase;	/* start of array of glyphs */
+    void        *pglyphBase;	/* start of array of glyphs */
 {
     ExtentInfoRec info;		/* used by QueryGlyphExtents() */
     XID gcvals[3];

--- a/nx-X11/programs/Xserver/mi/mioverlay.c
+++ b/nx-X11/programs/Xserver/mi/mioverlay.c
@@ -128,7 +128,7 @@ miInitOverlay(
     if(!(pScreenPriv = xalloc(sizeof(miOverlayScreenRec))))
 	return FALSE;
 
-    pScreen->devPrivates[miOverlayScreenIndex].ptr = (pointer)pScreenPriv;
+    pScreen->devPrivates[miOverlayScreenIndex].ptr = (void *)pScreenPriv;
 
     pScreenPriv->InOverlay = inOverlayFunc;
     pScreenPriv->MakeTransparent = transFunc;
@@ -1105,7 +1105,7 @@ typedef struct {
 static int
 miOverlayRecomputeExposures (
     WindowPtr	pWin,
-    pointer	value 
+    void *	value 
 ){
     register ScreenPtr pScreen;
     miOverlayTwoRegions	*pValid = (miOverlayTwoRegions*)value;
@@ -1503,7 +1503,7 @@ miOverlayResizeWindow(
 		TwoRegions.under = gravitate2[g];
 
 		TraverseTree (pChild, miOverlayRecomputeExposures, 
-					(pointer)(&TwoRegions));
+					(void *)(&TwoRegions));
 	    }
 
 	    /*

--- a/nx-X11/programs/Xserver/mi/mipointer.c
+++ b/nx-X11/programs/Xserver/mi/mipointer.c
@@ -103,7 +103,7 @@ miPointerInitialize (pScreen, spriteFuncs, screenFuncs, waitForUpdate)
     pScreenPriv->showTransparent = FALSE;
     pScreenPriv->CloseScreen = pScreen->CloseScreen;
     pScreen->CloseScreen = miPointerCloseScreen;
-    pScreen->devPrivates[miPointerScreenIndex].ptr = (pointer) pScreenPriv;
+    pScreen->devPrivates[miPointerScreenIndex].ptr = (void *) pScreenPriv;
     /*
      * set up screen cursor method table
      */
@@ -145,7 +145,7 @@ miPointerCloseScreen (index, pScreen)
     if (pScreen == miPointer.pSpriteScreen)
 	miPointer.pSpriteScreen = 0;
     pScreen->CloseScreen = pScreenPriv->CloseScreen;
-    xfree ((pointer) pScreenPriv);
+    xfree ((void *) pScreenPriv);
     return (*pScreen->CloseScreen) (index, pScreen);
 }
 
@@ -373,7 +373,7 @@ miPointerUpdate ()
 }
 
 /*
- * miPointerDeltaCursor.  The pointer has moved dx,dy from it's previous
+ * miPointerDeltaCursor.  The void * has moved dx,dy from it's previous
  * position.
  */
 
@@ -406,7 +406,7 @@ miPointerCurrentScreen ()
 }
 
 /*
- * miPointerAbsoluteCursor.  The pointer has moved to x,y
+ * miPointerAbsoluteCursor.  The void * has moved to x,y
  */
 
 void
@@ -465,7 +465,7 @@ miPointerPosition (x, y)
 }
 
 /*
- * miPointerMove.  The pointer has moved to x,y on current screen
+ * miPointerMove.  The void * has moved to x,y on current screen
  */
 
 static void

--- a/nx-X11/programs/Xserver/mi/mipolyrect.c
+++ b/nx-X11/programs/Xserver/mi/mipolyrect.c
@@ -164,7 +164,7 @@ miPolyRectangle(pDraw, pGC, nrects, pRects)
 	    }
 	}
 	(*pGC->ops->PolyFillRect) (pDraw, pGC, t - tmp, tmp);
-	DEALLOCATE_LOCAL ((pointer) tmp);
+	DEALLOCATE_LOCAL ((void *) tmp);
     }
     else
     {

--- a/nx-X11/programs/Xserver/mi/miscrinit.c
+++ b/nx-X11/programs/Xserver/mi/miscrinit.c
@@ -56,7 +56,7 @@ from The Open Group.
 
 typedef struct
 {
-    pointer pbits; /* pointer to framebuffer */
+    void * pbits; /* pointer to framebuffer */
     int width;    /* delta to add to a framebuffer addr to move one row down */
 } miScreenInitParmsRec, *miScreenInitParmsPtr;
 
@@ -71,7 +71,7 @@ miModifyPixmapHeader(pPixmap, width, height, depth, bitsPerPixel, devKind,
     int		depth;
     int		bitsPerPixel;
     int		devKind;
-    pointer     pPixData;
+    void        *pPixData;
 {
     if (!pPixmap)
 	return FALSE;
@@ -150,7 +150,7 @@ miCreateScreenResources(pScreen)
     ScreenPtr pScreen;
 {
     miScreenInitParmsPtr pScrInitParms;
-    pointer value;
+    void * value;
 
     pScrInitParms = (miScreenInitParmsPtr)pScreen->devPrivate;
 
@@ -174,7 +174,7 @@ miCreateScreenResources(pScreen)
 		    PixmapBytePad(pScrInitParms->width, pScreen->rootDepth),
 		    pScrInitParms->pbits))
 	    return FALSE;
-	value = (pointer)pPixmap;
+	value = (void *)pPixmap;
     }
     else
     {
@@ -189,7 +189,7 @@ Bool
 miScreenDevPrivateInit(pScreen, width, pbits)
     register ScreenPtr pScreen;
     int width;
-    pointer pbits;
+    void * pbits;
 {
     miScreenInitParmsPtr pScrInitParms;
 
@@ -202,7 +202,7 @@ miScreenDevPrivateInit(pScreen, width, pbits)
 	return FALSE;
     pScrInitParms->pbits = pbits;
     pScrInitParms->width = width;
-    pScreen->devPrivate = (pointer)pScrInitParms;
+    pScreen->devPrivate = (void *)pScrInitParms;
     return TRUE;
 }
 
@@ -210,7 +210,7 @@ Bool
 miScreenInit(pScreen, pbits, xsize, ysize, dpix, dpiy, width,
 	     rootDepth, numDepths, depths, rootVisual, numVisuals, visuals)
     register ScreenPtr pScreen;
-    pointer pbits;		/* pointer to screen bits */
+    void * pbits;		/* pointer to screen bits */
     int xsize, ysize;		/* in pixels */
     int dpix, dpiy;		/* dots per inch */
     int width;			/* pixel width of frame buffer */
@@ -296,8 +296,8 @@ miScreenInit(pScreen, pbits, xsize, ysize, dpix, dpiy, width,
     pScreen->SendGraphicsExpose = miSendGraphicsExpose;
     pScreen->BlockHandler = (ScreenBlockHandlerProcPtr)NoopDDA;
     pScreen->WakeupHandler = (ScreenWakeupHandlerProcPtr)NoopDDA;
-    pScreen->blockData = (pointer)0;
-    pScreen->wakeupData = (pointer)0;
+    pScreen->blockData = (void *)0;
+    pScreen->wakeupData = (void *)0;
     pScreen->MarkWindow = miMarkWindow;
     pScreen->MarkOverlappedWindows = miMarkOverlappedWindows;
     pScreen->ChangeSaveUnder = miChangeSaveUnder;
@@ -368,5 +368,5 @@ miSetScreenPixmap(pPix)
     PixmapPtr pPix;
 {
     if (pPix)
-	pPix->drawable.pScreen->devPrivate = (pointer)pPix;
+	pPix->drawable.pScreen->devPrivate = (void *)pPix;
 }

--- a/nx-X11/programs/Xserver/mi/misprite.c
+++ b/nx-X11/programs/Xserver/mi/misprite.c
@@ -84,9 +84,9 @@ static void	    miSpriteSourceValidate(DrawablePtr pDrawable, int x, int y,
 static void	    miSpriteCopyWindow (WindowPtr pWindow,
 					DDXPointRec ptOldOrg,
 					RegionPtr prgnSrc);
-static void	    miSpriteBlockHandler(int i, pointer blockData,
-					 pointer pTimeout,
-					 pointer pReadMask);
+static void	    miSpriteBlockHandler(int i, void * blockData,
+					 void * pTimeout,
+					 void * pReadMask);
 static void	    miSpriteInstallColormap(ColormapPtr pMap);
 static void	    miSpriteStoreColors(ColormapPtr pMap, int ndef,
 					xColorItem *pdef);
@@ -104,7 +104,7 @@ static void	    miSpriteComputeSaved(ScreenPtr pScreen);
     ((pScreen)->field = wrapper)
 
 /*
- * pointer-sprite method table
+ * void *-sprite method table
  */
 
 static Bool miSpriteRealizeCursor(ScreenPtr pScreen, CursorPtr pCursor);
@@ -182,7 +182,7 @@ miSpriteInitialize (pScreen, cursorFuncs, screenFuncs)
 
     if (!miPointerInitialize (pScreen, &miSpritePointerFuncs, screenFuncs,TRUE))
     {
-	xfree ((pointer) pScreenPriv);
+	xfree ((void *) pScreenPriv);
 	return FALSE;
     }
     for (pVisual = pScreen->visuals;
@@ -221,7 +221,7 @@ miSpriteInitialize (pScreen, cursorFuncs, screenFuncs)
     pScreenPriv->colors[MASK_COLOR].red = 0;
     pScreenPriv->colors[MASK_COLOR].green = 0;
     pScreenPriv->colors[MASK_COLOR].blue = 0;
-    pScreen->devPrivates[miSpriteScreenIndex].ptr = (pointer) pScreenPriv;
+    pScreen->devPrivates[miSpriteScreenIndex].ptr = (void *) pScreenPriv;
     
     pScreen->CloseScreen = miSpriteCloseScreen;
     pScreen->GetImage = miSpriteGetImage;
@@ -270,7 +270,7 @@ miSpriteCloseScreen (i, pScreen)
     miSpriteIsUpFALSE (pScreen, pScreenPriv);
     DamageDestroy (pScreenPriv->pDamage);
     
-    xfree ((pointer) pScreenPriv);
+    xfree ((void *) pScreenPriv);
 
     return (*pScreen->CloseScreen) (i, pScreen);
 }
@@ -402,9 +402,9 @@ miSpriteCopyWindow (WindowPtr pWindow, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
 static void
 miSpriteBlockHandler (i, blockData, pTimeout, pReadmask)
     int	i;
-    pointer	blockData;
-    pointer	pTimeout;
-    pointer	pReadmask;
+    void *	blockData;
+    void *	pTimeout;
+    void *	pReadmask;
 {
     ScreenPtr		pScreen = screenInfo.screens[i];
     miSpriteScreenPtr	pPriv;

--- a/nx-X11/programs/Xserver/mi/miwindow.c
+++ b/nx-X11/programs/Xserver/mi/miwindow.c
@@ -579,7 +579,7 @@ miMoveWindow(pWin, x, y, pNextSib, kind)
 static int
 miRecomputeExposures (
     register WindowPtr	pWin,
-    pointer		value) /* must conform to VisitWindowProcPtr */
+    void *		value) /* must conform to VisitWindowProcPtr */
 {
     register ScreenPtr	pScreen;
     RegionPtr	pValid = (RegionPtr)value;
@@ -910,7 +910,7 @@ miSlideAndSizeWindow(pWin, x, y, w, h, pSib)
 		    continue;
 		REGION_INTERSECT(pScreen, pRegion,
 				       &pChild->borderClip, gravitate[g]);
-		TraverseTree (pChild, miRecomputeExposures, (pointer)pRegion);
+		TraverseTree (pChild, miRecomputeExposures, (void *)pRegion);
 	    }
 
 	    /*

--- a/nx-X11/programs/Xserver/miext/cw/cw.c
+++ b/nx-X11/programs/Xserver/miext/cw/cw.c
@@ -64,7 +64,7 @@ cwCopyGC(GCPtr pGCSrc, unsigned long mask, GCPtr pGCDst);
 static void
 cwDestroyGC(GCPtr pGC);
 static void
-cwChangeClip(GCPtr pGC, int type, pointer pvalue, int nrects);
+cwChangeClip(GCPtr pGC, int type, void * pvalue, int nrects);
 static void
 cwCopyClip(GCPtr pgcDst, GCPtr pgcSrc);
 static void
@@ -199,7 +199,7 @@ cwValidateGC(GCPtr pGC, unsigned long stateChanges, DrawablePtr pDrawable)
 	 */
 	
 	(*pBackingGC->funcs->ChangeClip) (pBackingGC, CT_REGION,
-					  (pointer) pCompositeClip, 0);
+					  (void *) pCompositeClip, 0);
 	
 	vals[0] = x_off - pDrawable->x;
 	vals[1] = y_off - pDrawable->y;
@@ -273,7 +273,7 @@ cwDestroyGC(GCPtr pGC)
 }
 
 static void
-cwChangeClip(GCPtr pGC, int type, pointer pvalue, int nrects)
+cwChangeClip(GCPtr pGC, int type, void * pvalue, int nrects)
 {
     cwGCPtr	pPriv = (cwGCPtr)(pGC)->devPrivates[cwGCIndex].ptr;
 
@@ -425,7 +425,7 @@ cwFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
     pGC = GetScratchGC(pDrawable->depth, pScreen);
     v[0].val = GXcopy;
     v[1].val = FillTiled;
-    v[2].ptr = (pointer) pTile;
+    v[2].ptr = (void *) pTile;
     v[3].val = x_off;
     v[4].val = y_off;
     dixChangeGC(NullClient, pGC, (GCFunction | GCFillStyle | GCTile |
@@ -645,7 +645,7 @@ miInitializeCompositeWrapper(ScreenPtr pScreen)
     if (!pScreenPriv)
 	return;
 
-    pScreen->devPrivates[cwScreenIndex].ptr = (pointer)pScreenPriv;
+    pScreen->devPrivates[cwScreenIndex].ptr = (void *)pScreenPriv;
     
     SCREEN_EPILOGUE(pScreen, CloseScreen, cwCloseScreen);
     SCREEN_EPILOGUE(pScreen, GetImage, cwGetImage);
@@ -693,7 +693,7 @@ cwCloseScreen (int i, ScreenPtr pScreen)
 	cwFiniRender(pScreen);
 #endif
 
-    xfree((pointer)pScreenPriv);
+    xfree((void *)pScreenPriv);
 
     return (*pScreen->CloseScreen)(i, pScreen);
 }

--- a/nx-X11/programs/Xserver/miext/cw/cw.h
+++ b/nx-X11/programs/Xserver/miext/cw/cw.h
@@ -47,7 +47,7 @@ typedef struct {
 extern int cwGCIndex;
 
 #define getCwGC(pGC)	((cwGCPtr)(pGC)->devPrivates[cwGCIndex].ptr)
-#define setCwGC(pGC,p)	((pGC)->devPrivates[cwGCIndex].ptr = (pointer) (p))
+#define setCwGC(pGC,p)	((pGC)->devPrivates[cwGCIndex].ptr = (void *) (p))
 
 /*
  * One of these structures is allocated per Picture that gets used with a
@@ -61,7 +61,7 @@ typedef struct {
 } cwPictureRec, *cwPicturePtr;
 
 #define getCwPicture(pPicture)	((cwPicturePtr)(pPicture)->devPrivates[cwPictureIndex].ptr)
-#define setCwPicture(pPicture,p) ((pPicture)->devPrivates[cwPictureIndex].ptr = (pointer) (p))
+#define setCwPicture(pPicture,p) ((pPicture)->devPrivates[cwPictureIndex].ptr = (void *) (p))
 
 extern int  cwPictureIndex;
 
@@ -69,7 +69,7 @@ extern int cwWindowIndex;
 
 #define cwWindowPrivate(pWindow)    ((pWindow)->devPrivates[cwWindowIndex].ptr)
 #define getCwPixmap(pWindow)	    ((PixmapPtr) cwWindowPrivate(pWindow))
-#define setCwPixmap(pWindow,pPixmap) (cwWindowPrivate(pWindow) = (pointer) (pPixmap))
+#define setCwPixmap(pWindow,pPixmap) (cwWindowPrivate(pWindow) = (void *) (pPixmap))
 
 #define cwDrawableIsRedirWindow(pDraw)					\
 	((pDraw)->type == DRAWABLE_WINDOW &&				\

--- a/nx-X11/programs/Xserver/miext/cw/cw_ops.c
+++ b/nx-X11/programs/Xserver/miext/cw/cw_ops.c
@@ -96,10 +96,10 @@ static void cwImageText16(DrawablePtr pDst, GCPtr pGC, int x, int y,
 			  int count, unsigned short *chars);
 static void cwImageGlyphBlt(DrawablePtr pDst, GCPtr pGC, int x, int y,
 			    unsigned int nglyph, CharInfoPtr *ppci,
-			    pointer pglyphBase);
+			    void * pglyphBase);
 static void cwPolyGlyphBlt(DrawablePtr pDst, GCPtr pGC, int x, int y,
 			   unsigned int nglyph, CharInfoPtr *ppci,
-			   pointer pglyphBase);
+			   void * pglyphBase);
 static void cwPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDst,
 			 int w, int h, int x, int y);
 
@@ -422,7 +422,7 @@ cwImageText16(DrawablePtr pDst, GCPtr pGC, int x, int y, int count,
 
 static void
 cwImageGlyphBlt(DrawablePtr pDst, GCPtr pGC, int x, int y, unsigned int nglyph,
-		CharInfoPtr *ppci, pointer pglyphBase)
+		CharInfoPtr *ppci, void * pglyphBase)
 {
     SETUP_BACKING_DST(pDst, pGC);
 
@@ -438,7 +438,7 @@ cwImageGlyphBlt(DrawablePtr pDst, GCPtr pGC, int x, int y, unsigned int nglyph,
 
 static void
 cwPolyGlyphBlt(DrawablePtr pDst, GCPtr pGC, int x, int y, unsigned int nglyph,
-	       CharInfoPtr *ppci, pointer pglyphBase)
+	       CharInfoPtr *ppci, void * pglyphBase)
 {
     SETUP_BACKING_DST(pDst, pGC);
 

--- a/nx-X11/programs/Xserver/miext/damage/damage.c
+++ b/nx-X11/programs/Xserver/miext/damage/damage.c
@@ -327,7 +327,7 @@ static void damageValidateGC(GCPtr, unsigned long, DrawablePtr);
 static void damageChangeGC(GCPtr, unsigned long);
 static void damageCopyGC(GCPtr, unsigned long, GCPtr);
 static void damageDestroyGC(GCPtr);
-static void damageChangeClip(GCPtr, int, pointer, int);
+static void damageChangeClip(GCPtr, int, void *, int);
 static void damageDestroyClip(GCPtr);
 static void damageCopyClip(GCPtr, GCPtr);
 
@@ -440,7 +440,7 @@ damageCopyGC (GCPtr	    pGCSrc,
 static void
 damageChangeClip (GCPtr	    pGC,
 		  int	    type,
-		  pointer   pvalue,
+		  void      *pvalue,
 		  int	    nrects)
 {
     DAMAGE_GC_FUNC_PROLOGUE (pGC);
@@ -1453,7 +1453,7 @@ damageImageGlyphBlt(DrawablePtr	    pDrawable,
 		    int		    y,
 		    unsigned int    nglyph,
 		    CharInfoPtr	    *ppci,
-		    pointer	    pglyphBase)
+		    void *	    pglyphBase)
 {
     DAMAGE_GC_OP_PROLOGUE(pGC, pDrawable);
     damageDamageChars (pDrawable, pGC->font, x + pDrawable->x, y + pDrawable->y,
@@ -1470,7 +1470,7 @@ damagePolyGlyphBlt(DrawablePtr	pDrawable,
 		   int		y,
 		   unsigned int	nglyph,
 		   CharInfoPtr	*ppci,
-		   pointer	pglyphBase)
+		   void *	pglyphBase)
 {
     DAMAGE_GC_OP_PROLOGUE(pGC, pDrawable);
     damageDamageChars (pDrawable, pGC->font, x + pDrawable->x, y + pDrawable->y,
@@ -1801,7 +1801,7 @@ DamageSetup (ScreenPtr pScreen)
     }
 #endif
 
-    pScreen->devPrivates[damageScrPrivateIndex].ptr = (pointer) pScrPriv;
+    pScreen->devPrivates[damageScrPrivateIndex].ptr = (void *) pScrPriv;
     return TRUE;
 }
 

--- a/nx-X11/programs/Xserver/miext/damage/damagestr.h
+++ b/nx-X11/programs/Xserver/miext/damage/damagestr.h
@@ -93,7 +93,7 @@ extern int damageWinPrivateIndex;
     ((DamagePtr) (pPix)->devPrivates[damagePixPrivateIndex].ptr)
 
 #define damgeSetPixPriv(pPix,v) \
-    ((pPix)->devPrivates[damagePixPrivateIndex].ptr = (pointer ) (v))
+    ((pPix)->devPrivates[damagePixPrivateIndex].ptr = (void * ) (v))
 
 #define damagePixPriv(pPix) \
     DamagePtr	    pDamage = damageGetPixPriv(pPix)

--- a/nx-X11/programs/Xserver/os/WaitFor.c
+++ b/nx-X11/programs/Xserver/os/WaitFor.c
@@ -152,7 +152,7 @@ struct _OsTimerRec {
     OsTimerPtr		next;
     CARD32		expires;
     OsTimerCallback	callback;
-    pointer		arg;
+    void *		arg;
 };
 
 static void DoTimer(OsTimerPtr timer, CARD32 now, OsTimerPtr *prev);
@@ -254,7 +254,7 @@ WaitForSomething(int *pClientsReady)
 	}
 	SmartScheduleIdle = TRUE;
 #endif
-	BlockHandler((pointer)&wt, (pointer)&LastSelectMask);
+	BlockHandler((void *)&wt, (void *)&LastSelectMask);
 	if (NewOutputPending)
 	    FlushAllOutput();
 #ifdef XTESTEXT1
@@ -386,7 +386,7 @@ WaitForSomething(int *pClientsReady)
         }
 #endif
 	selecterr = GetErrno();
-	WakeupHandler(i, (pointer)&LastSelectMask);
+	WakeupHandler(i, (void *)&LastSelectMask);
 #ifdef XTESTEXT1
 	if (playback_on) {
 	    i = XTestProcessInputAction (i, &waittime);
@@ -515,7 +515,7 @@ WaitForSomething(int *pClientsReady)
 	    XFD_ANDSET(&tmp_set, &LastSelectMask, &WellKnownConnections);
 	    if (XFD_ANYSET(&tmp_set))
 		QueueWorkProc(EstablishNewConnections, NULL,
-			      (pointer)&LastSelectMask);
+		              (void *)&LastSelectMask);
 #ifdef DPMSExtension
 	    if (XFD_ANYSET (&devicesReadable) && (DPMSPowerLevel != DPMSModeOn))
 		DPMSSet(DPMSModeOn);
@@ -643,7 +643,7 @@ DoTimer(OsTimerPtr timer, CARD32 now, OsTimerPtr *prev)
 
 OsTimerPtr
 TimerSet(OsTimerPtr timer, int flags, CARD32 millis, 
-    OsTimerCallback func, pointer arg)
+    OsTimerCallback func, void * arg)
 {
     register OsTimerPtr *prev;
     CARD32 now = GetTimeInMillis();
@@ -755,7 +755,7 @@ TimerInit(void)
 }
 
 static CARD32
-ScreenSaverTimeoutExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+ScreenSaverTimeoutExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
     INT32 timeout = now - lastDeviceEventTime.milliseconds;
 
@@ -805,7 +805,7 @@ static OsTimerPtr DPMSSuspendTimer = NULL;
 static OsTimerPtr DPMSOffTimer = NULL;
 
 static CARD32
-DPMSStandbyTimerExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+DPMSStandbyTimerExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
     INT32 timeout = now - lastDeviceEventTime.milliseconds;
 
@@ -820,7 +820,7 @@ DPMSStandbyTimerExpire(OsTimerPtr timer,CARD32 now,pointer arg)
 }
 
 static CARD32
-DPMSSuspendTimerExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+DPMSSuspendTimerExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
     INT32 timeout = now - lastDeviceEventTime.milliseconds;
 
@@ -835,7 +835,7 @@ DPMSSuspendTimerExpire(OsTimerPtr timer,CARD32 now,pointer arg)
 }
 
 static CARD32
-DPMSOffTimerExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+DPMSOffTimerExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
     INT32 timeout = now - lastDeviceEventTime.milliseconds;
 

--- a/nx-X11/programs/Xserver/os/access.c
+++ b/nx-X11/programs/Xserver/os/access.c
@@ -226,14 +226,14 @@ Bool defeatAccessControl = FALSE;
 
 static int ConvertAddr(struct sockaddr * /*saddr*/,
 		       int * /*len*/,
-		       pointer * /*addr*/);
+		       void ** /*addr*/);
 
 static int CheckAddr(int /*family*/,
-		     pointer /*pAddr*/,
+		     void * /*pAddr*/,
 		     unsigned /*length*/);
 
 static Bool NewHost(int /*family*/,
-		    pointer /*addr*/,
+		    void * /*addr*/,
 		    int /*len*/,
 		    int /* addingLocalHosts */);
 
@@ -270,7 +270,7 @@ static int LocalHostRequested = FALSE;
 static int UsingXdmcp = FALSE;
 
 /* FamilyServerInterpreted implementation */
-static Bool siAddrMatch(int family, pointer addr, int len, HOST *host, 
+static Bool siAddrMatch(int family, void * addr, int len, HOST *host, 
 	ClientPtr client);
 static int  siCheckAddr(const char *addrString, int length);
 static void siTypesInitialize(void);
@@ -302,7 +302,7 @@ DisableLocalHost (void)
 	LocalHostEnabled = FALSE;
     for (self = selfhosts; self; self = self->next) {
       if (!self->requested)		/* Fix for XFree86 bug #156 */
-	(void) RemoveHost ((ClientPtr)NULL, self->family, self->len, (pointer)self->addr);
+	(void) RemoveHost ((ClientPtr)NULL, self->family, self->len, (void *)self->addr);
     }
 }
 
@@ -441,7 +441,7 @@ DefineSelf (int fd)
 	}
 
 	len = sizeof(struct sockaddr_in);
-	family = ConvertAddr (IA_SIN(&ifaddr), &len, (pointer *)&addr);
+	family = ConvertAddr (IA_SIN(&ifaddr), &len, (void **)&addr);
         if (family == -1 || family == FamilyLocal)
 	    continue;
         for (host = selfhosts;
@@ -602,7 +602,7 @@ DefineSelf (int fd)
 	default:
 	    goto DefineLocalHost;
 	}
-	family = ConvertAddr ( &(saddr.sa), &len, (pointer *)&addr);
+	family = ConvertAddr ( &(saddr.sa), &len, (void **)&addr);
 	if ( family != -1 && family != FamilyLocal )
 	{
 	    for (host = selfhosts;
@@ -812,7 +812,7 @@ DefineSelf (int fd)
 #define IFR_IFR_NAME ifr->ifr_name
 #endif
 
-    if (ifioctl (fd, IFC_IOCTL_REQ, (pointer) &ifc) < 0)
+    if (ifioctl (fd, IFC_IOCTL_REQ, (void *) &ifc) < 0)
         Error ("Getting interface configuration (4)");
 
     cplim = (char *) IFC_IFC_REQ + IFC_IFC_LEN;
@@ -822,7 +822,7 @@ DefineSelf (int fd)
 	ifr = (ifr_type *) cp;
 	len = ifraddr_size (IFR_IFR_ADDR);
 	family = ConvertAddr ((struct sockaddr *) &IFR_IFR_ADDR, 
-	  			&len, (pointer *)&addr);
+	  			&len, (void **)&addr);
 #ifdef DNETCONN
 	/*
 	 * DECnet was handled up above.
@@ -943,13 +943,13 @@ DefineSelf (int fd)
 	    	struct ifreq    broad_req;
     
 	    	broad_req = *ifr;
-		if (ifioctl (fd, SIOCGIFFLAGS, (pointer) &broad_req) != -1 &&
+		if (ifioctl (fd, SIOCGIFFLAGS, (void *) &broad_req) != -1 &&
 		    (broad_req.ifr_flags & IFF_BROADCAST) &&
 		    (broad_req.ifr_flags & IFF_UP)
 		    )
 		{
 		    broad_req = *ifr;
-		    if (ifioctl (fd, SIOCGIFBRDADDR, (pointer) &broad_req) != -1)
+		    if (ifioctl (fd, SIOCGIFBRDADDR, (void *) &broad_req) != -1)
 			broad_addr = broad_req.ifr_addr;
 		    else
 			continue;
@@ -980,7 +980,7 @@ DefineSelf (int fd)
 	    continue;
 #endif /* DNETCONN */
 	len = sizeof(*(ifr->ifa_addr));
-	family = ConvertAddr(ifr->ifa_addr, &len, (pointer *)&addr);
+	family = ConvertAddr(ifr->ifa_addr, &len, (void **)&addr);
 	if (family == -1 || family == FamilyLocal) 
 	    continue;
 #if defined(IPv6) && defined(AF_INET6)
@@ -1104,13 +1104,13 @@ DefineSelf (int fd)
 
 #ifdef XDMCP
 void
-AugmentSelf(pointer from, int len)
+AugmentSelf(void * from, int len)
 {
     int family;
-    pointer addr;
+    void * addr;
     register HOST *host;
 
-    family = ConvertAddr(from, &len, (pointer *)&addr);
+    family = ConvertAddr(from, &len, (void **)&addr);
     if (family == -1 || family == FamilyLocal)
 	return;
     for (host = selfhosts; host; host = host->next)
@@ -1175,7 +1175,7 @@ ResetHosts (char *display)
     krb5_data		kbuf;
 #endif
     int			family = 0;
-    pointer		addr;
+    void		*addr;
     int 		len;
 
     siTypesInitialize();
@@ -1284,7 +1284,7 @@ ResetHosts (char *display)
 		/* node was specified by name */
 		saddr.sa.sa_family = np->n_addrtype;
 		len = sizeof(saddr.sa);
-		if (ConvertAddr (&saddr.sa, &len, (pointer *)&addr) == FamilyDECnet)
+		if (ConvertAddr (&saddr.sa, &len, (void **)&addr) == FamilyDECnet)
 		{
 		    bzero ((char *) &dnaddr, sizeof (dnaddr));
 		    dnaddr.a_len = np->n_length;
@@ -1293,7 +1293,7 @@ ResetHosts (char *display)
 		}
     	    }
 	    if (dnaddrp)
-		(void) NewHost(FamilyDECnet, (pointer)dnaddrp,
+		(void) NewHost(FamilyDECnet, (void *)dnaddrp,
 			(int)(dnaddrp->a_len + sizeof(dnaddrp->a_len)), FALSE);
     	}
 	else
@@ -1329,7 +1329,7 @@ ResetHosts (char *display)
 		if (getaddrinfo(hostname, NULL, NULL, &addresses) == 0) {
 		    for (a = addresses ; a != NULL ; a = a->ai_next) {
 			len = a->ai_addrlen;
-			f = ConvertAddr(a->ai_addr,&len,(pointer *)&addr);
+			f = ConvertAddr(a->ai_addr,&len,(void **)&addr);
 			if ( (family == f) || 
 			     ((family == FamilyWild) && (f != -1)) ) {
 			    NewHost(f, addr, len, FALSE);
@@ -1351,16 +1351,16 @@ ResetHosts (char *display)
 	    {
     		saddr.sa.sa_family = hp->h_addrtype;
 		len = sizeof(saddr.sa);
-    		if ((family = ConvertAddr (&saddr.sa, &len, (pointer *)&addr)) != -1)
+		if ((family = ConvertAddr (&saddr.sa, &len, (void **)&addr)) != -1)
 		{
 #ifdef h_addr				/* new 4.3bsd version of gethostent */
 		    char **list;
 
 		    /* iterate over the addresses */
 		    for (list = hp->h_addr_list; *list; list++)
-			(void) NewHost (family, (pointer)*list, len, FALSE);
+			(void) NewHost (family, (void *)*list, len, FALSE);
 #else
-    		    (void) NewHost (family, (pointer)hp->h_addr, len, FALSE);
+		    (void) NewHost (family, (void *)hp->h_addr, len, FALSE);
 #endif
 		}
     	    }
@@ -1378,7 +1378,7 @@ Bool LocalClient(ClientPtr client)
 {
     int    		alen, family, notused;
     Xtransaddr		*from = NULL;
-    pointer		addr;
+    void		*addr;
     register HOST	*host;
 
 #ifdef XCSECURITY
@@ -1398,7 +1398,7 @@ Bool LocalClient(ClientPtr client)
 	&notused, &alen, &from))
     {
 	family = ConvertAddr ((struct sockaddr *) from,
-	    &alen, (pointer *)&addr);
+	    &alen, (void **)&addr);
 	if (family == -1)
 	{
 	    xfree ((char *) from);
@@ -1546,7 +1546,7 @@ int
 AddHost (ClientPtr	client,
 	 int            family,
 	 unsigned       length,        /* of bytes in pAddr */
-	 pointer        pAddr)
+	 void           *pAddr)
 {
     int			len;
 
@@ -1596,8 +1596,8 @@ ForEachHostInFamily (int	    family,
 		     Bool    (*func)(
 			 unsigned char * /* addr */,
 			 short           /* len */,
-			 pointer         /* closure */),
-		     pointer closure)
+			 void *         /* closure */),
+		     void * closure)
 {
     HOST    *host;
 
@@ -1611,7 +1611,7 @@ ForEachHostInFamily (int	    family,
  * called when starting or resetting the server */
 static Bool
 NewHost (int		family,
-	 pointer	addr,
+	 void		*addr,
 	 int		len,
 	 int		addingLocalHosts)
 {
@@ -1648,7 +1648,7 @@ RemoveHost (
     ClientPtr		client,
     int                 family,
     unsigned            length,        /* of bytes in pAddr */
-    pointer             pAddr)
+    void                *pAddr)
 {
     int			len;
     register HOST	*host, **prev;
@@ -1703,7 +1703,7 @@ RemoveHost (
 /* Get all hosts in the access control list */
 int
 GetHosts (
-    pointer		*data,
+    void *		*data,
     int			*pnHosts,
     int			*pLen,
     BOOL		*pEnabled)
@@ -1726,7 +1726,7 @@ GetHosts (
     }
     if (n)
     {
-        *data = ptr = (pointer) xalloc (n);
+        *data = ptr = (void *) xalloc (n);
 	if (!ptr)
 	{
 	    return(BadAlloc);
@@ -1756,7 +1756,7 @@ GetHosts (
 static int
 CheckAddr (
     int			family,
-    pointer		pAddr,
+    void *		pAddr,
     unsigned		length)
 {
     int	len;
@@ -1813,12 +1813,12 @@ InvalidHost (
     ClientPtr			client)
 {
     int 			family;
-    pointer			addr;
+    void			*addr;
     register HOST 		*selfhost, *host;
 
     if (!AccessEnabled)   /* just let them in */
         return(0);    
-    family = ConvertAddr (saddr, &len, (pointer *)&addr);
+    family = ConvertAddr (saddr, &len, (void **)&addr);
     if (family == -1)
         return 1;
     if (family == FamilyLocal)
@@ -1860,7 +1860,7 @@ static int
 ConvertAddr (
     register struct sockaddr	*saddr,
     int				*len,
-    pointer			*addr)
+    void			**addr)
 {
     if (*len == 0)
         return (FamilyLocal);
@@ -1878,7 +1878,7 @@ ConvertAddr (
             return FamilyLocal;
 #endif
         *len = sizeof (struct in_addr);
-        *addr = (pointer) &(((struct sockaddr_in *) saddr)->sin_addr);
+        *addr = (void *) &(((struct sockaddr_in *) saddr)->sin_addr);
         return FamilyInternet;
 #if defined(IPv6) && defined(AF_INET6)
     case AF_INET6: 
@@ -1886,11 +1886,11 @@ ConvertAddr (
 	struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *) saddr;
 	if (IN6_IS_ADDR_V4MAPPED(&(saddr6->sin6_addr))) {
 	    *len = sizeof (struct in_addr);
-	    *addr = (pointer) &(saddr6->sin6_addr.s6_addr[12]);
+	    *addr = (void *) &(saddr6->sin6_addr.s6_addr[12]);
 	    return FamilyInternet;
 	} else {
 	    *len = sizeof (struct in6_addr);
-	    *addr = (pointer) &(saddr6->sin6_addr);
+	    *addr = (void *) &(saddr6->sin6_addr);
 	    return FamilyInternet6;
 	}
     }
@@ -1901,7 +1901,7 @@ ConvertAddr (
 	{
 	    struct sockaddr_dn *sdn = (struct sockaddr_dn *) saddr;
 	    *len = sdn->sdn_nodeaddrl + sizeof(sdn->sdn_nodeaddrl);
-	    *addr = (pointer) &(sdn->sdn_add);
+	    *addr = (void *) &(sdn->sdn_add);
 	}
         return FamilyDECnet;
 #endif
@@ -1953,7 +1953,7 @@ GetAccessControl(void)
  * future to enable loading additional host types, but that was not done for
  * the initial implementation.
  */
-typedef Bool (*siAddrMatchFunc)(int family, pointer addr, int len, 
+typedef Bool (*siAddrMatchFunc)(int family, void * addr, int len, 
   const char *siAddr, int siAddrlen, ClientPtr client, void *siTypePriv);
 typedef int  (*siCheckAddrFunc)(const char *addrString, int length, 
   void *siTypePriv);
@@ -2005,7 +2005,7 @@ siTypeAdd(const char *typeName, siAddrMatchFunc addrMatch,
 
 /* Checks to see if a host matches a server-interpreted host entry */
 static Bool 
-siAddrMatch(int family, pointer addr, int len, HOST *host, ClientPtr client)
+siAddrMatch(int family, void * addr, int len, HOST *host, ClientPtr client)
 {
     Bool matches = FALSE;
     struct siType *s;
@@ -2105,7 +2105,7 @@ siCheckAddr(const char *addrString, int length)
 #endif
 
 static Bool 
-siHostnameAddrMatch(int family, pointer addr, int len,
+siHostnameAddrMatch(int family, void * addr, int len,
   const char *siAddr, int siAddrLen, ClientPtr client, void *typePriv)
 {
     Bool res = FALSE;
@@ -2120,7 +2120,7 @@ siHostnameAddrMatch(int family, pointer addr, int len,
 	struct addrinfo *addresses;
 	struct addrinfo *a;
 	int f, hostaddrlen;
-	pointer hostaddr;
+	void * hostaddr;
 
 	if (siAddrLen >= sizeof(hostname)) 
 	    return FALSE;
@@ -2149,7 +2149,7 @@ siHostnameAddrMatch(int family, pointer addr, int len,
 #endif
 	char hostname[SI_HOSTNAME_MAXLEN];
 	int f, hostaddrlen;
-	pointer hostaddr;
+	void * hostaddr;
 	const char **addrlist;
 
 	if (siAddrLen >= sizeof(hostname)) 
@@ -2249,7 +2249,7 @@ siHostnameCheckAddr(const char *valueString, int length, void *typePriv)
 #define SI_IPv6_MAXLEN INET6_ADDRSTRLEN
 
 static Bool 
-siIPv6AddrMatch(int family, pointer addr, int len,
+siIPv6AddrMatch(int family, void * addr, int len,
   const char *siAddr, int siAddrlen, ClientPtr client, void *typePriv)
 {
     struct in6_addr addr6;
@@ -2367,7 +2367,7 @@ siLocalCredGetId(const char *addr, int len, siLocalCredPrivPtr lcPriv, int *id)
 }
 
 static Bool 
-siLocalCredAddrMatch(int family, pointer addr, int len,
+siLocalCredAddrMatch(int family, void * addr, int len,
   const char *siAddr, int siAddrlen, ClientPtr client, void *typePriv)
 {
     int connUid, connGid, *connSuppGids, connNumSuppGids, siAddrId;

--- a/nx-X11/programs/Xserver/os/connection.c
+++ b/nx-X11/programs/Xserver/os/connection.c
@@ -142,7 +142,7 @@ extern __const__ int _nfiles;
 #endif
 #endif
 #endif /* WIN32 */
-#include "misc.h"		/* for typedef of pointer */
+#include "misc.h"
 #include "osdep.h"
 #include <X11/Xpoll.h>
 #include "opaque.h"
@@ -874,7 +874,7 @@ AllocNewConnection (XtransConnInfo trans_conn, int fd, CARD32 conn_time)
     oc->Close = Close;
     oc->largereq = (ConnectionInputPtr) NULL;
 #endif
-    if (!(client = NextAvailableClient((pointer)oc)))
+    if (!(client = NextAvailableClient((void *)oc)))
     {
 	xfree (oc);
 	return NullClient;
@@ -950,7 +950,7 @@ LbxProxyConnection (ClientPtr client, LbxProxyPtr proxy)
 
 /*ARGSUSED*/
 Bool
-EstablishNewConnections(ClientPtr clientUnused, pointer closure)
+EstablishNewConnections(ClientPtr clientUnused, void * closure)
 {
     fd_set  readyconnections;     /* set of listeners that are ready */
     int curconn;                  /* fd of listener that's ready */
@@ -1215,7 +1215,7 @@ CloseDownConnection(ClientPtr client)
     FreeOsBuffers(oc);
     xfree(oc);
 #endif
-    client->osPrivate = (pointer)NULL;
+    client->osPrivate = (void *)NULL;
     if (auditTrailLevel > 1)
 	AuditF("client %d disconnected\n", client->index);
 }

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -511,7 +511,7 @@ ReadRequestFromClient(ClientPtr client)
 	client->req_len -= (sizeof(xBigReq) - sizeof(xReq)) >> 2;
     }
 #endif
-    client->requestBuffer = (pointer)oci->bufptr;
+    client->requestBuffer = (void *)oci->bufptr;
 #ifdef DEBUG_COMMUNICATION
     {
 	xReq *req = client->requestBuffer;
@@ -998,7 +998,7 @@ WriteToClient (ClientPtr who, int count, char *buf)
 	    who->replyBytesRemaining -= count + padBytes;
 	    replyinfo.startOfReply = FALSE;
 	    replyinfo.bytesRemaining = who->replyBytesRemaining;
-	    CallCallbacks((&ReplyCallback), (pointer)&replyinfo);
+	    CallCallbacks((&ReplyCallback), (void *)&replyinfo);
 	}
 	else if (who->clientState == ClientStateRunning
 		 && buf[0] == X_Reply)
@@ -1013,7 +1013,7 @@ WriteToClient (ClientPtr who, int count, char *buf)
 	    bytesleft = (replylen * 4) + SIZEOF(xReply) - count - padBytes;
 	    replyinfo.startOfReply = TRUE;
 	    replyinfo.bytesRemaining = who->replyBytesRemaining = bytesleft;
-	    CallCallbacks((&ReplyCallback), (pointer)&replyinfo);
+	    CallCallbacks((&ReplyCallback), (void *)&replyinfo);
 	} 	                      
     }
 #ifdef DEBUG_COMMUNICATION

--- a/nx-X11/programs/Xserver/os/k5auth.c
+++ b/nx-X11/programs/Xserver/os/k5auth.c
@@ -79,7 +79,7 @@ static char kerror[256];
  * extract session key from a credentials struct
  */
 krb5_error_code tgt_keyproc(keyprocarg, principal, vno, key)
-    krb5_pointer keyprocarg;
+    krb5_void * keyprocarg;
     krb5_principal principal;
     krb5_kvno vno;
     krb5_keyblock **key;
@@ -237,15 +237,15 @@ XID K5Check(data_length, data, client, reason)
     client->clientState = ClientStateAuthenticating;
     if (ccname)
     {
-	((OsCommPtr)client->osPrivate)->authstate.srvcreds = (pointer)creds; /* save tgt creds */
+	((OsCommPtr)client->osPrivate)->authstate.srvcreds = (void *)creds; /* save tgt creds */
 	((OsCommPtr)client->osPrivate)->authstate.ktname = NULL;
 	((OsCommPtr)client->osPrivate)->authstate.srvname = NULL;
     }
     if (srvname)
     {
 	((OsCommPtr)client->osPrivate)->authstate.srvcreds = NULL;
-	((OsCommPtr)client->osPrivate)->authstate.ktname = (pointer)ktname;
-	((OsCommPtr)client->osPrivate)->authstate.srvname = (pointer)srvname;
+	((OsCommPtr)client->osPrivate)->authstate.ktname = (void *)ktname;
+	((OsCommPtr)client->osPrivate)->authstate.srvname = (void *)srvname;
     }
     ((OsCommPtr)client->osPrivate)->authstate.stageno = 1; /* next stage is 1 */
     return krb5_id;
@@ -476,7 +476,7 @@ int k5_stage1(client)
     /*
      * Now check to see if the principal we got is one that we want to let in
      */
-    if (ForEachHostInFamily(FamilyKrb5Principal, k5_cmpenc, (pointer)&buf))
+    if (ForEachHostInFamily(FamilyKrb5Principal, k5_cmpenc, (void *)&buf))
     {
 	free(buf.data);
 	/*

--- a/nx-X11/programs/Xserver/os/log.c
+++ b/nx-X11/programs/Xserver/os/log.c
@@ -531,7 +531,7 @@ AuditF(const char * f, ...)
 }
 
 static CARD32
-AuditFlush(OsTimerPtr timer, CARD32 now, pointer arg)
+AuditFlush(OsTimerPtr timer, CARD32 now, void * arg)
 {
     char *prefix;
 

--- a/nx-X11/programs/Xserver/os/osdep.h
+++ b/nx-X11/programs/Xserver/os/osdep.h
@@ -151,10 +151,10 @@ typedef struct _connectionOutput {
 #ifdef K5AUTH
 typedef struct _k5_state {
     int		stageno;	/* current stage of auth protocol */
-    pointer	srvcreds;	/* server credentials */
-    pointer	srvname;	/* server principal name */
-    pointer	ktname;		/* key table: principal-key pairs */
-    pointer	skey;		/* session key */
+    void	*srvcreds;	/* server credentials */
+    void	*srvname;	/* server principal name */
+    void	*ktname;	/* key table: principal-key pairs */
+    void	*skey;		/* session key */
 }           k5_state;
 #endif
 

--- a/nx-X11/programs/Xserver/os/rpcauth.c
+++ b/nx-X11/programs/Xserver/os/rpcauth.c
@@ -132,7 +132,7 @@ static Bool
 CheckNetName (
     unsigned char    *addr,
     short	    len,
-    pointer	    closure
+    void *	    closure
 )
 {
     return (len == strlen ((char *) closure) &&
@@ -176,7 +176,7 @@ int
 SecureRPCAdd (unsigned short data_length, char *data, XID id)
 {
     if (data_length)
-	AddHost ((pointer) 0, FamilyNetname, data_length, data);
+	AddHost ((void *) 0, FamilyNetname, data_length, data);
     rpc_id = id;
     return 1;
 }

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -598,7 +598,7 @@ GetTimeInMillis(void)
 #endif
 
 void
-AdjustWaitForDelay (pointer waitTime, unsigned long newdelay)
+AdjustWaitForDelay (void * waitTime, unsigned long newdelay)
 {
     static struct timeval   delay_val;
     struct timeval	    **wt = (struct timeval **) waitTime;
@@ -1299,7 +1299,7 @@ ExpandCommandLine(int *pargc, char ***pargv)
 /* Implement a simple-minded font authorization scheme.  The authorization
    name is "hp-hostname-1", the contents are simply the host name. */
 int
-set_font_authorizations(char **authorizations, int *authlen, pointer client)
+set_font_authorizations(char **authorizations, int *authlen, void * client)
 {
 #define AUTHORIZATION_NAME "hp-hostname-1"
 #if defined(TCPCONN) || defined(STREAMSCONN)
@@ -1380,7 +1380,7 @@ set_font_authorizations(char **authorizations, int *authlen, pointer client)
 void * 
 Xalloc(unsigned long amount)
 {
-    register pointer  ptr;
+    register void *  ptr;
 	
     if ((long)amount <= 0) {
 	return (unsigned long *)NULL;
@@ -1392,7 +1392,7 @@ Xalloc(unsigned long amount)
 	((random() % MEM_FAIL_SCALE) < Memory_fail))
 	return (unsigned long *)NULL;
 #endif
-    if ((ptr = (pointer)malloc(amount))) {
+    if ((ptr = (void *)malloc(amount))) {
 	return (unsigned long *)ptr;
     }
     if (Must_have_memory)
@@ -1408,7 +1408,7 @@ Xalloc(unsigned long amount)
 void *
 XNFalloc(unsigned long amount)
 {
-    register pointer ptr;
+    register void * ptr;
 
     if ((long)amount <= 0)
     {
@@ -1416,7 +1416,7 @@ XNFalloc(unsigned long amount)
     }
     /* aligned extra on long word boundary */
     amount = (amount + (sizeof(long) - 1)) & ~(sizeof(long) - 1);
-    ptr = (pointer)malloc(amount);
+    ptr = (void *)malloc(amount);
     if (!ptr)
     {
         FatalError("Out of memory");
@@ -1461,7 +1461,7 @@ XNFcalloc(unsigned long amount)
  *****************/
 
 void *
-Xrealloc(pointer ptr, unsigned long amount)
+Xrealloc(void * ptr, unsigned long amount)
 {
 #ifdef MEMBUG
     if (!Must_have_memory && Memory_fail &&
@@ -1476,9 +1476,9 @@ Xrealloc(pointer ptr, unsigned long amount)
     }
     amount = (amount + (sizeof(long) - 1)) & ~(sizeof(long) - 1);
     if (ptr)
-        ptr = (pointer)realloc((char *)ptr, amount);
+        ptr = (void *)realloc((char *)ptr, amount);
     else
-	ptr = (pointer)malloc(amount);
+	ptr = (void *)malloc(amount);
     if (ptr)
         return (unsigned long *)ptr;
     if (Must_have_memory)
@@ -1492,9 +1492,9 @@ Xrealloc(pointer ptr, unsigned long amount)
  *****************/
 
 void *
-XNFrealloc(pointer ptr, unsigned long amount)
+XNFrealloc(void * ptr, unsigned long amount)
 {
-    if (( ptr = (pointer)Xrealloc( ptr, amount ) ) == NULL)
+    if (( ptr = (void *)Xrealloc( ptr, amount ) ) == NULL)
     {
 	if ((long)amount > 0)
             FatalError( "Out of memory" );
@@ -1508,7 +1508,7 @@ XNFrealloc(pointer ptr, unsigned long amount)
  *****************/    
 
 void
-Xfree(pointer ptr)
+Xfree(void * ptr)
 {
     if (ptr)
 	free((char *)ptr); 
@@ -1816,7 +1816,7 @@ static struct pid {
     int pid;
 } *pidlist;
 
-pointer
+void *
 Popen(char *command, char *type)
 {
     struct pid *cur;
@@ -1953,7 +1953,7 @@ Popen(char *command, char *type)
 }
 
 /* fopen that drops privileges */
-pointer
+void *
 Fopen(char *file, char *type)
 {
     FILE *iop;
@@ -2047,7 +2047,7 @@ Fopen(char *file, char *type)
 }
 
 int
-Pclose(pointer iop)
+Pclose(void * iop)
 {
     struct pid *cur, *last;
     int pstat;
@@ -2087,7 +2087,7 @@ Pclose(pointer iop)
 }
 
 int 
-Fclose(pointer iop)
+Fclose(void * iop)
 {
 #ifdef HAS_SAVED_IDS_AND_SETEUID
     return fclose(iop);

--- a/nx-X11/programs/Xserver/os/xalloc.c
+++ b/nx-X11/programs/Xserver/os/xalloc.c
@@ -466,10 +466,10 @@ Xalloc (unsigned long amount)
  * "no failure" realloc, alternate interface to Xalloc w/o Must_have_memory
  *****************/
 
-pointer
+void *
 XNFalloc (unsigned long amount)
 {
-    register pointer ptr;
+    register void * ptr;
 
     /* zero size requested */
     if (amount == 0) {
@@ -499,10 +499,10 @@ XNFalloc (unsigned long amount)
  * Xcalloc
  *****************/
 
-pointer
+void *
 Xcalloc (unsigned long amount)
 {
-    pointer ret;
+    void * ret;
 
     ret = Xalloc (amount);
     if (ret != 0
@@ -520,7 +520,7 @@ Xcalloc (unsigned long amount)
 void *
 XNFcalloc (unsigned long amount)
 {
-    pointer ret;
+    void * ret;
 
     ret = XNFalloc (amount);
     if (ret != 0
@@ -537,7 +537,7 @@ XNFcalloc (unsigned long amount)
  *****************/
 
 void *
-Xrealloc (pointer ptr, unsigned long amount)
+Xrealloc (void * ptr, unsigned long amount)
 {
     register unsigned long *new_ptr;
 
@@ -614,9 +614,9 @@ Xrealloc (pointer ptr, unsigned long amount)
  *****************/
 
 void *
-XNFrealloc (pointer ptr, unsigned long amount)
+XNFrealloc (void * ptr, unsigned long amount)
 {
-    if (( ptr = (pointer)Xrealloc( ptr, amount ) ) == NULL)
+    if (( ptr = (void *)Xrealloc( ptr, amount ) ) == NULL)
     {
         FatalError( "Out of memory" );
     }
@@ -629,7 +629,7 @@ XNFrealloc (pointer ptr, unsigned long amount)
  *****************/    
 
 void
-Xfree(pointer ptr)
+Xfree(void * ptr)
 {
     unsigned long size;
     unsigned long *pheader;

--- a/nx-X11/programs/Xserver/os/xdmcp.c
+++ b/nx-X11/programs/Xserver/os/xdmcp.c
@@ -223,14 +223,14 @@ static void timeout(void);
 static void restart(void);
 
 static void XdmcpBlockHandler(
-    pointer /*data*/,
+    void * /*data*/,
     struct timeval ** /*wt*/,
-    pointer /*LastSelectMask*/);
+    void * /*LastSelectMask*/);
 
 static void XdmcpWakeupHandler(
-    pointer /*data*/,
+    void * /*data*/,
     int /*i*/,
-    pointer /*LastSelectMask*/);
+    void * /*LastSelectMask*/);
 
 void XdmcpRegisterManufacturerDisplayID(
     char    * /*name*/,
@@ -623,7 +623,7 @@ XdmcpInit(void)
 	XdmcpRegisterDisplayClass (defaultDisplayClass, strlen (defaultDisplayClass));
 	AccessUsingXdmcp();
 	RegisterBlockAndWakeupHandlers (XdmcpBlockHandler, XdmcpWakeupHandler,
-				        (pointer) 0);
+				        (void *) 0);
     	timeOutRtx = 0;
     	DisplayNumber = (CARD16) atoi(display);
     	get_xdmcp_sock();
@@ -638,7 +638,7 @@ XdmcpReset (void)
     if (state != XDM_OFF)
     {
 	RegisterBlockAndWakeupHandlers (XdmcpBlockHandler, XdmcpWakeupHandler,
-				        (pointer) 0);
+				        (void *) 0);
     	timeOutRtx = 0;
     	send_packet();
     }
@@ -683,9 +683,9 @@ XdmcpCloseDisplay(int sock)
 /*ARGSUSED*/
 static void
 XdmcpBlockHandler(
-    pointer	    data,   /* unused */
+    void *	    data,   /* unused */
     struct timeval  **wt,
-    pointer	    pReadmask)
+    void *	    pReadmask)
 {
     fd_set *LastSelectMask = (fd_set*)pReadmask;
     CARD32 millisToGo;
@@ -714,9 +714,9 @@ XdmcpBlockHandler(
 /*ARGSUSED*/
 static void
 XdmcpWakeupHandler(
-    pointer data,   /* unused */
+    void * data,   /* unused */
     int	    i,
-    pointer pReadmask)
+    void * pReadmask)
 {
     fd_set* LastSelectMask = (fd_set*)pReadmask;
     fd_set   devicesReadable;

--- a/nx-X11/programs/Xserver/randr/randr.c
+++ b/nx-X11/programs/Xserver/randr/randr.c
@@ -84,8 +84,8 @@ int	rrPrivIndex = -1;
 
 static void
 RRClientCallback (CallbackListPtr	*list,
-		  pointer		closure,
-		  pointer		data)
+		  void *		closure,
+		  void *		data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;
@@ -304,7 +304,7 @@ Bool RRScreenInit(ScreenPtr pScreen)
 
 /*ARGSUSED*/
 static int
-RRFreeClient (pointer data, XID id)
+RRFreeClient (void * data, XID id)
 {
     RREventPtr   pRREvent;
     WindowPtr	    pWin;
@@ -325,13 +325,13 @@ RRFreeClient (pointer data, XID id)
 	    	*pHead = pRREvent->next;
 	}
     }
-    xfree ((pointer) pRREvent);
+    xfree ((void *) pRREvent);
     return 1;
 }
 
 /*ARGSUSED*/
 static int
-RRFreeEvents (pointer data, XID id)
+RRFreeEvents (void * data, XID id)
 {
     RREventPtr   *pHead, pCur, pNext;
 
@@ -339,9 +339,9 @@ RRFreeEvents (pointer data, XID id)
     for (pCur = *pHead; pCur; pCur = pNext) {
 	pNext = pCur->next;
 	FreeResource (pCur->clientResource, RRClientType);
-	xfree ((pointer) pCur);
+	xfree ((void *) pCur);
     }
-    xfree ((pointer) pHead);
+    xfree ((void *) pHead);
     return 1;
 }
 
@@ -390,7 +390,7 @@ RRExtensionInit (void)
 }
 
 static int
-TellChanged (WindowPtr pWin, pointer value)
+TellChanged (WindowPtr pWin, void * value)
 {
     RREventPtr			*pHead, pRREvent;
     ClientPtr			client;
@@ -452,7 +452,7 @@ RRTellChanged (ScreenPtr pScreen)
 	    pScrPriv->configChanged = FALSE;
 	}
 	pScrPriv->changed = FALSE;
-	WalkTree (pScreen, TellChanged, (pointer) pScreen);
+	WalkTree (pScreen, TellChanged, (void *) pScreen);
 	for (i = 0; i < pScrPriv->numOutputs; i++)
 	    pScrPriv->outputs[i]->changed = FALSE;
 	for (i = 0; i < pScrPriv->numCrtcs; i++)

--- a/nx-X11/programs/Xserver/randr/randrstr.h
+++ b/nx-X11/programs/Xserver/randr/randrstr.h
@@ -91,7 +91,7 @@ struct _rrPropertyValue {
     Atom	    type;       /* ignored by server */
     short	    format;     /* format of data for swapping - 8,16,32 */
     long	    size;	/* size of data in (format/8) bytes */
-    pointer         data;	/* private to client */
+    void            *data;	/* private to client */
 };
 
 struct _rrProperty {
@@ -283,7 +283,7 @@ extern int rrPrivIndex;
 
 #define rrGetScrPriv(pScr)  ((rrScrPrivPtr) (pScr)->devPrivates[rrPrivIndex].ptr)
 #define rrScrPriv(pScr)	rrScrPrivPtr    pScrPriv = rrGetScrPriv(pScr)
-#define SetRRScreen(s,p) ((s)->devPrivates[rrPrivIndex].ptr = (pointer) (p))
+#define SetRRScreen(s,p) ((s)->devPrivates[rrPrivIndex].ptr = (void *) (p))
 
 #endif
 
@@ -785,7 +785,7 @@ RRPostPendingProperties (RROutputPtr output);
 int
 RRChangeOutputProperty (RROutputPtr output, Atom property, Atom type,
 			int format, int mode, unsigned long len,
-			pointer value, Bool sendevent, Bool pending);
+			void * value, Bool sendevent, Bool pending);
 
 int
 RRConfigureOutputProperty (RROutputPtr output, Atom property,

--- a/nx-X11/programs/Xserver/randr/rrcrtc.c
+++ b/nx-X11/programs/Xserver/randr/rrcrtc.c
@@ -107,7 +107,7 @@ RRCrtcCreate (ScreenPtr pScreen, void *devPrivate)
     crtc->changed = FALSE;
     crtc->devPrivate = devPrivate;
 
-    if (!AddResource (crtc->id, RRCrtcType, (pointer) crtc))
+    if (!AddResource (crtc->id, RRCrtcType, (void *) crtc))
 	return NULL;
 
     /* attach the screen and crtc together */
@@ -385,7 +385,7 @@ RRCrtcDestroy (RRCrtcPtr crtc)
 }
 
 static int
-RRCrtcDestroyResource (pointer value, XID pid)
+RRCrtcDestroyResource (void * value, XID pid)
 {
     RRCrtcPtr	crtc = (RRCrtcPtr) value;
     ScreenPtr	pScreen = crtc->pScreen;

--- a/nx-X11/programs/Xserver/randr/rrdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrdispatch.c
@@ -120,7 +120,7 @@ ProcRRSelectInput (ClientPtr client)
 	     */
 	    clientResource = FakeClientID (client->index);
 	    pRREvent->clientResource = clientResource;
-	    if (!AddResource (clientResource, RRClientType, (pointer)pRREvent))
+	    if (!AddResource (clientResource, RRClientType, (void *)pRREvent))
 		return BadAlloc;
 	    /*
 	     * create a resource to contain a pointer to the list
@@ -132,7 +132,7 @@ ProcRRSelectInput (ClientPtr client)
 	    {
 		pHead = (RREventPtr *) xalloc (sizeof (RREventPtr));
 		if (!pHead ||
-		    !AddResource (pWin->drawable.id, RREventType, (pointer)pHead))
+		    !AddResource (pWin->drawable.id, RREventType, (void *)pHead))
 		{
 		    FreeResource (clientResource, RT_NONE);
 		    return BadAlloc;

--- a/nx-X11/programs/Xserver/randr/rrmode.c
+++ b/nx-X11/programs/Xserver/randr/rrmode.c
@@ -98,7 +98,7 @@ RRModeCreate (xRRModeInfo   *modeInfo,
     }
 
     mode->mode.id = FakeClientID(0);
-    if (!AddResource(mode->mode.id, RRModeType, (pointer) mode)) {
+    if (!AddResource(mode->mode.id, RRModeType, (void *) mode)) {
         xfree(newModes);
         return NULL;
     }
@@ -274,7 +274,7 @@ RRModeDestroy (RRModePtr mode)
 }
 
 static int
-RRModeDestroyResource (pointer value, XID pid)
+RRModeDestroyResource (void * value, XID pid)
 {
     RRModeDestroy ((RRModePtr) value);
     return 1;

--- a/nx-X11/programs/Xserver/randr/rroutput.c
+++ b/nx-X11/programs/Xserver/randr/rroutput.c
@@ -100,7 +100,7 @@ RROutputCreate (ScreenPtr   pScreen,
     output->changed = FALSE;
     output->devPrivate = devPrivate;
     
-    if (!AddResource (output->id, RROutputType, (pointer) output))
+    if (!AddResource (output->id, RROutputType, (void *) output))
 	return NULL;
 
     pScrPriv->outputs[pScrPriv->numOutputs++] = output;
@@ -369,7 +369,7 @@ RROutputDestroy (RROutputPtr output)
 }
 
 static int
-RROutputDestroyResource (pointer value, XID pid)
+RROutputDestroyResource (void * value, XID pid)
 {
     RROutputPtr	output = (RROutputPtr) value;
     ScreenPtr	pScreen = output->pScreen;

--- a/nx-X11/programs/Xserver/randr/rrproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproperty.c
@@ -121,7 +121,7 @@ RRDeleteOutputProperty (RROutputPtr output, Atom property)
 int
 RRChangeOutputProperty (RROutputPtr output, Atom property, Atom type,
 			int format, int mode, unsigned long len,
-			pointer value, Bool sendevent, Bool pending)
+			void * value, Bool sendevent, Bool pending)
 {
     RRPropertyPtr		    prop;
     xRROutputPropertyNotifyEvent    event;
@@ -167,10 +167,10 @@ RRChangeOutputProperty (RROutputPtr output, Atom property, Atom type,
 
     if (mode == PropModeReplace || len > 0)
     {
-	pointer	    new_data = NULL, old_data = NULL;
+	void *new_data = NULL, *old_data = NULL;
 
 	total_size = total_len * size_in_bytes;
-	new_value.data = (pointer)xalloc (total_size);
+	new_value.data = (void *)xalloc (total_size);
 	if (!new_value.data && total_size)
 	{
 	    if (add)
@@ -187,13 +187,13 @@ RRChangeOutputProperty (RROutputPtr output, Atom property, Atom type,
 	    old_data = NULL;
 	    break;
 	case PropModeAppend:
-	    new_data = (pointer) (((char *) new_value.data) + 
+	    new_data = (void *) (((char *) new_value.data) + 
 				  (prop_value->size * size_in_bytes));
 	    old_data = new_value.data;
 	    break;
 	case PropModePrepend:
 	    new_data = new_value.data;
-	    old_data = (pointer) (((char *) new_value.data) + 
+	    old_data = (void *) (((char *) new_value.data) + 
 				  (prop_value->size * size_in_bytes));
 	    break;
 	}
@@ -534,7 +534,7 @@ ProcRRChangeOutputProperty (ClientPtr client)
 
     err = RRChangeOutputProperty(output, stuff->property,
 				 stuff->type, (int)format,
-				 (int)mode, len, (pointer)&stuff[1], TRUE, TRUE);
+				 (int)mode, len, (void *)&stuff[1], TRUE, TRUE);
     if (err != Success)
 	return err;
     else

--- a/nx-X11/programs/Xserver/record/record.c
+++ b/nx-X11/programs/Xserver/record/record.c
@@ -141,7 +141,7 @@ static int numEnabledRCAPs;
 }
 
 static int RecordDeleteContext(
-    pointer /*value*/,
+    void * /*value*/,
     XID /*id*/
 );
 
@@ -242,9 +242,9 @@ RecordFindContextOnAllContexts(pContext)
 static void
 RecordFlushReplyBuffer(
     RecordContextPtr pContext,
-    pointer data1,
+    void * data1,
     int len1,
-    pointer data2,
+    void * data2,
     int len2
 )
 {
@@ -290,7 +290,7 @@ RecordFlushReplyBuffer(
  */
 static void
 RecordAProtocolElement(RecordContextPtr pContext, ClientPtr pClient,
-		       int category, pointer data, int datalen, int futurelen)
+		       int category, void * data, int datalen, int futurelen)
 {
     CARD32 elemHeaderData[2];
     int numElemHeaders = 0;
@@ -404,8 +404,8 @@ RecordAProtocolElement(RecordContextPtr pContext, ClientPtr pClient,
 	}
     }
     else
-	RecordFlushReplyBuffer(pContext, (pointer)elemHeaderData,
-			       numElemHeaders, (pointer)data, datalen);
+	RecordFlushReplyBuffer(pContext, (void *)elemHeaderData,
+			       numElemHeaders, (void *)data, datalen);
 
 } /* RecordAProtocolElement */
 
@@ -487,19 +487,19 @@ RecordABigRequest(pContext, client, stuff)
     /* record the request header */
     bytesLeft = client->req_len << 2;
     RecordAProtocolElement(pContext, client, XRecordFromClient,
-			   (pointer)stuff, SIZEOF(xReq), bytesLeft);
+			   (void *)stuff, SIZEOF(xReq), bytesLeft);
 
     /* reinsert the extended length field that was squished out */
     bigLength = client->req_len + (sizeof(bigLength) >> 2);
     if (client->swapped)
 	swapl(&bigLength, n);
     RecordAProtocolElement(pContext, client, XRecordFromClient,
-		(pointer)&bigLength, sizeof(bigLength), /* continuation */ -1);
+		(void *)&bigLength, sizeof(bigLength), /* continuation */ -1);
     bytesLeft -= sizeof(bigLength);
 
     /* record the rest of the request after the length */
     RecordAProtocolElement(pContext, client, XRecordFromClient,
-		(pointer)(stuff + 1), bytesLeft, /* continuation */ -1);
+		(void *)(stuff + 1), bytesLeft, /* continuation */ -1);
 } /* RecordABigRequest */
 
 
@@ -547,7 +547,7 @@ RecordARequest(client)
 		    RecordABigRequest(pContext, client, stuff);
 		else
 		    RecordAProtocolElement(pContext, client, XRecordFromClient,
-				(pointer)stuff, client->req_len << 2, 0);
+				(void *)stuff, client->req_len << 2, 0);
 	    }
 	    else /* extension, check minor opcode */
 	    {
@@ -570,7 +570,7 @@ RecordARequest(client)
 			    RecordABigRequest(pContext, client, stuff);
 			else
 			    RecordAProtocolElement(pContext, client, 
-					XRecordFromClient, (pointer)stuff,
+					XRecordFromClient, (void *)stuff,
 					client->req_len << 2, 0);
 			break;
 		    }			    
@@ -607,8 +607,8 @@ RecordARequest(client)
 static void
 RecordASkippedRequest(pcbl , nulldata, calldata)
     CallbackListPtr *pcbl;
-    pointer nulldata;
-    pointer calldata;
+    void * nulldata;
+    void * calldata;
 {
     SkippedRequestInfoRec *psi = (SkippedRequestInfoRec *)calldata;
     RecordContextPtr pContext;
@@ -639,7 +639,7 @@ RecordASkippedRequest(pcbl , nulldata, calldata)
 		{ /* core request */
 
 		    RecordAProtocolElement(pContext, client, XRecordFromClient,
-				(pointer)stuff, reqlen, 0);
+				(void *)stuff, reqlen, 0);
 		}
 		else /* extension, check minor opcode */
 		{
@@ -659,7 +659,7 @@ RecordASkippedRequest(pcbl , nulldata, calldata)
 						minorop))
 			{
 			    RecordAProtocolElement(pContext, client, 
-				    XRecordFromClient, (pointer)stuff,
+				    XRecordFromClient, (void *)stuff,
 				    reqlen, 0);
 			    break;
 			}			    
@@ -697,8 +697,8 @@ RecordASkippedRequest(pcbl , nulldata, calldata)
 static void
 RecordAReply(pcbl, nulldata, calldata)
     CallbackListPtr *pcbl;
-    pointer nulldata;
-    pointer calldata;
+    void * nulldata;
+    void * calldata;
 {
     RecordContextPtr pContext;
     RecordClientsAndProtocolPtr pRCAP;
@@ -782,8 +782,8 @@ RecordAReply(pcbl, nulldata, calldata)
 static void
 RecordADeliveredEventOrError(pcbl, nulldata, calldata)
     CallbackListPtr *pcbl;
-    pointer nulldata;
-    pointer calldata;
+    void * nulldata;
+    void * calldata;
 {
     EventInfoRec *pei = (EventInfoRec *)calldata;
     RecordContextPtr pContext;
@@ -851,8 +851,8 @@ RecordADeliveredEventOrError(pcbl, nulldata, calldata)
 static void
 RecordADeviceEvent(pcbl, nulldata, calldata)
     CallbackListPtr *pcbl;
-    pointer nulldata;
-    pointer calldata;
+    void * nulldata;
+    void * calldata;
 {
     DeviceEventInfoRec *pei = (DeviceEventInfoRec *)calldata;
     RecordContextPtr pContext;
@@ -932,8 +932,8 @@ RecordADeviceEvent(pcbl, nulldata, calldata)
 static void
 RecordFlushAllContexts(
     CallbackListPtr *pcbl,
-    pointer nulldata,
-    pointer calldata
+    void * nulldata,
+    void * calldata
 )
 {
     int eci; /* enabled context index */
@@ -1008,7 +1008,7 @@ RecordInstallHooks(pRCAP, oneclient)
 			   sizeof (pClientPriv->recordVector));
 		    pClientPriv->originalVector = pClient->requestVector;
 		    pClient->devPrivates[RecordClientPrivateIndex].ptr =
-			(pointer)pClientPriv;
+			(void *)pClientPriv;
 		    pClient->requestVector = pClientPriv->recordVector;
 		}
 		while ((pIter = RecordIterateSet(pRCAP->pRequestMajorOpSet,
@@ -2061,7 +2061,7 @@ ProcRecordCreateContext(client)
     }
     else
     {
-	RecordDeleteContext((pointer)pContext, pContext->id);
+	RecordDeleteContext((void *)pContext, pContext->id);
 	err = BadAlloc;
     }
 bailout:
@@ -2621,7 +2621,7 @@ ProcRecordDisableContext(client)
  */
 static int
 RecordDeleteContext(value, id)
-    pointer value;
+    void * value;
     XID id;
 {
     int i;
@@ -2755,7 +2755,7 @@ SProcRecordCreateContext(client)
 
     swaps(&stuff->length, n);
     REQUEST_AT_LEAST_SIZE(xRecordCreateContextReq);
-    if ((status = SwapCreateRegister((pointer)stuff)) != Success)
+    if ((status = SwapCreateRegister((void *)stuff)) != Success)
 	return status;
     return ProcRecordCreateContext(client);
 } /* SProcRecordCreateContext */
@@ -2771,7 +2771,7 @@ SProcRecordRegisterClients(client)
 
     swaps(&stuff->length, n);
     REQUEST_AT_LEAST_SIZE(xRecordRegisterClientsReq);
-    if ((status = SwapCreateRegister((pointer)stuff)) != Success)
+    if ((status = SwapCreateRegister((void *)stuff)) != Success)
 	return status;
     return ProcRecordRegisterClients(client);
 } /* SProcRecordRegisterClients */
@@ -2908,7 +2908,7 @@ RecordConnectionSetupInfo(pContext, pci)
 	SwapConnSetupPrefix(pci->prefix, pConnSetup);
 	SwapConnSetupInfo(pci->setup, pConnSetup + prefixsize);
 	RecordAProtocolElement(pContext, pci->client, XRecordClientStarted,
-			       (pointer)pConnSetup, prefixsize + restsize, 0);
+			       (void *)pConnSetup, prefixsize + restsize, 0);
 	DEALLOCATE_LOCAL(pConnSetup);
     }
     else
@@ -2917,9 +2917,9 @@ RecordConnectionSetupInfo(pContext, pci)
 	 * data in two pieces
 	 */
 	RecordAProtocolElement(pContext, pci->client, XRecordClientStarted,
-			(pointer)pci->prefix, prefixsize, restsize);
+			(void *)pci->prefix, prefixsize, restsize);
 	RecordAProtocolElement(pContext, pci->client, XRecordClientStarted,
-			(pointer)pci->setup, restsize, /* continuation */ -1);
+			(void *)pci->setup, restsize, /* continuation */ -1);
     }
 } /* RecordConnectionSetupInfo */
 
@@ -2950,8 +2950,8 @@ RecordConnectionSetupInfo(pContext, pci)
 static void
 RecordAClientStateChange(pcbl, nulldata, calldata)
     CallbackListPtr *pcbl;
-    pointer nulldata;
-    pointer calldata;
+    void * nulldata;
+    void * calldata;
 {
     NewClientInfoRec *pci = (NewClientInfoRec *)calldata;
     int i;

--- a/nx-X11/programs/Xserver/record/recordmod.c
+++ b/nx-X11/programs/Xserver/record/recordmod.c
@@ -35,12 +35,12 @@ static XF86ModuleVersionInfo VersRec = {
 
 XF86ModuleData recordModuleData = { &VersRec, recordSetup, NULL };
 
-static pointer
-recordSetup(pointer module, pointer opts, int *errmaj, int *errmin)
+static void *
+recordSetup(void * module, void * opts, int *errmaj, int *errmin)
 {
     LoadExtension(&recordExt, FALSE);
 
     /* Need a non-NULL return value to indicate success */
-    return (pointer)1;
+    return (void *)1;
 }
 

--- a/nx-X11/programs/Xserver/render/animcur.c
+++ b/nx-X11/programs/Xserver/render/animcur.c
@@ -95,7 +95,7 @@ int	AnimCurGeneration;
 #define GetAnimCur(c)	    ((AnimCurPtr) ((c) + 1))
 #define GetAnimCurScreen(s) ((AnimCurScreenPtr) ((s)->devPrivates[AnimCurScreenPrivateIndex].ptr))
 #define GetAnimCurScreenIfSet(s) ((AnimCurScreenPrivateIndex != -1) ? GetAnimCurScreen(s) : NULL)
-#define SetAnimCurScreen(s,p) ((s)->devPrivates[AnimCurScreenPrivateIndex].ptr = (pointer) (p))
+#define SetAnimCurScreen(s,p) ((s)->devPrivates[AnimCurScreenPrivateIndex].ptr = (void *) (p))
 
 #define Wrap(as,s,elt,func) (((as)->elt = (s)->elt), (s)->elt = func)
 #define Unwrap(as,s,elt)    ((s)->elt = (as)->elt)
@@ -164,9 +164,9 @@ AnimCurCursorLimits (ScreenPtr pScreen,
 
 static void
 AnimCurScreenBlockHandler (int screenNum,
-			   pointer blockData,
-			   pointer pTimeout,
-			   pointer pReadmask)
+			   void * blockData,
+			   void * pTimeout,
+			   void * pReadmask)
 {
     ScreenPtr		pScreen = screenInfo.screens[screenNum];
     AnimCurScreenPtr    as = GetAnimCurScreen(pScreen);

--- a/nx-X11/programs/Xserver/render/glyph.c
+++ b/nx-X11/programs/Xserver/render/glyph.c
@@ -114,30 +114,30 @@ ResetGlyphSetPrivateIndex (void)
 }
 
 Bool
-_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, pointer ptr)
+_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, void * ptr)
 {
-    pointer *new;
+    void **new;
 
     if (n > glyphSet->maxPrivate) {
 	if (glyphSet->devPrivates &&
-	    glyphSet->devPrivates != (pointer)(&glyphSet[1])) {
-	    new = (pointer *) xrealloc (glyphSet->devPrivates,
-					(n + 1) * sizeof (pointer));
+	    glyphSet->devPrivates != (void *)(&glyphSet[1])) {
+	    new = (void **) xrealloc (glyphSet->devPrivates,
+					(n + 1) * sizeof (void *));
 	    if (!new)
 		return FALSE;
 	} else {
-	    new = (pointer *) xalloc ((n + 1) * sizeof (pointer));
+	    new = (void **) xalloc ((n + 1) * sizeof (void *));
 	    if (!new)
 		return FALSE;
 	    if (glyphSet->devPrivates)
 		memcpy (new,
 			glyphSet->devPrivates,
-			(glyphSet->maxPrivate + 1) * sizeof (pointer));
+			(glyphSet->maxPrivate + 1) * sizeof (void *));
 	}
 	glyphSet->devPrivates = new;
 	/* Zero out new, uninitialize privates */
 	while (++glyphSet->maxPrivate < n)
-	    glyphSet->devPrivates[glyphSet->maxPrivate] = (pointer)0;
+	    glyphSet->devPrivates[glyphSet->maxPrivate] = (void *)0;
     }
     glyphSet->devPrivates[n] = ptr;
     return TRUE;
@@ -430,14 +430,14 @@ AllocateGlyphSet (int fdepth, PictFormatPtr format)
     }
 
     size = (sizeof (GlyphSetRec) +
-	    (sizeof (pointer) * _GlyphSetPrivateAllocateIndex));
+	    (sizeof (void *) * _GlyphSetPrivateAllocateIndex));
     glyphSet = xalloc (size);
     if (!glyphSet)
 	return FALSE;
     bzero((char *)glyphSet, size);
     glyphSet->maxPrivate = _GlyphSetPrivateAllocateIndex - 1;
     if (_GlyphSetPrivateAllocateIndex)
-	glyphSet->devPrivates = (pointer)(&glyphSet[1]);
+	glyphSet->devPrivates = (void *)(&glyphSet[1]);
 
     if (!AllocateGlyphHash (&glyphSet->hash, &glyphHashSets[0]))
     {
@@ -451,7 +451,7 @@ AllocateGlyphSet (int fdepth, PictFormatPtr format)
 }
 
 int
-FreeGlyphSet (pointer	value,
+FreeGlyphSet (void	*value,
 	      XID       gid)
 {
     GlyphSetPtr	glyphSet = (GlyphSetPtr) value;
@@ -479,7 +479,7 @@ FreeGlyphSet (pointer	value,
 	xfree (table);
 
 	if (glyphSet->devPrivates &&
-	    glyphSet->devPrivates != (pointer)(&glyphSet[1]))
+	    glyphSet->devPrivates != (void *)(&glyphSet[1]))
 	    xfree(glyphSet->devPrivates);
 
 	xfree (glyphSet);

--- a/nx-X11/programs/Xserver/render/glyphstr.h
+++ b/nx-X11/programs/Xserver/render/glyphstr.h
@@ -69,12 +69,12 @@ typedef struct _GlyphSet {
     int		    fdepth;
     GlyphHashRec    hash;
     int             maxPrivate;
-    pointer         *devPrivates;
+    void            **devPrivates;
 } GlyphSetRec, *GlyphSetPtr;
 
 #define GlyphSetGetPrivate(pGlyphSet,n)					\
 	((n) > (pGlyphSet)->maxPrivate ?				\
-	 (pointer) 0 :							\
+	 (void *) 0 :							\
 	 (pGlyphSet)->devPrivates[n])
 
 #define GlyphSetSetPrivate(pGlyphSet,n,ptr)				\
@@ -101,7 +101,7 @@ void
 ResetGlyphSetPrivateIndex (void);
 
 Bool
-_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, pointer ptr);
+_GlyphSetSetNewPrivate (GlyphSetPtr glyphSet, int n, void * ptr);
 
 Bool
 GlyphInit (ScreenPtr pScreen);
@@ -140,7 +140,7 @@ GlyphSetPtr
 AllocateGlyphSet (int fdepth, PictFormatPtr format);
 
 int
-FreeGlyphSet (pointer   value,
+FreeGlyphSet (void      *value,
 	      XID       gid);
 
 

--- a/nx-X11/programs/Xserver/render/miglyph.c
+++ b/nx-X11/programs/Xserver/render/miglyph.c
@@ -168,7 +168,7 @@ miGlyphs (CARD8		op,
 		pPixmap = GetScratchPixmapHeader (pScreen, glyph->info.width, glyph->info.height, 
 						  list->format->depth,
 						  list->format->depth, 
-						  0, (pointer) (glyph + 1));
+						  0, (void *) (glyph + 1));
 		if (!pPixmap)
 		    return;
 		component_alpha = NeedsComponent(list->format->format);
@@ -183,7 +183,7 @@ miGlyphs (CARD8		op,
 	    }
 	    (*pScreen->ModifyPixmapHeader) (pPixmap, 
 					    glyph->info.width, glyph->info.height,
-					    0, 0, -1, (pointer) (glyph + 1));
+					    0, 0, -1, (void *) (glyph + 1));
 	    pPixmap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
 	    if (maskFormat)
 	    {
@@ -219,7 +219,7 @@ miGlyphs (CARD8		op,
 	if (pPicture)
 	{
 	    FreeScratchPixmapHeader (pPixmap);
-	    FreePicture ((pointer) pPicture, 0);
+	    FreePicture ((void *) pPicture, 0);
 	    pPicture = 0;
 	    pPixmap = 0;
 	}
@@ -237,7 +237,7 @@ miGlyphs (CARD8		op,
 			  0, 0,
 			  x, y,
 			  width, height);
-	FreePicture ((pointer) pMask, (XID) 0);
+	FreePicture ((void *) pMask, (XID) 0);
 	(*pScreen->DestroyPixmap) (pMaskPixmap);
     }
 }

--- a/nx-X11/programs/Xserver/render/mipict.c
+++ b/nx-X11/programs/Xserver/render/mipict.c
@@ -75,18 +75,18 @@ miDestroyPictureClip (PicturePtr pPicture)
 int
 miChangePictureClip (PicturePtr    pPicture,
 		     int	   type,
-		     pointer	   value,
+		     void *	   value,
 		     int	   n)
 {
     ScreenPtr		pScreen = pPicture->pDrawable->pScreen;
     PictureScreenPtr    ps = GetPictureScreen(pScreen);
-    pointer		clientClip;
+    void *		clientClip;
     int			clientClipType;
     
     switch (type) {
     case CT_PIXMAP:
 	/* convert the pixmap to a region */
-	clientClip = (pointer) BITMAP_TO_REGION(pScreen, (PixmapPtr) value);
+	clientClip = (void *) BITMAP_TO_REGION(pScreen, (PixmapPtr) value);
 	if (!clientClip)
 	    return BadAlloc;
 	clientClipType = CT_REGION;
@@ -101,7 +101,7 @@ miChangePictureClip (PicturePtr    pPicture,
 	clientClipType = CT_NONE;
 	break;
     default:
-	clientClip = (pointer) RECTS_TO_REGION(pScreen, n,
+	clientClip = (void *) RECTS_TO_REGION(pScreen, n,
 					       (xRectangle *) value,
 					       type);
 	if (!clientClip)

--- a/nx-X11/programs/Xserver/render/mipict.h
+++ b/nx-X11/programs/Xserver/render/mipict.h
@@ -60,7 +60,7 @@ miDestroyPictureClip (PicturePtr pPicture);
 int
 miChangePictureClip (PicturePtr    pPicture,
 		     int	   type,
-		     pointer	   value,
+		     void *	   value,
 		     int	   n);
 
 void

--- a/nx-X11/programs/Xserver/render/mirect.c
+++ b/nx-X11/programs/Xserver/render/mirect.c
@@ -174,7 +174,7 @@ miCompositeRects (CARD8		op,
 	    rects++;
 	}
 
-	FreePicture ((pointer) pSrc, 0);
+	FreePicture ((void *) pSrc, 0);
 bail4:
 	FreeScratchGC (pGC);
 bail3:

--- a/nx-X11/programs/Xserver/render/picture.c
+++ b/nx-X11/programs/Xserver/render/picture.c
@@ -114,7 +114,7 @@ PictureDestroyWindow (WindowPtr pWindow)
 	SetPictureWindow(pWindow, pPicture->pNext);
 	if (pPicture->id)
 	    FreeResource (pPicture->id, PictureType);
-	FreePicture ((pointer) pPicture, pPicture->id);
+	FreePicture ((void *) pPicture, pPicture->id);
     }
     pScreen->DestroyWindow = ps->DestroyWindow;
     ret = (*pScreen->DestroyWindow) (pWindow);
@@ -653,7 +653,7 @@ PictureInit (ScreenPtr pScreen, PictFormatPtr formats, int nformats)
     }
     for (n = 0; n < nformats; n++)
     {
-	if (!AddResource (formats[n].id, PictFormatType, (pointer) (formats+n)))
+	if (!AddResource (formats[n].id, PictFormatType, (void *) (formats+n)))
 	{
 	    xfree (formats);
 	    return FALSE;
@@ -789,11 +789,11 @@ AllocatePicture (ScreenPtr  pScreen)
     {
 	if ( (size = *sizes) )
 	{
-	    ppriv->ptr = (pointer)ptr;
+	    ppriv->ptr = (void *)ptr;
 	    ptr += size;
 	}
 	else
-	    ppriv->ptr = (pointer)NULL;
+	    ppriv->ptr = (void *)NULL;
     }
     return pPicture;
 }
@@ -1223,7 +1223,7 @@ ChangePicture (PicturePtr	pPicture,
 		    if (pAlpha && pAlpha->pDrawable->type == DRAWABLE_PIXMAP)
 			pAlpha->refcnt++;
 		    if (pPicture->alphaMap)
-			FreePicture ((pointer) pPicture->alphaMap, (XID) 0);
+			FreePicture ((void *) pPicture->alphaMap, (XID) 0);
 		    pPicture->alphaMap = pAlpha;
 		}
 	    }
@@ -1295,7 +1295,7 @@ ChangePicture (PicturePtr	pPicture,
 		    }
 		}
 		error = (*ps->ChangePictureClip)(pPicture, clipType,
-						 (pointer)pPixmap, 0);
+						 (void *)pPixmap, 0);
 		break;
 	    }
 	case CPGraphicsExposure:
@@ -1395,7 +1395,7 @@ SetPictureClipRects (PicturePtr	pPicture,
     if (!clientClip)
 	return BadAlloc;
     result =(*ps->ChangePictureClip) (pPicture, CT_REGION, 
-				      (pointer) clientClip, 0);
+				      (void *) clientClip, 0);
     if (result == Success)
     {
 	pPicture->clipOrigin.x = xOrigin;
@@ -1439,7 +1439,7 @@ SetPictureClipRegion (PicturePtr    pPicture,
     }
 
     result =(*ps->ChangePictureClip) (pPicture, type,
-                                      (pointer) clientClip, 0);
+                                      (void *) clientClip, 0);
     if (result == Success)
     {
         pPicture->clipOrigin.x = xOrigin;
@@ -1511,7 +1511,7 @@ CopyPicture (PicturePtr	pSrc,
 	    if (pSrc->alphaMap && pSrc->alphaMap->pDrawable->type == DRAWABLE_PIXMAP)
 		pSrc->alphaMap->refcnt++;
 	    if (pDst->alphaMap)
-		FreePicture ((pointer) pDst->alphaMap, (XID) 0);
+		FreePicture ((void *) pDst->alphaMap, (XID) 0);
 	    pDst->alphaMap = pSrc->alphaMap;
 	    break;
 	case CPAlphaXOrigin:
@@ -1593,7 +1593,7 @@ ValidatePicture(PicturePtr pPicture)
 }
 
 int
-FreePicture (pointer	value,
+FreePicture (void *	value,
 	     XID	pid)
 {
     PicturePtr	pPicture = (PicturePtr) value;
@@ -1613,7 +1613,7 @@ FreePicture (pointer	value,
             PictureScreenPtr    ps = GetPictureScreen(pScreen);
 	
             if (pPicture->alphaMap)
-                FreePicture ((pointer) pPicture->alphaMap, (XID) 0);
+                FreePicture ((void *) pPicture->alphaMap, (XID) 0);
             (*ps->DestroyPicture) (pPicture);
             (*ps->DestroyPictureClip) (pPicture);
             if (pPicture->pDrawable->type == DRAWABLE_WINDOW)
@@ -1643,7 +1643,7 @@ FreePicture (pointer	value,
 }
 
 int
-FreePictFormat (pointer	pPictFormat,
+FreePictFormat (void *	pPictFormat,
 		XID     pid)
 {
     return Success;

--- a/nx-X11/programs/Xserver/render/picturestr.h
+++ b/nx-X11/programs/Xserver/render/picturestr.h
@@ -149,7 +149,7 @@ typedef struct _Picture {
     DDXPointRec	    alphaOrigin;
 
     DDXPointRec	    clipOrigin;
-    pointer	    clientClip;
+    void	    *clientClip;
 
     Atom	    dither;
 
@@ -195,7 +195,7 @@ typedef int	(*CreatePictureProcPtr)	    (PicturePtr pPicture);
 typedef void	(*DestroyPictureProcPtr)    (PicturePtr pPicture);
 typedef int	(*ChangePictureClipProcPtr) (PicturePtr	pPicture,
 					     int	clipType,
-					     pointer    value,
+					     void       *value,
 					     int	n);
 typedef void	(*DestroyPictureClipProcPtr)(PicturePtr	pPicture);
 
@@ -374,9 +374,9 @@ extern RESTYPE		GlyphSetType;
 
 #define GetPictureScreen(s) ((PictureScreenPtr) ((s)->devPrivates[PictureScreenPrivateIndex].ptr))
 #define GetPictureScreenIfSet(s) ((PictureScreenPrivateIndex != -1) ? GetPictureScreen(s) : NULL)
-#define SetPictureScreen(s,p) ((s)->devPrivates[PictureScreenPrivateIndex].ptr = (pointer) (p))
+#define SetPictureScreen(s,p) ((s)->devPrivates[PictureScreenPrivateIndex].ptr = (void *) (p))
 #define GetPictureWindow(w) ((PicturePtr) ((w)->devPrivates[PictureWindowPrivateIndex].ptr))
-#define SetPictureWindow(w,p) ((w)->devPrivates[PictureWindowPrivateIndex].ptr = (pointer) (p))
+#define SetPictureWindow(w,p) ((w)->devPrivates[PictureWindowPrivateIndex].ptr = (void *) (p))
 
 #define VERIFY_PICTURE(pPicture, pid, client, mode, err) {\
     pPicture = SecurityLookupIDByType(client, pid, PictureType, mode);\
@@ -516,11 +516,11 @@ void
 ValidatePicture(PicturePtr pPicture);
 
 int
-FreePicture (pointer	pPicture,
+FreePicture (void	*pPicture,
 	     XID	pid);
 
 int
-FreePictFormat (pointer	pPictFormat,
+FreePictFormat (void	*pPictFormat,
 		XID     pid);
 
 void

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -230,8 +230,8 @@ typedef struct _RenderClient {
 
 static void
 RenderClientCallback (CallbackListPtr	*list,
-		      pointer		closure,
-		      pointer		data)
+		      void *		closure,
+		      void *		data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;
@@ -660,7 +660,7 @@ ProcRenderCreatePicture (ClientPtr client)
 			      &error);
     if (!pPicture)
 	return error;
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -1031,7 +1031,7 @@ ProcRenderCreateGlyphSet (ClientPtr client)
     glyphSet = AllocateGlyphSet (f, format);
     if (!glyphSet)
 	return BadAlloc;
-    if (!AddResource (stuff->gsid, GlyphSetType, (pointer)glyphSet))
+    if (!AddResource (stuff->gsid, GlyphSetType, (void *)glyphSet))
 	return BadAlloc;
     return Success;
 }
@@ -1056,7 +1056,7 @@ ProcRenderReferenceGlyphSet (ClientPtr client)
 	return RenderErrBase + BadGlyphSet;
     }
     glyphSet->refcnt++;
-    if (!AddResource (stuff->gsid, GlyphSetType, (pointer)glyphSet))
+    if (!AddResource (stuff->gsid, GlyphSetType, (void *)glyphSet))
 	return BadAlloc;
     return client->noClientException;
 }
@@ -1540,7 +1540,7 @@ ProcRenderCreateCursor (ClientPtr client)
     {
 	(*pScreen->GetImage) (pSrc->pDrawable,
 			      0, 0, width, height, ZPixmap,
-			      0xffffffff, (pointer) argbbits);
+			      0xffffffff, (void *) argbbits);
     }
     else
     {
@@ -1580,7 +1580,7 @@ ProcRenderCreateCursor (ClientPtr client)
 			  0, 0, 0, 0, 0, 0, width, height);
 	(*pScreen->GetImage) (pPicture->pDrawable,
 			      0, 0, width, height, ZPixmap,
-			      0xffffffff, (pointer) argbbits);
+			      0xffffffff, (void *) argbbits);
 	FreePicture (pPicture, 0);
     }
     /*
@@ -1673,7 +1673,7 @@ ProcRenderCreateCursor (ClientPtr client)
 			       GetColor(twocolor[1], 16),
 			       GetColor(twocolor[1], 8),
 			       GetColor(twocolor[1], 0));
-    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (pCursor && AddResource(stuff->cid, RT_CURSOR, (void *)pCursor))
 	return (client->noClientException);
     return BadAlloc;
 }
@@ -1864,7 +1864,7 @@ ProcRenderCreateAnimCursor (ClientPtr client)
     if (ret != Success)
 	return ret;
     
-    if (AddResource (stuff->cid, RT_CURSOR, (pointer)pCursor))
+    if (AddResource (stuff->cid, RT_CURSOR, (void *)pCursor))
 	return client->noClientException;
     return BadAlloc;
 }
@@ -1905,7 +1905,7 @@ static int ProcRenderCreateSolidFill(ClientPtr client)
     pPicture = CreateSolidPicture(stuff->pid, &stuff->color, &error);
     if (!pPicture)
 	return error;
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -1936,7 +1936,7 @@ static int ProcRenderCreateLinearGradient (ClientPtr client)
                                             stuff->nStops, stops, colors, &error);
     if (!pPicture)
 	return error;
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -1966,7 +1966,7 @@ static int ProcRenderCreateRadialGradient (ClientPtr client)
                                             stuff->nStops, stops, colors, &error);
     if (!pPicture)
 	return error;
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }
@@ -1995,7 +1995,7 @@ static int ProcRenderCreateConicalGradient (ClientPtr client)
                                              stuff->nStops, stops, colors, &error);
     if (!pPicture)
 	return error;
-    if (!AddResource (stuff->pid, PictureType, (pointer)pPicture))
+    if (!AddResource (stuff->pid, PictureType, (void *)pPicture))
 	return BadAlloc;
     return Success;
 }

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -76,7 +76,7 @@ typedef struct _CursorScreen {
 
 #define GetCursorScreen(s)	((CursorScreenPtr) ((s)->devPrivates[CursorScreenPrivateIndex].ptr))
 #define GetCursorScreenIfSet(s) ((CursorScreenPrivateIndex != -1) ? GetCursorScreen(s) : NULL)
-#define SetCursorScreen(s,p)	((s)->devPrivates[CursorScreenPrivateIndex].ptr = (pointer) (p))
+#define SetCursorScreen(s,p)	((s)->devPrivates[CursorScreenPrivateIndex].ptr = (void *) (p))
 #define Wrap(as,s,elt,func)	(((as)->elt = (s)->elt), (s)->elt = func)
 #define Unwrap(as,s,elt)	((s)->elt = (as)->elt)
 
@@ -172,13 +172,13 @@ XFixesSelectCursorInput (ClientPtr	pClient,
 	 */
 	if (!LookupIDByType(pWindow->drawable.id, CursorWindowType))
 	    if (!AddResource (pWindow->drawable.id, CursorWindowType,
-			      (pointer) pWindow))
+			      (void *) pWindow))
 	    {
 		xfree (e);
 		return BadAlloc;
 	    }
 
-	if (!AddResource (e->clientResource, CursorClientType, (pointer) e))
+	if (!AddResource (e->clientResource, CursorClientType, (void *) e))
 	    return BadAlloc;
 
 	*prev = e;
@@ -520,13 +520,13 @@ SProcXFixesGetCursorImageAndName (ClientPtr client)
  * whether it should be replaced with a reference to pCursor.
  */
 
-typedef Bool (*TestCursorFunc) (CursorPtr pOld, pointer closure);
+typedef Bool (*TestCursorFunc) (CursorPtr pOld, void * closure);
 
 typedef struct {
     RESTYPE type;
     TestCursorFunc testCursor;
     CursorPtr pNew;
-    pointer closure;
+    void * closure;
 } ReplaceCursorLookupRec, *ReplaceCursorLookupPtr;
 
 static const RESTYPE    CursorRestypes[] = {
@@ -536,7 +536,7 @@ static const RESTYPE    CursorRestypes[] = {
 #define NUM_CURSOR_RESTYPES (sizeof (CursorRestypes) / sizeof (CursorRestypes[0]))
 
 static Bool
-ReplaceCursorLookup (pointer value, XID id, pointer closure)
+ReplaceCursorLookup (void * value, XID id, void * closure)
 {
     ReplaceCursorLookupPtr  rcl = (ReplaceCursorLookupPtr) closure;
     WindowPtr		    pWin;
@@ -583,7 +583,7 @@ ReplaceCursorLookup (pointer value, XID id, pointer closure)
 static void
 ReplaceCursor (CursorPtr pCursor,
 	       TestCursorFunc testCursor,
-	       pointer closure)
+	       void * closure)
 {
     int	clientIndex;
     int resIndex;
@@ -612,7 +612,7 @@ ReplaceCursor (CursorPtr pCursor,
 	    LookupClientResourceComplex (clients[clientIndex], 
 					 rcl.type, 
 					 ReplaceCursorLookup,
-					 (pointer) &rcl);
+					 (void *) &rcl);
 	}
     }
     /* this "knows" that WindowHasNewCursor doesn't depend on it's argument */
@@ -620,7 +620,7 @@ ReplaceCursor (CursorPtr pCursor,
 }
 
 static Bool 
-TestForCursor (CursorPtr pCursor, pointer closure)
+TestForCursor (CursorPtr pCursor, void * closure)
 {
     return (pCursor == (CursorPtr) closure);
 }
@@ -635,7 +635,7 @@ ProcXFixesChangeCursor (ClientPtr client)
     VERIFY_CURSOR (pSource, stuff->source, client, SecurityReadAccess);
     VERIFY_CURSOR (pDestination, stuff->destination, client, SecurityWriteAccess);
 
-    ReplaceCursor (pSource, TestForCursor, (pointer) pDestination);
+    ReplaceCursor (pSource, TestForCursor, (void *) pDestination);
     return (client->noClientException);
 }
 
@@ -653,7 +653,7 @@ SProcXFixesChangeCursor (ClientPtr client)
 }
 
 static Bool
-TestForCursorName (CursorPtr pCursor, pointer closure)
+TestForCursorName (CursorPtr pCursor, void * closure)
 {
     return (pCursor->name == (Atom) closure);
 }
@@ -671,7 +671,7 @@ ProcXFixesChangeCursorByName (ClientPtr client)
     tchar = (char *) &stuff[1];
     name = MakeAtom (tchar, stuff->nbytes, FALSE);
     if (name)
-	ReplaceCursor (pSource, TestForCursorName, (pointer) name);
+	ReplaceCursor (pSource, TestForCursorName, (void *) name);
     return (client->noClientException);
 }
 
@@ -689,7 +689,7 @@ SProcXFixesChangeCursorByName (ClientPtr client)
 }
 
 static int
-CursorFreeClient (pointer data, XID id)
+CursorFreeClient (void * data, XID id)
 {
     CursorEventPtr	old = (CursorEventPtr) data;
     CursorEventPtr	*prev, e;
@@ -707,7 +707,7 @@ CursorFreeClient (pointer data, XID id)
 }
 
 static int
-CursorFreeWindow (pointer data, XID id)
+CursorFreeWindow (void * data, XID id)
 {
     WindowPtr		pWindow = (WindowPtr) data;
     CursorEventPtr	e, next;

--- a/nx-X11/programs/Xserver/xfixes/region.c
+++ b/nx-X11/programs/Xserver/xfixes/region.c
@@ -39,7 +39,7 @@ extern int RenderErrBase;
 RESTYPE	    RegionResType;
 
 static int
-RegionResFree (pointer data, XID id)
+RegionResFree (void * data, XID id)
 {
     RegionPtr    pRegion = (RegionPtr) data;
 
@@ -87,7 +87,7 @@ ProcXFixesCreateRegion (ClientPtr client)
     pRegion = RECTS_TO_REGION(0, things, (xRectangle *) (stuff + 1), CT_UNSORTED);
     if (!pRegion)
 	return BadAlloc;
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
     
     return(client->noClientException);
@@ -132,7 +132,7 @@ ProcXFixesCreateRegionFromBitmap (ClientPtr client)
     if (!pRegion)
 	return BadAlloc;
     
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
     
     return(client->noClientException);
@@ -196,7 +196,7 @@ ProcXFixesCreateRegionFromWindow (ClientPtr client)
 	pRegion = XFixesRegionCopy (pRegion);
     if (!pRegion)
 	return BadAlloc;
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
     
     return(client->noClientException);
@@ -243,7 +243,7 @@ ProcXFixesCreateRegionFromGC (ClientPtr client)
 	return BadImplementation;   /* assume sane server bits */
     }
     
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
     
     return(client->noClientException);
@@ -292,7 +292,7 @@ ProcXFixesCreateRegionFromPicture (ClientPtr client)
 	return BadImplementation;   /* assume sane server bits */
     }
     
-    if (!AddResource (stuff->region, RegionResType, (pointer) pRegion))
+    if (!AddResource (stuff->region, RegionResType, (void *) pRegion))
 	return BadAlloc;
     
     return(client->noClientException);
@@ -646,7 +646,7 @@ ProcXFixesSetGCClipRegion (ClientPtr client)
     vals[0] = stuff->xOrigin;
     vals[1] = stuff->yOrigin;
     DoChangeGC (pGC, GCClipXOrigin|GCClipYOrigin, vals, 0);
-    (*pGC->funcs->ChangeClip)(pGC, pRegion ? CT_REGION : CT_NONE, (pointer)pRegion, 0);
+    (*pGC->funcs->ChangeClip)(pGC, pRegion ? CT_REGION : CT_NONE, (void *)pRegion, 0);
 
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/xfixes/select.c
+++ b/nx-X11/programs/Xserver/xfixes/select.c
@@ -52,7 +52,7 @@ typedef struct _SelectionEvent {
 static SelectionEventPtr	selectionEvents;
 
 static void
-XFixesSelectionCallback (CallbackListPtr *callbacks, pointer data, pointer args)
+XFixesSelectionCallback (CallbackListPtr *callbacks, void * data, void * args)
 {
     SelectionEventPtr	e;
     SelectionInfoRec	*info = (SelectionInfoRec *) args;
@@ -172,13 +172,13 @@ XFixesSelectSelectionInput (ClientPtr	pClient,
 	 */
 	if (!LookupIDByType(pWindow->drawable.id, SelectionWindowType))
 	    if (!AddResource (pWindow->drawable.id, SelectionWindowType,
-			      (pointer) pWindow))
+			      (void *) pWindow))
 	    {
 		xfree (e);
 		return BadAlloc;
 	    }
 
-	if (!AddResource (e->clientResource, SelectionClientType, (pointer) e))
+	if (!AddResource (e->clientResource, SelectionClientType, (void *) e))
 	    return BadAlloc;
 
 	*prev = e;
@@ -240,7 +240,7 @@ SXFixesSelectionNotifyEvent (xXFixesSelectionNotifyEvent *from,
 }
 
 static int
-SelectionFreeClient (pointer data, XID id)
+SelectionFreeClient (void * data, XID id)
 {
     SelectionEventPtr	old = (SelectionEventPtr) data;
     SelectionEventPtr	*prev, e;
@@ -259,7 +259,7 @@ SelectionFreeClient (pointer data, XID id)
 }
 
 static int
-SelectionFreeWindow (pointer data, XID id)
+SelectionFreeWindow (void * data, XID id)
 {
     WindowPtr		pWindow = (WindowPtr) data;
     SelectionEventPtr	e, next;

--- a/nx-X11/programs/Xserver/xfixes/xfixes.c
+++ b/nx-X11/programs/Xserver/xfixes/xfixes.c
@@ -185,8 +185,8 @@ SProcXFixesDispatch (ClientPtr client)
 
 static void
 XFixesClientCallback (CallbackListPtr	*list,
-		      pointer		closure,
-		      pointer		data)
+		      void		*closure,
+		      void		*data)
 {
     NewClientInfoRec	*clientinfo = (NewClientInfoRec *) data;
     ClientPtr		pClient = clientinfo->client;

--- a/nx-X11/programs/Xserver/xkb/ddxBeep.c
+++ b/nx-X11/programs/Xserver/xkb/ddxBeep.c
@@ -148,7 +148,7 @@ _XkbDDXBeepInitAtoms(void)
 }
 
 static CARD32
-_XkbDDXBeepExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+_XkbDDXBeepExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 DeviceIntPtr	dev= (DeviceIntPtr)arg;
 KbdFeedbackPtr	feed;
@@ -322,11 +322,11 @@ Atom		name;
 	ctrl->bell_duration= duration;
 	ctrl->bell_pitch= pitch;
 	if (xkbInfo->beepCount==0) {
-	     XkbHandleBell(0,0,dev,ctrl->bell,(pointer)ctrl,KbdFeedbackClass,name,None,
+	     XkbHandleBell(0,0,dev,ctrl->bell,(void *)ctrl,KbdFeedbackClass,name,None,
 									NULL);
 	}
 	else if (xkbInfo->desc->ctrls->enabled_ctrls&XkbAudibleBellMask) {
-	    (*dev->kbdfeed->BellProc)(ctrl->bell,dev,(pointer)ctrl,KbdFeedbackClass);
+	    (*dev->kbdfeed->BellProc)(ctrl->bell,dev,(void *)ctrl,KbdFeedbackClass);
 	}
 	ctrl->bell_duration= oldDuration;
 	ctrl->bell_pitch= oldPitch;
@@ -360,11 +360,11 @@ CARD32		 next;
 
     xkbInfo->beepType= what;
     xkbInfo->beepCount= 0;
-    next= _XkbDDXBeepExpire(NULL,0,(pointer)dev);
+    next= _XkbDDXBeepExpire(NULL,0,(void *)dev);
     if (next>0) {
 	xkbInfo->beepTimer= TimerSet(xkbInfo->beepTimer,
 					0, next,
-					_XkbDDXBeepExpire, (pointer)dev);
+					_XkbDDXBeepExpire, (void *)dev);
     }
     return 1;
 }

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -369,7 +369,7 @@ ProcXkbBell(ClientPtr client)
     WindowPtr	 pWin;
     int base;
     int newPercent,oldPitch,oldDuration;
-    pointer ctrl;
+    void * ctrl;
 
     REQUEST_SIZE_MATCH(xkbBellReq);
 
@@ -416,7 +416,7 @@ ProcXkbBell(ClientPtr client)
 	    return BadValue;
 	}
 	base = k->ctrl.bell;
-	ctrl = (pointer) &(k->ctrl);
+	ctrl = (void *) &(k->ctrl);
 	oldPitch= k->ctrl.bell_pitch;
 	oldDuration= k->ctrl.bell_duration;
 	if (stuff->pitch!=0) {
@@ -445,7 +445,7 @@ ProcXkbBell(ClientPtr client)
 	    return BadValue;
 	}
 	base = b->ctrl.percent;
-	ctrl = (pointer) &(b->ctrl);
+	ctrl = (void *) &(b->ctrl);
 	oldPitch= b->ctrl.pitch;
 	oldDuration= b->ctrl.duration;
 	if (stuff->pitch!=0) {
@@ -6241,7 +6241,7 @@ ProcXkbDispatch (ClientPtr client)
 }
 
 static int
-XkbClientGone(pointer data,XID id)
+XkbClientGone(void * data,XID id)
 {
     DevicePtr	pXDev = (DevicePtr)data;
 

--- a/nx-X11/programs/Xserver/xkb/xkb.h
+++ b/nx-X11/programs/Xserver/xkb/xkb.h
@@ -51,7 +51,7 @@ extern Bool XkbApplyLEDChangeToKeyboard(
     Bool                    on,
     XkbChangesPtr           change);
 
-extern Bool XkbWriteRulesProp(ClientPtr client, pointer closure);
+extern Bool XkbWriteRulesProp(ClientPtr client, void * closure);
 
 extern XkbAction XkbGetButtonAction(DeviceIntPtr kbd, DeviceIntPtr dev, int button);
 

--- a/nx-X11/programs/Xserver/xkb/xkbAccessX.c
+++ b/nx-X11/programs/Xserver/xkb/xkbAccessX.c
@@ -47,7 +47,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 int	XkbDfltRepeatDelay=	660;
 int	XkbDfltRepeatInterval=	40;
-pointer	XkbLastRepeatEvent=	NULL;
+void *	XkbLastRepeatEvent=	NULL;
 
 #define	DFLT_TIMEOUT_CTRLS (XkbAX_KRGMask|XkbStickyKeysMask|XkbMouseKeysMask)
 #define	DFLT_TIMEOUT_OPTS  (XkbAX_IndicatorFBMask)
@@ -141,7 +141,7 @@ xEvent		xE;
     if (_XkbIsPressEvent(type))
 	XkbDDXKeyClick(keybd,keyCode,TRUE);
     else if (isRepeat)
-	XkbLastRepeatEvent=	(pointer)&xE;
+	XkbLastRepeatEvent=	(void *)&xE;
     XkbProcessKeyboardEvent(&xE,keybd,1L);
     XkbLastRepeatEvent= NULL;
     return;
@@ -286,7 +286,7 @@ XkbSrvLedInfoPtr	sli;
 } /* AccessXStickyKeysTurnOff */
 
 static CARD32
-AccessXKRGExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+AccessXKRGExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 XkbSrvInfoPtr		xkbi= ((DeviceIntPtr)arg)->key->xkbInfo;
 xkbControlsNotify	cn;
@@ -308,7 +308,7 @@ xkbControlsNotify	cn;
 }
 
 static CARD32
-AccessXRepeatKeyExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+AccessXRepeatKeyExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 XkbSrvInfoPtr	xkbi= ((DeviceIntPtr)arg)->key->xkbInfo;
 KeyCode		key;
@@ -330,7 +330,7 @@ AccessXCancelRepeatKey(XkbSrvInfoPtr xkbi,KeyCode key)
 }
 
 static CARD32
-AccessXSlowKeyExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+AccessXSlowKeyExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 DeviceIntPtr	keybd;
 XkbSrvInfoPtr	xkbi;
@@ -370,7 +370,7 @@ XkbControlsPtr	ctrls;
 		xkbi->repeatKey = xkbi->slowKey;
 		xkbi->repeatKeyTimer= TimerSet(xkbi->repeatKeyTimer,
 					0, ctrls->repeat_delay,
-					AccessXRepeatKeyExpire, (pointer)keybd);
+					AccessXRepeatKeyExpire, (void *)keybd);
 	    }
 	}
     }
@@ -378,7 +378,7 @@ XkbControlsPtr	ctrls;
 }
 
 static CARD32
-AccessXBounceKeyExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+AccessXBounceKeyExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 XkbSrvInfoPtr	xkbi= ((DeviceIntPtr)arg)->key->xkbInfo;
 
@@ -387,7 +387,7 @@ XkbSrvInfoPtr	xkbi= ((DeviceIntPtr)arg)->key->xkbInfo;
 }
 
 static CARD32
-AccessXTimeoutExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+AccessXTimeoutExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 DeviceIntPtr		dev = (DeviceIntPtr)arg;
 XkbSrvInfoPtr		xkbi= dev->key->xkbInfo;
@@ -466,12 +466,12 @@ KeySym *	sym = XkbKeySymsPtr(xkbi->desc,key);
 	    if (XkbAX_NeedFeedback(ctrls,XkbAX_SlowWarnFBMask)) {
 		xkbi->krgTimerActive = _KRG_WARN_TIMER;
 		xkbi->krgTimer= TimerSet(xkbi->krgTimer, 0, 4000,
-					AccessXKRGExpire, (pointer)keybd);
+					AccessXKRGExpire, (void *)keybd);
 	    }
 	    else {
 		xkbi->krgTimerActive = _KRG_TIMER;
 		xkbi->krgTimer= TimerSet(xkbi->krgTimer, 0, 8000,
-					AccessXKRGExpire, (pointer)keybd);
+					AccessXKRGExpire, (void *)keybd);
 	    }
 	    if (!(ctrls->enabled_ctrls & XkbSlowKeysMask)) {
 		CARD32 now= GetTimeInMillis();
@@ -510,7 +510,7 @@ KeySym *	sym = XkbKeySymsPtr(xkbi->desc,key);
 	xkbi->slowKey= key;
 	xkbi->slowKeysTimer = TimerSet(xkbi->slowKeysTimer,
 				 0, ctrls->slow_keys_delay,
-				 AccessXSlowKeyExpire, (pointer)keybd);
+				 AccessXSlowKeyExpire, (void *)keybd);
 	ignoreKeyEvent = TRUE;
     }
 
@@ -543,7 +543,7 @@ KeySym *	sym = XkbKeySymsPtr(xkbi->desc,key);
 		xkbi->repeatKey = key;
 		xkbi->repeatKeyTimer= TimerSet(xkbi->repeatKeyTimer,
 					0, ctrls->repeat_delay,
-					AccessXRepeatKeyExpire, (pointer)keybd);
+					AccessXRepeatKeyExpire, (void *)keybd);
 	    }
 	}
     }
@@ -604,7 +604,7 @@ Bool		ignoreKeyEvent = FALSE;
 	xkbi->inactiveKey= key;
 	xkbi->bounceKeysTimer= TimerSet(xkbi->bounceKeysTimer, 0,
 					ctrls->debounce_delay,
-					AccessXBounceKeyExpire, (pointer)keybd);
+					AccessXBounceKeyExpire, (void *)keybd);
     }
 
     /* Don't transmit the KeyRelease if SlowKeys is turned on and
@@ -645,7 +645,7 @@ Bool		ignoreKeyEvent = FALSE;
 	xkbi->lastPtrEventTime= 0;
 	xkbi->krgTimer= TimerSet(xkbi->krgTimer, 0, 
 					ctrls->ax_timeout*1000,
-					AccessXTimeoutExpire, (pointer)keybd);
+					AccessXTimeoutExpire, (void *)keybd);
 	xkbi->krgTimerActive= _ALL_TIMEOUT_TIMER;
     }
     else if (xkbi->krgTimerActive!=_OFF_TIMER) {

--- a/nx-X11/programs/Xserver/xkb/xkbActions.c
+++ b/nx-X11/programs/Xserver/xkb/xkbActions.c
@@ -48,7 +48,7 @@ int xkbDevicePrivateIndex = -1;
 
 void
 xkbUnwrapProc(DeviceIntPtr device, DeviceHandleProc proc,
-                   pointer data)
+                   void * data)
 {
     xkbDeviceInfoPtr xkbPrivPtr = XKBDEVICEINFO(device);
     ProcessInputProc tmp = device->public.processInputProc;
@@ -533,7 +533,7 @@ _XkbFilterISOLock(	XkbSrvInfoPtr	xkbi,
 
 
 static CARD32
-_XkbPtrAccelExpire(OsTimerPtr timer,CARD32 now,pointer arg)
+_XkbPtrAccelExpire(OsTimerPtr timer,CARD32 now,void * arg)
 {
 XkbSrvInfoPtr	xkbi= (XkbSrvInfoPtr)arg;
 XkbControlsPtr	ctrls= xkbi->desc->ctrls;
@@ -602,7 +602,7 @@ Bool	accel;
 	xkbi->mouseKeysDY= XkbPtrActionY(&pAction->ptr);
 	xkbi->mouseKeyTimer= TimerSet(xkbi->mouseKeyTimer, 0,
 				xkbi->desc->ctrls->mk_delay,
-				_XkbPtrAccelExpire,(pointer)xkbi);
+				_XkbPtrAccelExpire,(void *)xkbi);
     }
     else if (filter->keycode==keycode) {
 	filter->active = 0;

--- a/nx-X11/programs/Xserver/xkb/xkbEvents.c
+++ b/nx-X11/programs/Xserver/xkb/xkbEvents.c
@@ -383,7 +383,7 @@ XkbHandleBell(	BOOL		 force,
 		BOOL		 eventOnly,
 		DeviceIntPtr	 kbd,
 		CARD8		 percent,
-		pointer		 pCtrl,
+		void *		 pCtrl,
 		CARD8		 class,
 		Atom		 name,
 		WindowPtr	 pWin,
@@ -402,7 +402,7 @@ XID		winID = 0;
 
     if ((force||(xkbi->desc->ctrls->enabled_ctrls&XkbAudibleBellMask))&&
 							(!eventOnly)) {
-	(*kbd->kbdfeed->BellProc)(percent,kbd,(pointer)pCtrl,class);
+	(*kbd->kbdfeed->BellProc)(percent,kbd,(void *)pCtrl,class);
     }
     interest = kbd->xkb_interest;
     if ((!interest)||(force))
@@ -822,7 +822,7 @@ XkbSrvInfoPtr	xkbi;
 	    ErrorF("   Event state= 0x%04x\n",xE[0].u.keyButtonPointer.state);
 	    ErrorF("   XkbLastRepeatEvent!=xE (0x%x!=0x%x) %s\n",
 			XkbLastRepeatEvent,xE,
-			((XkbLastRepeatEvent!=(pointer)xE)?"True":"False"));
+			((XkbLastRepeatEvent!=(void *)xE)?"True":"False"));
 	    ErrorF("   (xkbClientEventsFlags&XWDA)==0 (0x%x) %s\n",
 		pClient->xkbClientFlags,
 		(_XkbWantsDetectableAutoRepeat(pClient)?"True":"False"));
@@ -830,7 +830,7 @@ XkbSrvInfoPtr	xkbi;
 			(!_XkbIsReleaseEvent(xE[0].u.u.type))?"True":"False");
 	}
 #endif /* DEBUG */
-	if (	(XkbLastRepeatEvent==(pointer)xE) &&
+	if (	(XkbLastRepeatEvent==(void *)xE) &&
 	     	(_XkbWantsDetectableAutoRepeat(pClient)) &&
 	     	(_XkbIsReleaseEvent(xE[0].u.u.type)) ) {
 	    return False;

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -168,7 +168,7 @@ XkbGetRulesDflts(XkbRF_VarDefsPtr defs)
 }
 
 Bool
-XkbWriteRulesProp(ClientPtr client, pointer closure)
+XkbWriteRulesProp(ClientPtr client, void * closure)
 {
 int 			len,out;
 Atom			name;
@@ -296,7 +296,7 @@ XkbSetRulesDflts(char *rulesFile,char *model,char *layout,
 #include "xkbDflts.h"
 
 /* A dummy to keep the compiler quiet */
-pointer xkbBogus = &indicators;
+void * xkbBogus = &indicators;
 
 static Bool
 XkbInitKeyTypes(XkbDescPtr xkb,SrvXkmInfo *file)
@@ -619,7 +619,7 @@ XkbInitKeyboardDeviceStruct(
     void                        (*bellProc)(
         int /*percent*/,
         DeviceIntPtr /*device*/,
-        pointer /*ctrl*/,
+        void * /*ctrl*/,
         int),
     void                        (*ctrlProc)(
         DeviceIntPtr /*device*/,

--- a/nx-X11/programs/Xserver/xkb/xkbPrKeyEv.c
+++ b/nx-X11/programs/Xserver/xkb/xkbPrKeyEv.c
@@ -76,7 +76,7 @@ unsigned        ndx;
 	    case XkbKB_Default:
 		if (( xE->u.u.type == KeyPress ) && 
 		    (keyc->down[key>>3] & (1<<(key&7)))) {
-		    XkbLastRepeatEvent=	(pointer)xE;
+		    XkbLastRepeatEvent=	(void *)xE;
 		    xE->u.u.type = KeyRelease;
 		    XkbHandleActions(keybd,keybd,xE,count);
 		    xE->u.u.type = KeyPress;
@@ -86,7 +86,7 @@ unsigned        ndx;
 		}
 		else if ((xE->u.u.type==KeyRelease) &&
 			(!(keyc->down[key>>3]&(1<<(key&7))))) {
-		    XkbLastRepeatEvent=	(pointer)&xE;
+		    XkbLastRepeatEvent=	(void *)&xE;
 		    xE->u.u.type = KeyPress;
 		    XkbHandleActions(keybd,keybd,xE,count);
 		    xE->u.u.type = KeyRelease;


### PR DESCRIPTION
While looking at libNX_Xtst and libNX_Xext  I stumbled over a type declaration named "pointer" (defined as "void *") that got removed all over the Xserver code in X.Org [1] for a good reason (dupilicate use of pointer as type and pointer as var name).

Rather than backporting the exact patch, I have used several rounds of sed magic + build tests + manual editings.

Note: Don't merge this PR before #57 has been merged.

[1] http://cgit.freedesktop.org/xorg/xserver/commit/?id=60014a4a98ff924ae7f6840781f768c1cc93bbab
