### PR TITLE
Properly enable/disable Xinerama support in nxagent via cmdline options.

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Options.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.c
@@ -155,7 +155,7 @@ void nxagentInitOptions()
 
   nxagentOptions.ImageRateLimit = 0;
 
-  nxagentOptions.Xinerama = 0;
+  nxagentOptions.Xinerama = 1;
 
   nxagentOptions.SleepTime = DEFAULT_SLEEP_TIME;
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -390,12 +390,12 @@ typedef struct _AgentOptions
   int NoRootlessExit;
 
  /*
-  * Store if the user wants Xinerama. There's a variable called
-  * noPanoramiXExtension in os/utils.c but we cannot rely on that
-  * because RandR and Panoramix change its value when trying to
-  * initialize. So we use this variable to save the user preference
-  * provided by the -/+xinerama parameter before initalizing those
-  * extensions.
+  * Store if the user wants Xinerama. There are variables called
+  * noPanoramiXExtension noRRXineramaExtensison in os/utils.c but
+  * we cannot rely on them because RandR and PanoramiX change their
+  * values when trying to initialize. So we use this variable to
+  * save the user preference provided by the -/+(rr)xinerama parameter(s)
+  * before initalizing those extensions.
   */
 
   int Xinerama;

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -1114,11 +1114,6 @@ Bool nxagentOpenScreen(int index, ScreenPtr pScreen,
   nxagentChangeOption(ViewportXSpan, nxagentOption(Width) - nxagentOption(RootWidth));
   nxagentChangeOption(ViewportYSpan, nxagentOption(Height) - nxagentOption(RootHeight));
 
-  /* PanoramiXExtension enabled via cmdline, turn on Xinerama in nxagent
-   */
-  if( (!noPanoramiXExtension) && (!PanoramiXExtensionDisabledHack) )
-    nxagentOption(Xinerama) = True;
-
   if (nxagentReconnectTrap == 0)
   {
     if (nxagentOption(Persistent))

--- a/nx-X11/programs/Xserver/include/globals.h
+++ b/nx-X11/programs/Xserver/include/globals.h
@@ -87,6 +87,7 @@ extern Bool noMITShmExtension;
 
 #ifdef RANDR
 extern Bool noRRExtension;
+extern Bool noRRXineramaExtension;
 #endif
 
 #ifdef RENDER

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -179,6 +179,7 @@ Bool noMITShmExtension = FALSE;
 #endif
 #ifdef RANDR
 Bool noRRExtension = FALSE;
+Bool noRRXineramaExtension = FALSE;
 #endif
 #ifdef RENDER
 Bool noRenderExtension = FALSE;
@@ -664,9 +665,13 @@ void UseMsg(void)
     ErrorF("-x string              loads named extension at init time \n");
     ErrorF("-maxbigreqsize         set maximal bigrequest size \n");
 #ifdef PANORAMIX
-    ErrorF("+xinerama              Enable XINERAMA extension\n");
-    ErrorF("-xinerama              Disable XINERAMA extension\n");
+    ErrorF("+xinerama              Enable XINERAMA (PanoramiX) extension\n");
+    ErrorF("-xinerama              Disable XINERAMA (PanoramiX) extension (default)\n");
     ErrorF("-disablexineramaextension Disable XINERAMA extension\n");
+#endif
+#ifdef RANDR
+    ErrorF("+rrxinerama            Enable XINERAMA (via RandR) extension (default)\n");
+    ErrorF("-rrxinerama            Disable XINERAMA (via RandR) extension\n");
 #endif
 #ifdef SMART_SCHEDULE
     ErrorF("-dumbSched             Disable smart scheduling, enable old behavior\n");
@@ -1035,6 +1040,14 @@ ProcessCommandLine(int argc, char *argv[])
 	}
 	else if ( strcmp( argv[i], "-disablexineramaextension") == 0){
 	    PanoramiXExtensionDisabledHack = TRUE;
+	}
+#endif
+#ifdef RANDR
+	else if ( strcmp( argv[i], "+rrxinerama") == 0){
+	    noRRXineramaExtension = FALSE;
+	}
+	else if ( strcmp( argv[i], "-rrxinerama") == 0){
+	    noRRXineramaExtension = TRUE;
 	}
 #endif
 	else if ( strcmp( argv[i], "-x") == 0)

--- a/nx-X11/programs/Xserver/randr/rrxinerama.c
+++ b/nx-X11/programs/Xserver/randr/rrxinerama.c
@@ -107,6 +107,8 @@ static int ProcRRXineramaIsActive(ClientPtr client);
 static int ProcRRXineramaQueryScreens(ClientPtr client);
 static int SProcRRXineramaDispatch(ClientPtr client);
 
+extern Bool noRRXineramaExtension;
+
 /* Proc */
 
 int


### PR DESCRIPTION
 Properly enable/disable Xinerama support in nxagent via cmdline options provider in Xserver/os/utils.c.

The first commit adds a cmdline switch to the Xserver code (Xserver/os/utils.c): +|-rrxinerama. With that switch, you can set the now global variable noRRXineramaExtension.

The second commit deals with setting nxagentOptions.Xinerama properly in the nxagent code, utilizing the new +|-rrxinerama command line switch and the globally accessible noRRXineramaExtension.

These behavious are expected (and have been tested):

```
  * Xinerama defaults to enabled, using RRXineramaExtension
    (i.e. cmdline option: +rrxinerama).
  * Cmdline option -rrxinerama disables Xinerama support entirely.
  * Cmdline option +xinerama switches from RRXineramaExtension to
    PanoramiXExtension.
  * Cmdline option -xinerama is actually non-functional (i.e. the
    default).
  * If the nx/nx option "xinerama" is handed over to nxagent,
    then Xinerama is only switched on if that given option enables it
    (value: 1) _and_ if either of the Xinerama extensions (PanoramiX
    or RRXinerama) has been initialized (via cmdline options above).
```
