### PR TITLE
Clean up compiler warnings in nxcomp

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -9393,12 +9393,7 @@ int ParseRemoteOptions(char *opts)
   int hasDelta  = 0;
   int hasStream = 0;
   int hasData   = 0;
-  int hasLimit  = 0;
-  int hasRender = 0;
-  int hasTaint  = 0;
   int hasType   = 0;
-  int hasStrict = 0;
-  int hasShseg  = 0;
 
   //
   // Get rid of the terminating space.
@@ -9623,7 +9618,6 @@ int ParseRemoteOptions(char *opts)
         }
       }
 
-      hasLimit = 1;
     }
     else if (strcasecmp(name, "render") == 0)
     {
@@ -9636,7 +9630,6 @@ int ParseRemoteOptions(char *opts)
         useRender = ValidateArg("remote", name, value);
       }
 
-      hasRender = 1;
     }
     else if (strcasecmp(name, "taint") == 0)
     {
@@ -9649,7 +9642,6 @@ int ParseRemoteOptions(char *opts)
         useTaint = ValidateArg("remote", name, value);
       }
 
-      hasTaint = 1;
     }
     else if (strcasecmp(name, "type") == 0)
     {
@@ -9682,7 +9674,6 @@ int ParseRemoteOptions(char *opts)
         useStrict = ValidateArg("remote", name, value);
       }
 
-      hasStrict = 1;
     }
     else if (strcasecmp(name, "shseg") == 0)
     {
@@ -9704,7 +9695,6 @@ int ParseRemoteOptions(char *opts)
         return -1;
       }
 
-      hasShseg = 1;
     }
     else if (strcasecmp(name, "delta") == 0)
     {

--- a/nxcomp/Pipe.cpp
+++ b/nxcomp/Pipe.cpp
@@ -237,8 +237,14 @@ FILE *Popen(char * const parameters[], const char *type)
 
       struct passwd *pwent = getpwuid(getuid());
       if (pwent) initgroups(pwent->pw_name,getgid());
-      setgid(getgid());
-      setuid(getuid());
+      if (setgid(getgid()) == -1)
+      {
+        _exit(127);
+      }
+      if (setuid(getuid()) == -1)
+      {
+        _exit(127);
+      }
 
       if (*type == 'r')
       {

--- a/nxcomp/Proxy.h
+++ b/nxcomp/Proxy.h
@@ -985,7 +985,7 @@ class Proxy
   int handleLoadStores();
   int handleSaveStores();
 
-  char *handleSaveAllStores(const char *savePath) const;
+  char *handleSaveAllStores(const char *savePath, bool & isTooSmall) const;
 
   virtual int handleSaveAllStores(ostream *cachefs, md5_state_t *md5StateStream,
                                       md5_state_t *md5StateClient) const = 0;

--- a/nxcomp/ServerChannel.cpp
+++ b/nxcomp/ServerChannel.cpp
@@ -4374,6 +4374,24 @@ int ServerChannel::handleWrite(const unsigned char *message, unsigned int length
       } // End of switch on opcode.
 
       //
+      // TODO: at the moment the variable hit was being set
+      // but no used, so to avoid the corresponding warning
+      // it has been added this block with a logging command.
+      // This code will be probably optimized away when none
+      // of the defines is set, but if there is no additional
+      // use for the hit variable in the future, then maybe
+      // it could be removed completely.
+      //
+
+      if (hit)
+      {
+        #if defined(TEST) || defined(OPCODES)
+        *logofs << "handleWrite: Cached flag enabled in handled request.\n"
+                << logofs_flush;
+        #endif
+      }
+
+      //
       // A packed image request can generate more than just
       // a single X_PutImage. Write buffer is handled inside
       // handleUnpack(). Cannot simply assume that the final


### PR DESCRIPTION
Besides the warnings included in ArcticaProject's issue #103 there has
been removed another one related to setgid and setuid returning values
not being checked:

Pipe.cpp: In function ‘FILE\* Popen(char\* const_, const char_)’:
Pipe.cpp:240:23: warning: ignoring return value of ‘int setgid(__gid_t)’,
declared with attribute warn_unused_result [-Wunused-result]
       setgid(getgid());
                       ^
Pipe.cpp:241:23: warning: ignoring return value of ‘int setuid(__uid_t)’,
declared with attribute warn_unused_result [-Wunused-result]
       setuid(getuid());
                       ^

There was also a hidden problem in the way Proxy::handleSaveAllStores was
checking for an error in the returning value from the call to the virtual
method handleSaveAllStores of the specific proxy class really being used
(ClientProxy or ServerProxy).

Former code was considering the value 0 as the returning value in case of
an error whereas both subclasses return the value -1 when there is an error
in their handleSaveAllStores method.

This bug has been fixed in this commit taking advantage of the modification
that was already being made to this method in order to replace tempnam
function with the more secure one mkstemp.

Refs: ArcticaProject/nx-libs#103
