### PR TITLE
Make the sleeping slowdown configurable.

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1339,6 +1339,44 @@ static void nxagentParseOptions(char *name, char *value)
       nxagentChangeOption(Clipboard, ClipboardBoth);
     }
   }
+  else if (!strcmp(name, "sleep"))
+  {
+    long sleep_parse = 0;
+
+    errno = 0;
+    sleep_parse = strtol(value, NULL, 10);
+
+    if ((errno) && (0 == sleep_parse))
+    {
+      fprintf(stderr, "nxagentParseOptions: Unable to convert value [%s] of option [%s]. "
+                      "Ignoring option.\n",
+                      validateString(value), validateString(name));
+
+      return;
+    }
+
+    if ((long) UINT_MAX < sleep_parse)
+    {
+      sleep_parse = UINT_MAX;
+
+      fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+                      "out of range, clamped to [%u].\n",
+                      validateString(value), validateString(name), sleep_parse);
+    }
+
+    if (0 > sleep_parse)
+    {
+      sleep_parse = 0;
+
+      fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+                      "out of range, clamped to [%u].\n",
+                      validateString(value), validateString(name), sleep_parse);
+    }
+
+    nxagentChangeOption(SleepTime, sleep_parse);
+
+    return;
+  }
   else
   {
     #ifdef DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Image.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Image.c
@@ -69,15 +69,6 @@
 #define IMAGE_UNIQUE_RATIO   10
 
 /*
- * Introduce a small delay after each image
- * operation if the session is down. Value
- * is in microseconds and is multiplied by
- * the image data size in kilobytes.
- */
-
-#define IMAGE_DELAY_IF_DOWN  250
-
-/*
  * Preferred pack and split parameters we
  * got from the NX transport.
  */
@@ -521,11 +512,12 @@ void nxagentPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth,
   length = nxagentImageLength(dstWidth, dstHeight, format, leftPad, depth);
 
   if (nxagentShadowCounter == 0 &&
-          NXDisplayError(nxagentDisplay) == 1)
+          NXDisplayError(nxagentDisplay) == 1 &&
+              nxagentOption(SleepTime) > 0)
   {
     int us;
 
-    us = IMAGE_DELAY_IF_DOWN * (length / 1024);
+    us = nxagentOption(SleepTime) * 4 * (length / 1024);
 
     us = (us < 10000 ? 10000 : (us > 1000000 ? 1000000 : us));
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.c
@@ -156,6 +156,8 @@ void nxagentInitOptions()
   nxagentOptions.ImageRateLimit = 0;
 
   nxagentOptions.Xinerama = 0;
+
+  nxagentOptions.SleepTime = DEFAULT_SLEEP_TIME;
 }
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -28,6 +28,7 @@
 
 #define UNDEFINED -1
 #define COPY_UNLIMITED -1
+#define DEFAULT_SLEEP_TIME 50
 
 extern unsigned int nxagentPrintGeometryFlags;
 
@@ -398,6 +399,12 @@ typedef struct _AgentOptions
   */
 
   int Xinerama;
+
+  /*
+   * Sleep delay in microseconds.
+   */
+
+  unsigned int SleepTime;
 
 } AgentOptionsRec;
 

--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -9003,7 +9003,8 @@ int ParseEnvironmentOptions(const char *env, int force)
                              strcasecmp(name, "keyboard") == 0 ||
                                  strcasecmp(name, "clipboard") == 0 ||
                                      strcasecmp(name, "streaming") == 0 ||
-                                         strcasecmp(name, "backingstore") == 0)
+                                         strcasecmp(name, "backingstore") == 0 ||
+                                             strcasecmp(name, "sleep") == 0)
     {
       #ifdef DEBUG
       *logofs << "Loop: Ignoring agent option '" << name

--- a/nxcomp/Misc.cpp
+++ b/nxcomp/Misc.cpp
@@ -316,7 +316,8 @@ shadowuid=n\n\
 shadowmode=s\n\
 defer=n\n\
 tile=s\n\
-menu=n         These options are interpreted by the NX agent. They\n\
+menu=n\n\
+sleep=n        These options are interpreted by the NX agent. They\n\
                are ignored by the proxy.\n\
 \n\
   Environment:\n\


### PR DESCRIPTION
As part of the first enhancement in https://github.com/ArcticaProject/nx-libs/issues/132, we want to make optional sleep delays adjustable.

This PR handles this.

Sleep delays are given in milliseconds from 0 (disable slowdowns completely) to UINT_MAX (although high values will probably not be useful.)

If necessary, we can also change this to take values in microseconds.
