### PR TITLE
use xfree instead of free for xalloced data

### DIFF
--- a/nx-X11/programs/Xserver/randr/rrmode.c
+++ b/nx-X11/programs/Xserver/randr/rrmode.c
@@ -99,7 +99,7 @@ RRModeCreate (xRRModeInfo   *modeInfo,
 
     mode->mode.id = FakeClientID(0);
     if (!AddResource(mode->mode.id, RRModeType, (pointer) mode)) {
-        free(newModes);
+        xfree(newModes);
         return NULL;
     }
     modes = newModes;

--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -943,12 +943,12 @@ ProcRRSetScreenConfig (ClientPtr client)
 
     if (width < pScrPriv->minWidth || pScrPriv->maxWidth < width) {
 	client->errorValue = width;
-	free(pData);
+	xfree (pData);
 	return BadValue;
     }
     if (height < pScrPriv->minHeight || pScrPriv->maxHeight < height) {
 	client->errorValue = height;
-	free(pData);
+	xfree (pData);
 	return BadValue;
     }
 


### PR DESCRIPTION
This was brought in by a backport since in later versions xalloc/xfree have
been replaced by malloc/free.
