### PR TITLE
Fix alpha premultiplication in XRenderParseColor.

### DIFF
--- a/nx-X11/lib/Xrender/Color.c
+++ b/nx-X11/lib/Xrender/Color.c
@@ -85,8 +85,8 @@ XRenderParseColor(Display *dpy, char *spec, XRenderColor *def)
 	def->blue = coreColor.blue;
 	def->alpha = 0xffff;
     }
-    def->red = (def->red * def->alpha) / 65535;
-    def->green = (def->green * def->alpha) / 65535;
-    def->blue = (def->blue * def->alpha) / 65535;
+    def->red = (def->red * def->alpha) / 0xffffU;
+    def->green = (def->green * def->alpha) / 0xffffU;
+    def->blue = (def->blue * def->alpha) / 0xffffU;
     return 1;
 }


### PR DESCRIPTION
 Due to C arithmetic conversion rules we must use an unsigned constant (or a
 cast) to perform the multiplication using unsigned arithmetic.

 Fixes ArcticaProject/nx-libs#55.

 Author: Emanuele Giaquinta emanuele.giaquinta@gmail.com
 Reviewed-by: Jeremy Huddleston jeremyhu@apple.com
 Rebased against NX: Mike Gabriel mike.gabriel@das-netzwerkteam.de
