### PR TITLE
Add pkg-config support to nxcomp, nxcompext and nxcompshad

### DIFF
--- a/nxcomp/Makefile.in
+++ b/nxcomp/Makefile.in
@@ -58,14 +58,15 @@ LIBS        = @LIBS@
 # Other autoconfigured settings, not used at the moment.
 #
 
-srcdir      = @srcdir@
-prefix      = @prefix@
-exec_prefix = @exec_prefix@
-bindir      = @bindir@
-man1dir     = @mandir@/man1
-VPATH       = @srcdir@
-libdir      = @libdir@
-includedir  = @includedir@
+srcdir       = @srcdir@
+prefix       = @prefix@
+exec_prefix  = @exec_prefix@
+bindir       = @bindir@
+man1dir      = @mandir@/man1
+VPATH        = @srcdir@
+libdir       = @libdir@
+includedir   = @includedir@
+pkgconfigdir = @pkgconfigdir@
 
 INSTALL         = @INSTALL@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
@@ -292,6 +293,7 @@ install.lib: all
 	$(INSTALL_DATA) $(LIBARCHIVE)           $(DESTDIR)${libdir}
 	$(INSTALL_DATA) NX*.h                   $(DESTDIR)${includedir}/nx
 	$(INSTALL_DATA) MD5.h                   $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) nxcomp.pc               $(DESTDIR)${pkgconfigdir}
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 install.man:
@@ -313,6 +315,7 @@ uninstall.lib:
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXrender.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXvars.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/MD5.h
+	$(RM_FILE) $(DESTDIR)${pkgconfigdir}/nxcomp.pc
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 uninstall.man:

--- a/nxcomp/configure.in
+++ b/nxcomp/configure.in
@@ -5,6 +5,9 @@ dnl Prolog
 AC_INIT(NX.h)
 AC_PREREQ(2.13)
 
+pkgconfigdir=${libdir}/pkgconfig
+AC_SUBST(pkgconfigdir)
+
 dnl Set our default compilation flags.
 
 CXXFLAGS="$CXXFLAGS -O3 -fno-rtti -fno-exceptions"
@@ -387,4 +390,4 @@ else
     ALL="\$(LIBFULL) \$(LIBLOAD) \$(LIBSHARED) \$(LIBARCHIVE)"
 fi
 
-AC_OUTPUT(Makefile)
+AC_OUTPUT(Makefile nxcomp.pc)

--- a/nxcomp/nxcomp.pc.in
+++ b/nxcomp/nxcomp.pc.in
@@ -1,0 +1,15 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: nxcomp
+Description: NX Compression Library
+Version: @VERSION@
+#libjepg does not provide a pkgconfig-file, zlib does not provide it for older versions
+#Requires: libjpeg zlib
+Requires: libpng
+Requires.private: x11
+Cflags: -I${includedir} -I${includedir}/nx
+Libs: -L${libdir} -lXcomp
+

--- a/nxcompext/Makefile.in
+++ b/nxcompext/Makefile.in
@@ -50,14 +50,15 @@ LIBS        = @LIBS@ -lz -lNX_X11 -lXcomp
 # LIBS = @LIBS@ -lz -ljpeg -lpthread -lNX_X11 -lXcomp
 #
 
-srcdir      = @srcdir@
-prefix      = @prefix@
-exec_prefix = @exec_prefix@
-bindir      = @bindir@
-man1dir     = @mandir@/man1
-VPATH       = @srcdir@
-libdir = @libdir@
-includedir = @includedir@
+srcdir       = @srcdir@
+prefix       = @prefix@
+exec_prefix  = @exec_prefix@
+bindir       = @bindir@
+man1dir      = @mandir@/man1
+VPATH        = @srcdir@
+libdir       = @libdir@
+includedir   = @includedir@
+pkgconfigdir = @pkgconfigdir@
 
 INSTALL         = @INSTALL@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
@@ -171,6 +172,7 @@ install.lib: all
 	$(INSTALL_LINK) $(LIBLOAD)              $(DESTDIR)${libdir}
 	$(INSTALL_LINK) $(LIBSHARED)            $(DESTDIR)${libdir}
 	$(INSTALL_DATA) NX*.h                   $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) nxcompext.pc            $(DESTDIR)${pkgconfigdir}
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 install.man:
@@ -185,6 +187,7 @@ uninstall.lib:
 	$(RM_FILE) $(DESTDIR)${libdir}/$(LIBSHARED)
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXlib.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXlibint.h
+	$(RM_FILE) $(DESTDIR)${pkgconfigdir}/nxcompext.pc
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 uninstall.man:

--- a/nxcompext/configure.in
+++ b/nxcompext/configure.in
@@ -5,6 +5,9 @@ dnl Prolog
 AC_INIT(NXlib.h)
 AC_PREREQ(2.13)
 
+pkgconfigdir=${libdir}/pkgconfig
+AC_SUBST(pkgconfigdir)
+
 dnl Reset default compilation flags.
 
 CXXFLAGS="$CXXFLAGS -O3"
@@ -243,4 +246,4 @@ else
     ALL="\$(LIBFULL) \$(LIBLOAD) \$(LIBSHARED) \$(LIBARCHIVE)"
 fi
 
-AC_OUTPUT(Makefile)
+AC_OUTPUT(Makefile nxcompext.pc)

--- a/nxcompext/nxcompext.pc.in
+++ b/nxcompext/nxcompext.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: nxcompext
+Description: Extension for NX Compression Library
+Version: @VERSION@
+Requires: nxcomp
+Requires.private: x11
+Cflags: -I${includedir} -I${includedir}/nx
+Libs: -L${libdir} -lXcompext
+

--- a/nxcompshad/Makefile.in
+++ b/nxcompshad/Makefile.in
@@ -68,14 +68,15 @@ LIBS        = @LIBS@ -lNX_X11
 # LIBS = $(LIBS) -lmpatrol -lbfd -liberty
 #
 
-srcdir      = @srcdir@
-prefix      = @prefix@
-exec_prefix = @exec_prefix@
-bindir      = @bindir@
-man1dir     = @mandir@/man1
-VPATH       = @srcdir@
-libdir      = @libdir@
-includedir  = @includedir@
+srcdir       = @srcdir@
+prefix       = @prefix@
+exec_prefix  = @exec_prefix@
+bindir       = @bindir@
+man1dir      = @mandir@/man1
+VPATH        = @srcdir@
+libdir       = @libdir@
+includedir   = @includedir@
+pkgconfigdir = @pkgconfigdir@
 
 INSTALL         = @INSTALL@
 INSTALL_DIR     = $(INSTALL) -d -o root -g root -m 0755 
@@ -206,6 +207,7 @@ install.lib: all
 	$(INSTALL_LINK) $(LIBSHARED)            $(DESTDIR)${libdir}
 	$(INSTALL_DATA) $(LIBARCHIVE)           $(DESTDIR)${libdir}
 	$(INSTALL_DATA) *.h                     $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) nxcompshad.pc           $(DESTDIR)${pkgconfigdir}
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 install.man:
@@ -222,6 +224,7 @@ uninstall.lib:
 	for header in *.h; do $(RM_FILE) $(DESTDIR)${includedir}/nx/$$header; done
 	$(RM_DIR) $(DESTDIR)${libdir}/nx/
 	$(RM_DIR) $(DESTDIR)${includedir}/nx/
+	$(RM_FILE) $(DESTDIR)${pkgconfigdir}/nxcompshad.pc
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
 uninstall.man:

--- a/nxcompshad/configure.in
+++ b/nxcompshad/configure.in
@@ -5,6 +5,9 @@ dnl Prolog
 AC_INIT(Shadow.h)
 AC_PREREQ(2.13)
 
+pkgconfigdir=${libdir}/pkgconfig
+AC_SUBST(pkgconfigdir)
+
 dnl Reset default compilation flags.
 
 CXXFLAGS="$CXXFLAGS -O3"
@@ -281,4 +284,4 @@ if test -z "${MAKEDEPEND}"; then
   fi
 fi
 
-AC_OUTPUT(Makefile)
+AC_OUTPUT(Makefile nxcompshad.pc)

--- a/nxcompshad/nxcompshad.pc.in
+++ b/nxcompshad/nxcompshad.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: nxcompshad
+Description: Shadow Session Support for NX Compression Library
+Version: @VERSION@
+Requires: nxcomp
+Requires.private: x11
+Cflags: -I${includedir} -I${includedir}/nx
+Libs: -L${libdir} -lXcompshad
+


### PR DESCRIPTION
Add (rudimentary) pkg-config support to the nx libraries. 

The .pc files should also be included to the resulting -dev packages (for debian) but I do not know what needs to be done for that. So please can someone have a look a this?
