### PR TITLE
Include system wide headers for nxcomp, nxcompext, nxcompshad

### DIFF
--- a/debian/libxcomp-dev.install.in
+++ b/debian/libxcomp-dev.install.in
@@ -1,10 +1,8 @@
 usr/lib/*/libXcomp.so
 usr/include/*/nx/NX.h
 usr/include/*/nx/NXalert.h
-usr/include/*/nx/NXmitshm.h
 usr/include/*/nx/NXpack.h
 usr/include/*/nx/NXproto.h
-usr/include/*/nx/NXrender.h
 usr/include/*/nx/NXvars.h
 usr/include/*/nx/MD5.h
 usr/lib/*/pkgconfig/nxcomp.pc

--- a/debian/libxcompshad-dev.install.in
+++ b/debian/libxcompshad-dev.install.in
@@ -1,13 +1,3 @@
 usr/lib/*/libXcompshad.so
-usr/include/*/nx/Core.h
-usr/include/*/nx/Input.h
-usr/include/*/nx/Logger.h
-usr/include/*/nx/Manager.h
-usr/include/*/nx/Misc.h
-usr/include/*/nx/Poller.h
-usr/include/*/nx/Regions.h
 usr/include/*/nx/Shadow.h
-usr/include/*/nx/Updater.h
-usr/include/*/nx/Win.h
-usr/include/*/nx/X11.h
 usr/lib/*/pkgconfig/nxcompshad.pc

--- a/nx-X11/lib/X11/XlibInt.c
+++ b/nx-X11/lib/X11/XlibInt.c
@@ -118,12 +118,12 @@ xthread_t (*_Xthread_self_fn)(void) = NULL;
 
 #endif /* XTHREADS else */ 
 
-#include "NX.h"
+#include <nx/NX.h>
 
 #ifdef NX_TRANS_SOCKET
 
-#include "NX.h"
-#include "NXvars.h"
+#include <nx/NX.h>
+#include <nx/NXvars.h>
 
 static struct timeval retry;
 

--- a/nx-X11/lib/X11/Xlibint.h
+++ b/nx-X11/lib/X11/Xlibint.h
@@ -64,7 +64,7 @@ from The Open Group.
 
 #ifdef NX_TRANS_SOCKET
 
-#include "NXvars.h"
+#include <nx/NXvars.h>
 
 #define _XGetIOError(dpy) \
     (dpy -> flags & XlibDisplayIOError)

--- a/nx-X11/lib/xtrans/Xtranssock.c
+++ b/nx-X11/lib/xtrans/Xtranssock.c
@@ -344,7 +344,7 @@ static int haveIPv6 = 1;
 
 #ifdef TRANS_CLIENT
 
-#include "NX.h"
+#include <nx/NX.h>
 
 typedef struct
 {

--- a/nx-X11/programs/Xserver/Imakefile
+++ b/nx-X11/programs/Xserver/Imakefile
@@ -318,6 +318,27 @@ NXAGENTDDXDIR = hw
 
 NXAGENTDIRS = $(STDDIRS) $(MFBDIR) $(FBDIR) $(MIDAMAGEDIR) $(NXAGENTDDXDIR) $(DEPDIRS)
 
+NX_XCOMP_HEADERS = \
+              ../../../nxcomp/NXalert.h         \
+              ../../../nxcomp/NX.h              \
+              ../../../nxcomp/NXpack.h          \
+              ../../../nxcomp/NXproto.h         \
+              ../../../nxcomp/NXvars.h
+
+NX_XCOMPEXT_HEADERS =                           \
+              ../../../nxcompext/NXlib.h        \
+              ../../../nxcompext/NXlibint.h
+
+NX_XCOMPSHAD_HEADERS =                          \
+              ../../../nxcompshad/Shadow.h
+
+NX_HEADERS =                                    \
+             $(NX_XCOMP_HEADERS)                \
+             $(NX_XCOMPEXT_HEADERS)             \
+             $(NX_XCOMPSHAD_HEADERS)
+
+BuildIncludes($(NX_HEADERS),nx,..)
+
 #if defined(SunArchitecture) || \
     defined(SparcArchitecture)
 NXAGENTOBJS = hw/nxagent/miinitext.o     \

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -67,8 +67,8 @@ is" without express or implied warranty.
  * NX includes and definitions.
  */
 
-#include "NXlib.h"
-#include "NXpack.h"
+#include <nx/NXlib.h>
+#include <nx/NXpack.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
@@ -26,7 +26,7 @@
 #include "scrnintstr.h"
 #include "resource.h"
 
-#include "NXpack.h"
+#include <nx/NXpack.h>
 
 #include "Atoms.h"
 #include "Args.h"

--- a/nx-X11/programs/Xserver/hw/nxagent/Binder.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Binder.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "NX.h"
+#include <nx/NX.h>
 
 #include "Binder.h"
 #include "Options.h"

--- a/nx-X11/programs/Xserver/hw/nxagent/Client.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Client.c
@@ -23,7 +23,7 @@
 #include <time.h>
 #include <errno.h>
 
-#include "NX.h"
+#include <nx/NX.h>
 
 #include "Xatom.h"
 #include "dixstruct.h"
@@ -49,7 +49,7 @@
  * definition of GC in Agent.h.
  */
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -39,7 +39,7 @@
  * Use asyncronous get property replies.
  */
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
@@ -57,7 +57,7 @@ is" without express or implied warranty.
 #include "windowstr.h"
 #include "resource.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
@@ -33,9 +33,9 @@
 #include "Display.h"
 #include "Dialog.h"
 
-#include "NX.h"
-#include "NXlib.h"
-#include "NXalert.h"
+#include <nx/NX.h>
+#include <nx/NXlib.h>
+#include <nx/NXalert.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -52,7 +52,7 @@ is" without express or implied warranty.
 #include "unistd.h"
 #endif
 
-#include "NXalert.h"
+#include <nx/NXalert.h>
 
 #include "Agent.h"
 #include "Display.h"
@@ -77,8 +77,8 @@ is" without express or implied warranty.
 #include "Screen.h"
 #include "Handlers.h"
 
-#include "NX.h"
-#include "NXlib.h"
+#include <nx/NX.h>
+#include <nx/NXlib.h>
 
 #include NXAGENT_ICON_NAME
 #include X2GOAGENT_ICON_NAME

--- a/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
@@ -34,7 +34,7 @@
 #include "Reconnect.h"
 #include "GCOps.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 #include "mibstorest.h"
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -58,9 +58,9 @@
 #include "Utils.h"
 #include "Error.h"
 
-#include "NX.h"
-#include "NXvars.h"
-#include "NXproto.h"
+#include <nx/NX.h>
+#include <nx/NXvars.h>
+#include <nx/NXproto.h>
 
 #include "xfixesproto.h"
 #define Window     XlibWindow
@@ -92,10 +92,10 @@
 
 #include <nx-X11/cursorfont.h>
 
-#include "Shadow.h"
+#include <nx/Shadow.h>
 #include "X11/include/Xrandr_nxagent.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level. Please note

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -50,8 +50,8 @@ is" without express or implied warranty.
 
 #include "Args.h"
 
-#include "NXlib.h"
-#include "NXalert.h"
+#include <nx/NXlib.h>
+#include <nx/NXalert.h>
 
 #include <string.h>
 #include <stdlib.h>

--- a/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
@@ -50,7 +50,7 @@ is" without express or implied warranty.
 #include "Args.h"
 #include "Screen.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
@@ -32,8 +32,8 @@
 #include "Screen.h"
 #include "Millis.h"
 
-#include "NXlib.h"
-#include "Shadow.h"
+#include <nx/NXlib.h>
+#include <nx/Shadow.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Image.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Image.c
@@ -37,8 +37,8 @@
 #include "Pixels.h"
 #include "Utils.h"
 
-#include "NXlib.h"
-#include "NXpack.h"
+#include <nx/NXlib.h>
+#include <nx/NXpack.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Imakefile
+++ b/nx-X11/programs/Xserver/hw/nxagent/Imakefile
@@ -133,7 +133,7 @@ OBJS =  NXwindow.o \
 
 VFBINCLUDES = -I../../fb -I../../mfb -I../../render
 
-INCLUDES = -I. -I../../../../../nxcomp -I../../../../../nxcompext -I../../../../../nxcompshad \
+INCLUDES = -I. \
            -I../../../../extras/Mesa/include \
 	   -I$(XBUILDINCDIR) \
 	   -I../../mi -I../../include -I../../os \
@@ -144,7 +144,7 @@ INCLUDES = -I. -I../../../../../nxcomp -I../../../../../nxcompext -I../../../../
            `pkg-config --cflags-only-I libxml-2.0` \
            `pkg-config --cflags-only-I pixman-1`
 #ifdef SunArchitecture
-INCLUDES = -I. -I../../../../../nxcomp -I../../../../../nxcompext -I../../../../../nxcompshad \
+INCLUDES = -I. \
            -I../../../../extras/Mesa/include \
 	   -I$(XBUILDINCDIR) \
 	   -I/usr/sfw/include \

--- a/nx-X11/programs/Xserver/hw/nxagent/Init.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Init.c
@@ -61,8 +61,8 @@ is" without express or implied warranty.
 #include "Millis.h"
 #include "Error.h"
 
-#include "NX.h"
-#include "NXlib.h"
+#include <nx/NX.h>
+#include <nx/NXlib.h>
 #include "Reconnect.h"
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -54,9 +54,9 @@ is" without express or implied warranty.
 #include "Options.h"
 #include "Error.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
-#include "Shadow.h"
+#include <nx/Shadow.h>
 
 #ifdef XKB
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -154,7 +154,7 @@ int ProcInitialConnection();
 #include "Reconnect.h"
 #include "Millis.h"
 #include "Font.h"
-#include "Shadow.h"
+#include <nx/Shadow.h>
 #include "Handlers.h"
 #include "Keyboard.h"
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -183,7 +183,7 @@ xEvent *xeviexE;
 #include "dixgrabs.h"
 #include "../../dix/dispatch.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 #include "Events.h"
 #include "Windows.h"

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
@@ -42,8 +42,8 @@
 #include "Holder.h"
 #include "Args.h"
 
-#include "NXlib.h"
-#include "NXpack.h"
+#include <nx/NXlib.h>
+#include <nx/NXpack.h>
 
 RESTYPE  RT_NX_PIXMAP;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
@@ -46,7 +46,7 @@ is" without express or implied warranty.
 #include "Events.h"
 #include "Options.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
@@ -49,9 +49,9 @@
 #include "XKBsrv.h"
 #endif
 
-#include "NX.h"
-#include "NXlib.h"
-#include "NXalert.h"
+#include <nx/NX.h>
+#include <nx/NXlib.h>
+#include <nx/NXalert.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Render.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.c
@@ -54,7 +54,7 @@
 #include "Pixels.h"
 #include "Handlers.h"
 
-#include "NXproto.h"
+#include <nx/NXproto.h>
 
 #define MAX_FORMATS 255
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -30,7 +30,7 @@
 #include "Atoms.h"
 #include "Trap.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 /*
  * Set here the required log level.

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -74,7 +74,7 @@ is" without express or implied warranty.
 #include "Pointer.h"
 #include "Reconnect.h"
 #include "Composite.h"
-#include "Shadow.h"
+#include <nx/Shadow.h>
 #include "Utils.h"
 
 #include "X11/include/Xrandr_nxagent.h"
@@ -96,7 +96,7 @@ is" without express or implied warranty.
 #include "Xatom.h"
 #include "Xproto.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 #include "mibstorest.h"
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Splash.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Splash.h
@@ -20,7 +20,7 @@
 
 #include "Windows.h"
 #include "X11/Xdmcp.h"
-#include "NXalert.h"
+#include <nx/NXalert.h>
 
 #define XDM_TIMEOUT       20000
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Split.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Split.c
@@ -26,7 +26,7 @@
 #include "Events.h"
 #include "GCs.h"
 
-#include "NXlib.h"
+#include <nx/NXlib.h>
 
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -56,8 +56,8 @@
 #include "Composite.h"
 #include "Events.h"
 
-#include "NX.h"
-#include "NXlib.h"
+#include <nx/NX.h>
+#include <nx/NXlib.h>
 
 #include "Xatom.h"
 

--- a/nx-X11/programs/Xserver/os/log.c
+++ b/nx-X11/programs/Xserver/os/log.c
@@ -117,7 +117,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 
 #ifdef NX_TRANS_SOCKET
 
-#include "NX.h"
+#include <nx/NX.h>
 
 #endif
 

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -229,8 +229,8 @@ Bool noXvExtension = FALSE;
 
 #ifdef NX_TRANS_SOCKET
 
-#include "NX.h"
-#include "NXvars.h"
+#include <nx/NX.h>
+#include <nx/NXvars.h>
 
 #endif
 

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -580,10 +580,8 @@ rm -r %{buildroot}%{_includedir}/nx-X11/Xtrans
 %{_includedir}/nx/MD5.h
 %{_includedir}/nx/NX.h
 %{_includedir}/nx/NXalert.h
-%{_includedir}/nx/NXmitshm.h
 %{_includedir}/nx/NXpack.h
 %{_includedir}/nx/NXproto.h
-%{_includedir}/nx/NXrender.h
 %{_includedir}/nx/NXvars.h
 %{_libdir}/pkgconfig/nxcomp.pc
 

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -609,17 +609,7 @@ rm -r %{buildroot}%{_includedir}/nx-X11/Xtrans
 %files -n libXcompshad-devel
 %defattr(-,root,root)
 %_libdir/libXcompshad.so
-%{_includedir}/nx/Core.h
-%{_includedir}/nx/Input.h
-%{_includedir}/nx/Logger.h
-%{_includedir}/nx/Manager.h
-%{_includedir}/nx/Misc.h
-%{_includedir}/nx/Poller.h
-%{_includedir}/nx/Regions.h
 %{_includedir}/nx/Shadow.h
-%{_includedir}/nx/Updater.h
-%{_includedir}/nx/Win.h
-%{_includedir}/nx/X11.h
 %{_libdir}/pkgconfig/nxcompshad.pc
 
 %files -n libXcompshad3

--- a/nxcomp/Makefile.in
+++ b/nxcomp/Makefile.in
@@ -283,8 +283,12 @@ install.lib: all
 	$(INSTALL_LINK) $(LIBLOAD)              $(DESTDIR)${libdir}
 	$(INSTALL_LINK) $(LIBSHARED)            $(DESTDIR)${libdir}
 	$(INSTALL_DATA) $(LIBARCHIVE)           $(DESTDIR)${libdir}
-	$(INSTALL_DATA) NX*.h                   $(DESTDIR)${includedir}/nx
 	$(INSTALL_DATA) MD5.h                   $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) NX.h                    $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) NXalert.h               $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) NXpack.h                $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) NXproto.h               $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) NXvars.h                $(DESTDIR)${includedir}/nx
 	$(INSTALL_DATA) nxcomp.pc               $(DESTDIR)${pkgconfigdir}
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 
@@ -301,10 +305,8 @@ uninstall.lib:
 	$(RM_FILE) $(DESTDIR)${libdir}/$(LIBARCHIVE)
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXalert.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NX.h
-	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXmitshm.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXpack.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXproto.h
-	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXrender.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/NXvars.h
 	$(RM_FILE) $(DESTDIR)${includedir}/nx/MD5.h
 	$(RM_FILE) $(DESTDIR)${pkgconfigdir}/nxcomp.pc

--- a/nxcomp/nxcomp.pc.in
+++ b/nxcomp/nxcomp.pc.in
@@ -10,6 +10,6 @@ Version: @VERSION@
 #Requires: libjpeg zlib
 Requires: libpng
 Requires.private: x11
-Cflags: -I${includedir} -I${includedir}/nx
+Cflags: -I${includedir}
 Libs: -L${libdir} -lXcomp
 

--- a/nxcompext/nxcompext.pc.in
+++ b/nxcompext/nxcompext.pc.in
@@ -8,6 +8,6 @@ Description: Extension for NX Compression Library
 Version: @VERSION@
 Requires: nxcomp
 Requires.private: x11
-Cflags: -I${includedir} -I${includedir}/nx
+Cflags: -I${includedir}
 Libs: -L${libdir} -lXcompext
 

--- a/nxcompshad/Makefile.in
+++ b/nxcompshad/Makefile.in
@@ -210,7 +210,7 @@ install.lib: all
 	$(INSTALL_LINK) $(LIBLOAD)              $(DESTDIR)${libdir}
 	$(INSTALL_LINK) $(LIBSHARED)            $(DESTDIR)${libdir}
 	$(INSTALL_DATA) $(LIBARCHIVE)           $(DESTDIR)${libdir}
-	$(INSTALL_DATA) *.h                     $(DESTDIR)${includedir}/nx
+	$(INSTALL_DATA) Shadow.h                $(DESTDIR)${includedir}/nx
 	$(INSTALL_DATA) nxcompshad.pc           $(DESTDIR)${pkgconfigdir}
 	echo "Running ldconfig tool, this may take a while..." && ldconfig || true
 

--- a/nxcompshad/nxcompshad.pc.in
+++ b/nxcompshad/nxcompshad.pc.in
@@ -8,6 +8,6 @@ Description: Shadow Session Support for NX Compression Library
 Version: @VERSION@
 Requires: nxcomp
 Requires.private: x11
-Cflags: -I${includedir} -I${includedir}/nx
+Cflags: -I${includedir}
 Libs: -L${libdir} -lXcompshad
 


### PR DESCRIPTION
Let's prepare for including nxcomp{,ext,shad} headers from a system-wide location.

Before reviewing this PR, the following PRs need to be reviewed:
https://github.com/ArcticaProject/nx-libs/pull/93
https://github.com/ArcticaProject/nx-libs/pull/102
https://github.com/ArcticaProject/nx-libs/pull/106
