### PR TITLE
Introduce Xserver's protocols-version.h file as done in X.org

### DIFF
--- a/nx-X11/programs/Xserver/GL/glx/Imakefile
+++ b/nx-X11/programs/Xserver/GL/glx/Imakefile
@@ -31,6 +31,8 @@ NXAGENT_SKIP_SRCS =                     \
 NXAGENT_SKIP_OBJS =                     \
                 glxext.o                \
                 $(NULL)
+#else
+       NX_DEFINES = -DNXAGENT_SERVER
 #endif
 
          SRCS = global.c                \
@@ -124,8 +126,12 @@ NXAGENT_SKIP_OBJS =                     \
 
 XCOMM If you add "-DDEBUG" in DEFINES, then make sure you also
 XCOMM add DEBUG to the define in ../mesa/src/X/xf86glx.c
-      DEFINES = $(GLX_DEFINES) $(NO_EXT_DEFS) $(APIENTRY_DEFS)
-
+      DEFINES = 			\
+                $(GLX_DEFINES)		\
+                $(NO_EXT_DEFS)		\
+                $(APIENTRY_DEFS)	\
+                $(NX_DEFINES)		\
+                $(NULL)
 
 #ifdef IHaveModules
 ModuleObjectRule()

--- a/nx-X11/programs/Xserver/GL/glx/glxserver.h
+++ b/nx-X11/programs/Xserver/GL/glx/glxserver.h
@@ -52,7 +52,7 @@
 #include <resource.h>
 #include <scrnintstr.h>
 #include "GL/glx_ansic.h"
-
+#include "protocol-versions.h"
 
 #include <limits.h>
 /*
@@ -75,8 +75,8 @@ typedef struct __GLXdrawablePrivateRec __GLXdrawablePrivate;
 #include "glxerror.h"
 
 
-#define GLX_SERVER_MAJOR_VERSION 1
-#define GLX_SERVER_MINOR_VERSION 2
+#define GLX_SERVER_MAJOR_VERSION SERVER_GLX_MAJOR_VERSION
+#define GLX_SERVER_MINOR_VERSION SERVER_GLX_MINOR_VERSION
 
 #ifndef True
 #define True 1

--- a/nx-X11/programs/Xserver/Xext/panoramiX.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiX.c
@@ -59,7 +59,7 @@ Equipment Corporation.
 #include "picturestr.h"
 #endif
 #include "modinit.h"
-
+#include "protocol-versions.h"
 
 #ifdef GLXPROXY
 extern VisualPtr glxMatchVisual(ScreenPtr pScreen,
@@ -942,8 +942,8 @@ ProcPanoramiXQueryVersion (ClientPtr client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.majorVersion = PANORAMIX_MAJOR_VERSION;
-    rep.minorVersion = PANORAMIX_MINOR_VERSION;   
+    rep.majorVersion = SERVER_PANORAMIX_MAJOR_VERSION;
+    rep.minorVersion = SERVER_PANORAMIX_MINOR_VERSION;
     if (client->swapped) { 
         swaps(&rep.sequenceNumber, n);
         swapl(&rep.length, n);     

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -65,6 +65,8 @@ in this Software without prior written authorization from the X Consortium.
 
 #include "modinit.h"
 
+#include "protocol-versions.h"
+
 #if 0
 static unsigned char ScreenSaverReqCode = 0;
 #endif
@@ -699,8 +701,8 @@ ProcScreenSaverQueryVersion (client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.majorVersion = ScreenSaverMajorVersion;
-    rep.minorVersion = ScreenSaverMinorVersion;
+    rep.majorVersion = SERVER_SAVER_MAJOR_VERSION;
+    rep.minorVersion = SERVER_SAVER_MINOR_VERSION;
     if (client->swapped) {
     	swaps(&rep.sequenceNumber, n);
     	swapl(&rep.length, n);

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -56,6 +56,7 @@ in this Software without prior written authorization from The Open Group.
 #include "gcstruct.h"
 #include "colormapst.h"
 #include "propertyst.h"
+#include "protocol-versions.h"
 #define _SECURITY_SERVER
 #include <nx-X11/extensions/securstr.h>
 #include <assert.h>
@@ -486,8 +487,8 @@ ProcSecurityQueryVersion(
     rep.type        	= X_Reply;
     rep.sequenceNumber 	= client->sequence;
     rep.length         	= 0;
-    rep.majorVersion  	= SECURITY_MAJOR_VERSION;
-    rep.minorVersion  	= SECURITY_MINOR_VERSION;
+    rep.majorVersion  	= SERVER_SECURITY_MAJOR_VERSION;
+    rep.minorVersion  	= SERVER_SECURITY_MINOR_VERSION;
     if(client->swapped)
     {
 	register char n;

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -45,6 +45,7 @@ in this Software without prior written authorization from The Open Group.
 #include "resource.h"
 #include "opaque.h"
 #include <X11/extensions/shapeproto.h>
+#include "protocol-versions.h"
 #include "regionstr.h"
 #include "gcstruct.h"
 #ifdef EXTMODULE
@@ -295,8 +296,8 @@ ProcShapeQueryVersion (client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.majorVersion = SHAPE_MAJOR_VERSION;
-    rep.minorVersion = SHAPE_MINOR_VERSION;
+    rep.majorVersion = SERVER_SHAPE_MAJOR_VERSION;
+    rep.minorVersion = SERVER_SHAPE_MINOR_VERSION;
     if (client->swapped) {
     	swaps(&rep.sequenceNumber, n);
     	swapl(&rep.length, n);

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -65,6 +65,7 @@ in this Software without prior written authorization from The Open Group.
 #ifdef EXTMODULE
 #include "xf86_ansic.h"
 #endif
+#include "protocol-versions.h"
 
 #ifdef PANORAMIX
 #include "panoramiX.h"
@@ -354,8 +355,8 @@ ProcShmQueryVersion(client)
     rep.sequenceNumber = client->sequence;
     rep.sharedPixmaps = sharedPixmaps;
     rep.pixmapFormat = pixmapFormat;
-    rep.majorVersion = SHM_MAJOR_VERSION;
-    rep.minorVersion = SHM_MINOR_VERSION;
+    rep.majorVersion = SERVER_SHM_MAJOR_VERSION;
+    rep.minorVersion = SERVER_SHM_MINOR_VERSION;
     rep.uid = geteuid();
     rep.gid = getegid();
     if (client->swapped) {

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -70,6 +70,7 @@ PERFORMANCE OF THIS SOFTWARE.
 #define _SYNC_SERVER
 #include <nx-X11/extensions/sync.h>
 #include <nx-X11/extensions/syncstr.h>
+#include "protocol-versions.h"
 
 #ifdef EXTMODULE
 #include "xf86_ansic.h"
@@ -1349,8 +1350,8 @@ ProcSyncInitialize(client)
     memset(&rep, 0, sizeof(xSyncInitializeReply));
     rep.type = X_Reply;
     rep.sequenceNumber = client->sequence;
-    rep.majorVersion = SYNC_MAJOR_VERSION;
-    rep.minorVersion = SYNC_MINOR_VERSION;
+    rep.majorVersion = SERVER_SYNC_MAJOR_VERSION;
+    rep.minorVersion = SERVER_SYNC_MINOR_VERSION;
     rep.length = 0;
 
     if (client->swapped)

--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
@@ -72,6 +72,7 @@
 #include "gcstruct.h"
 #include "dixfontstr.h"
 #include "extnsionst.h"
+#include "protocol-versions.h"
 
 #define _XF86BIGFONT_SERVER_
 #include <nx-X11/extensions/xf86bigfstr.h>
@@ -357,8 +358,8 @@ ProcXF86BigfontQueryVersion(
     reply.type = X_Reply;
     reply.length = 0;
     reply.sequenceNumber = client->sequence;
-    reply.majorVersion = XF86BIGFONT_MAJOR_VERSION;
-    reply.minorVersion = XF86BIGFONT_MINOR_VERSION;
+    reply.majorVersion = SERVER_XF86BIGFONT_MAJOR_VERSION;
+    reply.minorVersion = SERVER_XF86BIGFONT_MINOR_VERSION;
     reply.uid = geteuid();
     reply.gid = getegid();
 #ifdef HAS_SHM

--- a/nx-X11/programs/Xserver/Xext/xres.c
+++ b/nx-X11/programs/Xserver/Xext/xres.c
@@ -20,6 +20,7 @@
 #include <nx-X11/extensions/XResproto.h>
 #include "pixmapstr.h"
 #include "modinit.h"
+#include "protocol-versions.h"
 
 static int
 ProcXResQueryVersion (ClientPtr client)
@@ -38,8 +39,8 @@ ProcXResQueryVersion (ClientPtr client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.server_major = XRES_MAJOR_VERSION;
-    rep.server_minor = XRES_MINOR_VERSION;   
+    rep.server_major = SERVER_XRES_MAJOR_VERSION;
+    rep.server_minor = SERVER_XRES_MINOR_VERSION;
     if (client->swapped) { 
         int n;
         swaps(&rep.sequenceNumber, n);

--- a/nx-X11/programs/Xserver/Xi/Imakefile
+++ b/nx-X11/programs/Xserver/Xi/Imakefile
@@ -86,6 +86,12 @@ XCOMM $XFree86: xc/programs/Xserver/Xi/Imakefile,v 3.2 1999/04/17 09:08:22 dawes
    INCLUDES = -I../include -I$(EXTINCSRC) -I$(XINCLUDESRC) `pkg-config --cflags-only-I pixman-1`
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
 
+#if defined(NXAgentServer) && NXAgentServer
+ NX_DEFINES = -DNXAGENT_SERVER
+#endif
+
+    DEFINES = $(NX_DEFINES)
+
 NormalLibraryTarget(xinput,$(OBJS))
 NormalLibraryObjectRule()
 LintLibraryTarget(xinput,$(SRCS))

--- a/nx-X11/programs/Xserver/Xi/extinit.c
+++ b/nx-X11/programs/Xserver/Xi/extinit.c
@@ -74,6 +74,7 @@ SOFTWARE.
 #include "extinit.h"
 #include "exglobals.h"
 #include "swaprep.h"
+#include "protocol-versions.h"
 
 /* modules local to Xi */
 #include "allowev.h"
@@ -204,8 +205,9 @@ Mask	PropagateMask[MAX_DEVICES];
 
 static	XExtensionVersion	thisversion = 
 					{XI_Present, 
-					 XI_Add_XChangeDeviceControl_Major, 
-					 XI_Add_XChangeDeviceControl_Minor};
+					 SERVER_XI_MAJOR_VERSION,
+					 SERVER_XI_MINOR_VERSION,
+					};
 
 /**********************************************************************
  *

--- a/nx-X11/programs/Xserver/composite/Imakefile
+++ b/nx-X11/programs/Xserver/composite/Imakefile
@@ -1,5 +1,7 @@
 #include <Server.tmpl>
 
+       NULL =
+
        SRCS =	compalloc.c compext.c compinit.c compoverlay.c compwindow.c
 
        OBJS =	compalloc.o compext.o compinit.o compoverlay.o compwindow.o
@@ -11,7 +13,13 @@
 
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
 
-   DEFINES = -DNXAGENT_SERVER
+#if defined(NXAgentServer) && NXAgentServer
+ NX_DEFINES = -DNXAGENT_SERVER
+#endif
+
+    DEFINES = 			\
+              $(NX_DEFINES)	\
+              $(NULL)
 
 NormalLibraryTarget(composite,$(OBJS))
 NormalLibraryObjectRule()

--- a/nx-X11/programs/Xserver/composite/compext.c
+++ b/nx-X11/programs/Xserver/composite/compext.c
@@ -29,15 +29,8 @@
 #include "compint.h"
 #include "XI.h"
 #include "XIproto.h"
+#include "protocol-versions.h"
 #include "extinit.h"
-
-#ifndef SERVER_COMPOSITE_MAJOR_VERSION
-#define SERVER_COMPOSITE_MAJOR_VERSION 0
-#endif
-
-#ifndef SERVER_COMPOSITE_MINOR_VERSION
-#define SERVER_COMPOSITE_MINOR_VERSION 4
-#endif
 
 static CARD8	CompositeReqCode;
 

--- a/nx-X11/programs/Xserver/damageext/Imakefile
+++ b/nx-X11/programs/Xserver/damageext/Imakefile
@@ -1,5 +1,7 @@
 #include <Server.tmpl>
 
+       NULL =
+
        SRCS =	damageext.c
 
        OBJS =	damageext.o
@@ -9,6 +11,14 @@
 		`pkg-config --cflags-only-I pixman-1`
 
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
+
+#if defined(NXAgentServer) && NXAgentServer
+ NX_DEFINES = -DNXAGENT_SERVER
+#endif
+
+    DEFINES = 			\
+              $(NX_DEFINES)	\
+              $(NULL)
 
 NormalLibraryTarget(damage,$(OBJS))
 NormalLibraryObjectRule()

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -27,6 +27,7 @@
 #endif
 
 #include "damageextint.h"
+#include "protocol-versions.h"
 
 unsigned char	DamageReqCode;
 int		DamageEventBase;
@@ -143,16 +144,16 @@ ProcDamageQueryVersion(ClientPtr client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    if (stuff->majorVersion < DAMAGE_MAJOR) {
+    if (stuff->majorVersion < SERVER_DAMAGE_MAJOR_VERSION) {
 	rep.majorVersion = stuff->majorVersion;
 	rep.minorVersion = stuff->minorVersion;
     } else {
-	rep.majorVersion = DAMAGE_MAJOR;
-	if (stuff->majorVersion == DAMAGE_MAJOR && 
-	    stuff->minorVersion < DAMAGE_MINOR)
+	rep.majorVersion = SERVER_DAMAGE_MAJOR_VERSION;
+	if (stuff->majorVersion == SERVER_DAMAGE_MAJOR_VERSION &&
+	    stuff->minorVersion < SERVER_DAMAGE_MINOR_VERSION)
 	    rep.minorVersion = stuff->minorVersion;
 	else
-	    rep.minorVersion = DAMAGE_MINOR;
+	    rep.minorVersion = SERVER_DAMAGE_MINOR_VERSION;
     }
     pDamageClient->major_version = rep.majorVersion;
     pDamageClient->minor_version = rep.minorVersion;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
@@ -47,7 +47,6 @@ in this Software without prior written authorization from The Open Group.
 /* $Xorg: shm.c,v 1.4 2001/02/09 02:04:33 xorgcvs Exp $ */
 
 #include <nx-X11/X.h>
-
 #include "Trap.h"
 #include "Agent.h"
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Render.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.c
@@ -31,6 +31,7 @@
 #include "mipict.h"
 #include "fbpict.h"
 #include "dixstruct.h"
+#include "protocol-versions.h"
 
 #include "Agent.h"
 #include "Drawable.h"
@@ -217,26 +218,26 @@ void nxagentRenderExtensionInit()
      + two versions.
      */
 
-    if (major_version > RENDER_MAJOR || 
-            (major_version == RENDER_MAJOR &&
-                 minor_version > RENDER_MINOR))
+    if (major_version > SERVER_RENDER_MAJOR_VERSION ||
+            (major_version == SERVER_RENDER_MAJOR_VERSION &&
+                 minor_version > SERVER_RENDER_MINOR_VERSION))
     {
       #ifdef TEST
       fprintf(stderr, "nxagentRenderExtensionInit: Using render version [%d.%d] with "
-                  "remote version [%d.%d].\n", RENDER_MAJOR, RENDER_MINOR,
+                  "remote version [%d.%d].\n", SERVER_RENDER_MAJOR_VERSION, SERVER_RENDER_MINOR_VERSION,
                       major_version, minor_version);
       #endif
 
-      nxagentRenderVersionMajor = RENDER_MAJOR;
-      nxagentRenderVersionMinor = RENDER_MINOR;
+      nxagentRenderVersionMajor = SERVER_RENDER_MAJOR_VERSION;
+      nxagentRenderVersionMinor = SERVER_RENDER_MINOR_VERSION;
     }
-    else if (major_version < RENDER_MAJOR ||
-                 (major_version == RENDER_MAJOR &&
-                      minor_version < RENDER_MINOR))
+    else if (major_version < SERVER_RENDER_MAJOR_VERSION ||
+                 (major_version == SERVER_RENDER_MAJOR_VERSION &&
+                      minor_version < SERVER_RENDER_MINOR_VERSION))
     {
       #ifdef TEST
       fprintf(stderr, "Info: Local render version %d.%d is higher "
-                  "than remote version %d.%d.\n", RENDER_MAJOR, RENDER_MINOR,
+                  "than remote version %d.%d.\n", SERVER_RENDER_MAJOR_VERSION, SERVER_RENDER_MINOR_VERSION,
                       major_version, minor_version);
 
       fprintf(stderr, "Info: Lowering the render version reported to clients.\n");
@@ -249,7 +250,7 @@ void nxagentRenderExtensionInit()
     {
       #ifdef TEST
       fprintf(stderr, "nxagentRenderExtensionInit: Local render version %d.%d "
-                  "matches remote version %d.%d.\n", RENDER_MAJOR, RENDER_MINOR,
+                  "matches remote version %d.%d.\n", SERVER_RENDER_MAJOR_VERSION, SERVER_RENDER_MINOR_VERSION,
                       major_version, minor_version);
       #endif
 

--- a/nx-X11/programs/Xserver/include/protocol-versions.h
+++ b/nx-X11/programs/Xserver/include/protocol-versions.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2009 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * This file specifies the server-supported protocol versions.
+ */
+#ifndef PROTOCOL_VERSIONS_H
+#define PROTOCOL_VERSIONS_H
+
+#ifdef NXAGENT_SERVER
+# define XTRANS_SEND_FDS 0
+#endif
+
+/* Composite */
+#define SERVER_COMPOSITE_MAJOR_VERSION		0
+#define SERVER_COMPOSITE_MINOR_VERSION		4
+
+/* Damage */
+#define SERVER_DAMAGE_MAJOR_VERSION		1
+#ifndef NXAGENT_SERVER
+#define SERVER_DAMAGE_MINOR_VERSION		1
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_DAMAGE_MINOR_VERSION		0
+#endif /* !defined(NXAGENT_SERVER) */
+
+#ifndef NXAGENT_SERVER
+/* DRI3 */
+#define SERVER_DRI3_MAJOR_VERSION               1
+#define SERVER_DRI3_MINOR_VERSION               0
+#endif /* !defined(NXAGENT_SERVER) */
+
+#ifndef NXAGENT_SERVER
+/* DMX */
+#define SERVER_DMX_MAJOR_VERSION                2
+#define SERVER_DMX_MINOR_VERSION                2
+#define SERVER_DMX_PATCH_VERSION                20040604
+#endif /* !defined(NXAGENT_SERVER) */
+
+#ifndef NXAGENT_SERVER
+/* Generic event extension */
+#define SERVER_GE_MAJOR_VERSION                 1
+#define SERVER_GE_MINOR_VERSION                 0
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* GLX */
+#define SERVER_GLX_MAJOR_VERSION		1
+#ifndef NXAGENT_SERVER
+#define SERVER_GLX_MINOR_VERSION		4
+#else
+#define SERVER_GLX_MINOR_VERSION		2
+#endif
+
+/* Xinerama */
+#define SERVER_PANORAMIX_MAJOR_VERSION          1
+#define SERVER_PANORAMIX_MINOR_VERSION		1
+
+#ifndef NXAGENT_SERVER
+/* Present */
+#define SERVER_PRESENT_MAJOR_VERSION            1
+#define SERVER_PRESENT_MINOR_VERSION            0
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* RandR */
+#define SERVER_RANDR_MAJOR_VERSION		1
+#define SERVER_RANDR_MINOR_VERSION		5
+
+/* Record */
+#define SERVER_RECORD_MAJOR_VERSION		1
+#define SERVER_RECORD_MINOR_VERSION		13
+
+/* Render */
+#define SERVER_RENDER_MAJOR_VERSION		0
+#ifndef NXAGENT_SERVER
+#define SERVER_RENDER_MINOR_VERSION		11
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_RENDER_MINOR_VERSION		10
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* RandR Xinerama */
+#define SERVER_RRXINERAMA_MAJOR_VERSION		1
+#define SERVER_RRXINERAMA_MINOR_VERSION		1
+
+/* Screensaver */
+#define SERVER_SAVER_MAJOR_VERSION		1
+#define SERVER_SAVER_MINOR_VERSION		1
+
+/* Security */
+#define SERVER_SECURITY_MAJOR_VERSION		1
+#define SERVER_SECURITY_MINOR_VERSION		0
+
+/* Shape */
+#define SERVER_SHAPE_MAJOR_VERSION		1
+#define SERVER_SHAPE_MINOR_VERSION		1
+
+/* SHM */
+#define SERVER_SHM_MAJOR_VERSION		1
+#ifndef NXAGENT_SERVER
+#if XTRANS_SEND_FDS
+#define SERVER_SHM_MINOR_VERSION		2
+#else
+#define SERVER_SHM_MINOR_VERSION		1
+#endif
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_SHM_MINOR_VERSION		1
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* Sync */
+#define SERVER_SYNC_MAJOR_VERSION		3
+#ifndef NXAGENT_SERVER
+#define SERVER_SYNC_MINOR_VERSION		1
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_SYNC_MINOR_VERSION		0
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* Big Font */
+#define SERVER_XF86BIGFONT_MAJOR_VERSION	1
+#define SERVER_XF86BIGFONT_MINOR_VERSION	1
+
+#ifndef NXAGENT_SERVER
+/* Vidmode */
+#define SERVER_XF86VIDMODE_MAJOR_VERSION	2
+#define SERVER_XF86VIDMODE_MINOR_VERSION	2
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* Fixes */
+#ifndef NXAGENT_SERVER
+#define SERVER_XFIXES_MAJOR_VERSION		5
+#define SERVER_XFIXES_MINOR_VERSION		0
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_XFIXES_MAJOR_VERSION		3
+#define SERVER_XFIXES_MINOR_VERSION		0
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* X Input */
+#ifndef NXAGENT_SERVER
+#define SERVER_XI_MAJOR_VERSION			2
+#define SERVER_XI_MINOR_VERSION			3
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_XI_MAJOR_VERSION			1
+#define SERVER_XI_MINOR_VERSION			3
+#endif /* !defined(NXAGENT_SERVER) */
+
+/* XKB */
+#define SERVER_XKB_MAJOR_VERSION		1
+#define SERVER_XKB_MINOR_VERSION		0
+
+/* Resource */
+#define SERVER_XRES_MAJOR_VERSION		1
+#ifndef NXAGENT_SERVER
+#define SERVER_XRES_MINOR_VERSION		2
+#else /* !defined(NXAGENT_SERVER) */
+#define SERVER_XRES_MINOR_VERSION		0
+#endif /* !defined(NXAGENT_SERVER) */
+
+#ifndef NXAGENT_SERVER
+/* XvMC */
+#define SERVER_XVMC_MAJOR_VERSION		1
+#define SERVER_XVMC_MINOR_VERSION		1
+#endif /* !defined(NXAGENT_SERVER) */
+
+#endif /* PROTOCOL_VERSIONS_H */

--- a/nx-X11/programs/Xserver/randr/Imakefile
+++ b/nx-X11/programs/Xserver/randr/Imakefile
@@ -62,7 +62,7 @@ XCOMM $XFree86: xc/programs/Xserver/randr/Imakefile,v 1.1 2001/05/23 03:29:44 ke
     PNRX_DEFINES = -DXINERAMA -DPANORAMIX
 #endif
 
-#if defined(NXAgentServer)
+#if defined(NXAgentServer) && NXAgentServer
     NX_DEFINES = -DNXAGENT_SERVER
 #endif
 

--- a/nx-X11/programs/Xserver/randr/rrdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrdispatch.c
@@ -21,12 +21,7 @@
  */
 
 #include "randrstr.h"
-#ifndef NXAGENT_SERVER
 #include "protocol-versions.h"
-#else
-#define SERVER_RANDR_MAJOR_VERSION     1
-#define SERVER_RANDR_MINOR_VERSION     5
-#endif
 
 Bool
 RRClientKnowsRates(ClientPtr pClient)

--- a/nx-X11/programs/Xserver/randr/rrxinerama.c
+++ b/nx-X11/programs/Xserver/randr/rrxinerama.c
@@ -88,12 +88,7 @@
 #include "randrstr.h"
 #include "swaprep.h"
 #include "panoramiXproto.h"
-#ifndef NXAGENT_SERVER
 #include "protocol-versions.h"
-#else
-#define SERVER_RRXINERAMA_MAJOR_VERSION     1
-#define SERVER_RRXINERAMA_MINOR_VERSION     1
-#endif
 
 /* Xinerama is not multi-screen capable; just report about screen 0 */
 #define RR_XINERAMA_SCREEN  0

--- a/nx-X11/programs/Xserver/record/Imakefile
+++ b/nx-X11/programs/Xserver/record/Imakefile
@@ -1,9 +1,7 @@
 XCOMM $Xorg: Imakefile,v 1.3 2000/08/17 19:53:45 cpqbld Exp $
-
-
-
-
 XCOMM $XFree86: xc/programs/Xserver/record/Imakefile,v 1.12 2001/11/02 23:29:34 dawes Exp $
+
+       NULL =
 
 #if DoLoadableServer
 #define IHaveSubdirs
@@ -18,7 +16,15 @@ XCOMM $XFree86: xc/programs/Xserver/record/Imakefile,v 1.12 2001/11/02 23:29:34 
        OBJS = record.o set.o
    INCLUDES = -I../include -I$(XINCLUDESRC) -I$(EXTINCSRC) -I$(SERVERSRC)/Xext `pkg-config --cflags-only-I pixman-1`
    LINTLIBS = ../dix/llib-ldix.ln
-    DEFINES = -DNDEBUG
+
+#if defined(NXAgentServer) && NXAgentServer
+ NX_DEFINES = -DNXAGENT_SERVER
+#endif
+
+    DEFINES =			\
+              -DNDEBUG		\
+              $(NX_DEFINES)	\
+              $(NULL)
 
 NormalLibraryObjectRule()
 NormalLibraryTarget(record,$(OBJS))

--- a/nx-X11/programs/Xserver/record/record.c
+++ b/nx-X11/programs/Xserver/record/record.c
@@ -60,6 +60,8 @@ and Jim Haggerty of Metheus.
 #include "cursor.h"
 #endif
 
+#include "protocol-versions.h"
+
 static RESTYPE RTContext;   /* internal resource type for Record contexts */
 static int RecordErrorBase; /* first Record error number */
 
@@ -2002,8 +2004,8 @@ ProcRecordQueryVersion(client)
     rep.type        	= X_Reply;
     rep.sequenceNumber 	= client->sequence;
     rep.length         	= 0;
-    rep.majorVersion  	= RECORD_MAJOR_VERSION;
-    rep.minorVersion  	= RECORD_MINOR_VERSION;
+    rep.majorVersion  	= SERVER_RECORD_MAJOR_VERSION;
+    rep.minorVersion  	= SERVER_RECORD_MINOR_VERSION;
     if(client->swapped)
     {
     	swaps(&rep.sequenceNumber, n);

--- a/nx-X11/programs/Xserver/render/Imakefile
+++ b/nx-X11/programs/Xserver/render/Imakefile
@@ -1,6 +1,6 @@
 XCOMM $XFree86: xc/programs/Xserver/render/Imakefile,v 1.10 2002/11/23 02:38:15 keithp Exp $
 
-NULL =
+             NULL =
 
 #include <Server.tmpl>
 
@@ -20,7 +20,7 @@ NXAGENT_SKIP_OBJS =             \
                     render.o    \
                     $(NULL)
 #else
-          DEFINES = -DNXAGENT_SERVER
+       NX_DEFINES = -DNXAGENT_SERVER
 #endif
 
        SRCS =   animcur.c \
@@ -52,6 +52,10 @@ NXAGENT_SKIP_OBJS =             \
                 -I../Xext \
                 `pkg-config --cflags-only-I pixman-1`
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
+
+    DEFINES = 			\
+              $(NX_DEFINES)	\
+              $(NULL)
 
 NormalLibraryTarget(render,$(OBJS))
 NormalLibraryObjectRule()

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -52,6 +52,8 @@
 #include "xf86_ansic.h"
 #endif
 
+#include "protocol-versions.h"
+
 #if !defined(UINT32_MAX)
 #define UINT32_MAX 0xffffffffU
 #endif
@@ -293,8 +295,8 @@ ProcRenderQueryVersion (ClientPtr client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.majorVersion = RENDER_MAJOR;
-    rep.minorVersion = RENDER_MINOR;
+    rep.majorVersion = SERVER_RENDER_MAJOR_VERSION;
+    rep.minorVersion = SERVER_RENDER_MINOR_VERSION;
     if (client->swapped) {
     	swaps(&rep.sequenceNumber, n);
     	swapl(&rep.length, n);

--- a/nx-X11/programs/Xserver/xfixes/Imakefile
+++ b/nx-X11/programs/Xserver/xfixes/Imakefile
@@ -1,5 +1,7 @@
 #include <Server.tmpl>
 
+       NULL =
+
        SRCS =	cursor.c region.c saveset.c select.c xfixes.c
 
        OBJS =	cursor.o region.o saveset.o select.o xfixes.o
@@ -9,6 +11,14 @@
 		`pkg-config --cflags-only-I pixman-1`
 
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
+
+#if defined(NXAgentServer) && NXAgentServer
+ NX_DEFINES = -DNXAGENT_SERVER
+#endif
+
+    DEFINES = 			\
+              $(NX_DEFINES)	\
+              $(NULL)
 
 NormalLibraryTarget(xfixes,$(OBJS))
 NormalLibraryObjectRule()

--- a/nx-X11/programs/Xserver/xfixes/xfixes.c
+++ b/nx-X11/programs/Xserver/xfixes/xfixes.c
@@ -27,6 +27,7 @@
 #endif
 
 #include "xfixesint.h"
+#include "protocol-versions.h"
 
 unsigned char	XFixesReqCode;
 int		XFixesEventBase;
@@ -46,16 +47,16 @@ ProcXFixesQueryVersion(ClientPtr client)
     rep.type = X_Reply;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    if (stuff->majorVersion < XFIXES_MAJOR) {
-	rep.majorVersion = stuff->majorVersion;
-	rep.minorVersion = stuff->minorVersion;
+    if (stuff->majorVersion < SERVER_XFIXES_MAJOR_VERSION) {
+        rep.majorVersion = stuff->majorVersion;
+        rep.minorVersion = stuff->minorVersion;
     } else {
-	rep.majorVersion = XFIXES_MAJOR;
-	if (stuff->majorVersion == XFIXES_MAJOR && 
-	    stuff->minorVersion < XFIXES_MINOR)
-	    rep.minorVersion = stuff->minorVersion;
-	else
-	    rep.minorVersion = XFIXES_MINOR;
+        rep.majorVersion = SERVER_XFIXES_MAJOR_VERSION;
+        if (stuff->majorVersion == SERVER_XFIXES_MAJOR_VERSION &&
+            stuff->minorVersion < SERVER_XFIXES_MINOR_VERSION)
+            rep.minorVersion = stuff->minorVersion;
+        else
+            rep.minorVersion = SERVER_XFIXES_MINOR_VERSION;
     }
     pXFixesClient->major_version = rep.majorVersion;
     pXFixesClient->minor_version = rep.minorVersion;

--- a/nx-X11/programs/Xserver/xkb/Imakefile
+++ b/nx-X11/programs/Xserver/xkb/Imakefile
@@ -26,7 +26,7 @@ XKB_DISABLE = -DXKB_DFLT_DISABLED=0
 XKB_DDXDEFS = XkbServerDefines
 
 #if defined(NXAgentServer) && NXAgentServer
-NX_DEFINES = -DNXAGENT_SERVER
+ NX_DEFINES = -DNXAGENT_SERVER
 #endif
 
 #if (defined(XorgServer) && XorgServer)

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -41,6 +41,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/extensions/XKBsrv.h>
 #include "extnsionst.h"
 #include "xkb.h"
+#include "protocol-versions.h"
 
 #include <nx-X11/extensions/XI.h>
 
@@ -168,9 +169,9 @@ ProcXkbUseExtension(ClientPtr client)
     int	supported;
 
     REQUEST_SIZE_MATCH(xkbUseExtensionReq);
-    if (stuff->wantedMajor != XkbMajorVersion) {
+    if (stuff->wantedMajor != SERVER_XKB_MAJOR_VERSION) {
 	/* pre-release version 0.65 is compatible with 1.00 */
-	supported= ((XkbMajorVersion==1)&&
+	supported= ((SERVER_XKB_MAJOR_VERSION==1)&&
 		    (stuff->wantedMajor==0)&&(stuff->wantedMinor==65));
     }
     else supported = 1;
@@ -190,15 +191,15 @@ ProcXkbUseExtension(ClientPtr client)
 					client->index,
 					(long)client->clientAsMask,
 					stuff->wantedMajor,stuff->wantedMinor,
-					XkbMajorVersion,XkbMinorVersion);
+					SERVER_XKB_MAJOR_VERSION,SERVER_XKB_MINOR_VERSION);
     }
     memset(&rep, 0, sizeof(xkbUseExtensionReply));
     rep.type = X_Reply;
     rep.supported = supported;
     rep.length = 0;
     rep.sequenceNumber = client->sequence;
-    rep.serverMajor = XkbMajorVersion;
-    rep.serverMinor = XkbMinorVersion;
+    rep.serverMajor = SERVER_XKB_MAJOR_VERSION;
+    rep.serverMinor = SERVER_XKB_MINOR_VERSION;
     if ( client->swapped ) {
 	swaps(&rep.sequenceNumber, n);
 	swaps(&rep.serverMajor, n);


### PR DESCRIPTION
The X.org Xserver has one file specifying the proto versions of provided Xserver extensions. Immitating this for nx-libs's Xserver (aka nxagent).
