### PR TITLE
 On realloc failure, free font_path_string instead of leaking it

### DIFF
--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -1929,11 +1929,14 @@ GetFontPath(int *count, int *length)
 	fpe = font_path_elements[i];
 	len += fpe->name_length + 1;
     }
-    font_path_string = (unsigned char *) xrealloc(font_path_string, len);
-    if (!font_path_string)
-	return NULL;
+    c = realloc(font_path_string, len);
+    if (c == NULL) {
+	free(font_path_string);
+	font_path_string = NULL;
+	return BadAlloc;
+    }
 
-    c = font_path_string;
+    font_path_string = c;
     *length = 0;
     for (i = 0; i < num_fpes; i++) {
 	fpe = font_path_elements[i];


### PR DESCRIPTION
Flagged by cppcheck 1.62:
[dix/dixfonts.c:1792]: (error) Common realloc mistake:
 'font_path_string' nulled but not freed upon failure

Picked from X.Org upstream.

Note: Don't merge this PR before https://github.com/ArcticaProject/nx-libs/pull/54 has been merged.
