### PR TITLE
libX11: Extend Event functions to handle IOErrors

### DIFF
--- a/nx-X11/lib/X11/IfEvent.c
+++ b/nx-X11/lib/X11/IfEvent.c
@@ -73,6 +73,7 @@ XIfEvent (dpy, event, predicate, arg)
 		prev = NULL;
 #ifdef NX_TRANS_SOCKET
             if (_XGetIOError(dpy)) {
+                UnlockDisplay(dpy);
                 return 0;
             }
 #endif

--- a/nx-X11/lib/X11/MaskEvent.c
+++ b/nx-X11/lib/X11/MaskEvent.c
@@ -77,6 +77,7 @@ XMaskEvent (dpy, mask, event)
 		prev = NULL;
 #ifdef NX_TRANS_SOCKET
             if (_XGetIOError(dpy)) {
+                UnlockDisplay(dpy);
                 return 0;
             }
 #endif

--- a/nx-X11/lib/X11/NextEvent.c
+++ b/nx-X11/lib/X11/NextEvent.c
@@ -48,6 +48,12 @@ XNextEvent (dpy, event)
 	
 	if (dpy->head == NULL)
 	    _XReadEvents(dpy);
+#ifdef NX_TRANS_SOCKET
+	if (_XGetIOError(dpy)) {
+	    UnlockDisplay(dpy);
+	    return 0;
+	}
+#endif
 	qelt = dpy->head;
 	*event = qelt->event;
 	_XDeq(dpy, NULL, qelt);

--- a/nx-X11/lib/X11/PeekEvent.c
+++ b/nx-X11/lib/X11/PeekEvent.c
@@ -46,6 +46,12 @@ XPeekEvent (dpy, event)
 	LockDisplay(dpy);
 	if (dpy->head == NULL)
 	    _XReadEvents(dpy);
+#ifdef NX_TRANS_SOCKET
+	if (_XGetIOError(dpy)) {
+	    UnlockDisplay(dpy);
+	    return 1;
+	}
+#endif
 	*event = (dpy->head)->event;
 	UnlockDisplay(dpy);
 	return 1;

--- a/nx-X11/lib/X11/PeekIfEv.c
+++ b/nx-X11/lib/X11/PeekIfEv.c
@@ -73,6 +73,7 @@ XPeekIfEvent (dpy, event, predicate, arg)
 		prev = NULL;
 #ifdef NX_TRANS_SOCKET
             if (_XGetIOError(dpy)) {
+                UnlockDisplay(dpy);
                 return 0;
             }
 #endif

--- a/nx-X11/lib/X11/WinEvent.c
+++ b/nx-X11/lib/X11/WinEvent.c
@@ -79,5 +79,11 @@ XWindowEvent (dpy, w, mask, event)
 	    if (prev && prev->qserial_num != qe_serial)
 		/* another thread has snatched this event */
 		prev = NULL;
+#ifdef NX_TRANS_SOCKET
+	    if (_XGetIOError(dpy)) {
+	      UnlockDisplay(dpy);
+	      return 0;
+	    }
+#endif
 	}
 }


### PR DESCRIPTION
To allow for suspend/resume NX has changed _XReadEvents() and
_XIOError(). _XIOError() does not simply exit but returns. And
_XReadEvents() returns after _XIOError(). But as the original
_XReadEvents() is supposed to block until at least one event is there
calling functions are not prepared for situations where no event is
available. These calling functions have to check that condition.,

Some of the calling functions already had that check but the
UnlockDisplay() call was missing.

Fixes https://github.com/ArcticaProject/nx-libs/issues/118
