### PR TITLE
 Use internal temp variable for swap macros. Make swaps/swapl type safe (introducing wrong_size check at build time).

### DIFF
--- a/nx-X11/programs/Xserver/Xext/bigreq.c
+++ b/nx-X11/programs/Xserver/Xext/bigreq.c
@@ -85,10 +85,9 @@ ProcBigReqDispatch (client)
 {
     REQUEST(xBigReqEnableReq);
     xBigReqEnableReply rep;
-    register int n;
 
     if (client->swapped) {
-	swaps(&stuff->length, n);
+	swaps(&stuff->length);
     }
     if (stuff->brReqType != X_BigReqEnable)
 	return BadRequest;
@@ -100,8 +99,8 @@ ProcBigReqDispatch (client)
     rep.sequenceNumber = client->sequence;
     rep.max_request_size = maxBigRequestSize;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.max_request_size, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.max_request_size);
     }
     WriteToClient(client, sizeof(xBigReqEnableReply), (char *)&rep);
     return(client->noClientException);

--- a/nx-X11/programs/Xserver/Xext/dpms.c
+++ b/nx-X11/programs/Xserver/Xext/dpms.c
@@ -105,7 +105,6 @@ ProcDPMSGetVersion(client)
 {
     /* REQUEST(xDPMSGetVersionReq); */
     xDPMSGetVersionReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xDPMSGetVersionReq);
 
@@ -115,9 +114,9 @@ ProcDPMSGetVersion(client)
     rep.majorVersion = DPMSMajorVersion;
     rep.minorVersion = DPMSMinorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.majorVersion, n);
-	swaps(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.majorVersion);
+	swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xDPMSGetVersionReply), (char *)&rep);
     return(client->noClientException);
@@ -128,7 +127,6 @@ ProcDPMSCapable(register ClientPtr client)
 {
     /* REQUEST(xDPMSCapableReq); */
     xDPMSCapableReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xDPMSCapableReq);
 
@@ -138,7 +136,7 @@ ProcDPMSCapable(register ClientPtr client)
     rep.capable = DPMSCapableFlag;
 
     if (client->swapped) {
-	swaps(&rep.sequenceNumber, n);
+	swaps(&rep.sequenceNumber);
     }
     WriteToClient(client, sizeof(xDPMSCapableReply), (char *)&rep);
     return(client->noClientException);
@@ -150,7 +148,6 @@ ProcDPMSGetTimeouts(client)
 {
     /* REQUEST(xDPMSGetTimeoutsReq); */
     xDPMSGetTimeoutsReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xDPMSGetTimeoutsReq);
 
@@ -162,10 +159,10 @@ ProcDPMSGetTimeouts(client)
     rep.off = DPMSOffTime / MILLI_PER_SECOND;
 
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.standby, n);
-	swaps(&rep.suspend, n);
-	swaps(&rep.off, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.standby);
+	swaps(&rep.suspend);
+	swaps(&rep.off);
     }
     WriteToClient(client, sizeof(xDPMSGetTimeoutsReply), (char *)&rep);
     return(client->noClientException);
@@ -265,7 +262,6 @@ ProcDPMSInfo(register ClientPtr client)
 {
     /* REQUEST(xDPMSInfoReq); */
     xDPMSInfoReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xDPMSInfoReq);
 
@@ -276,8 +272,8 @@ ProcDPMSInfo(register ClientPtr client)
     rep.state = DPMSEnabled;
 
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.power_level, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.power_level);
     }
     WriteToClient(client, sizeof(xDPMSInfoReply), (char *)&rep);
     return(client->noClientException);
@@ -316,13 +312,12 @@ static int
 SProcDPMSGetVersion(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xDPMSGetVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSGetVersionReq);
-    swaps(&stuff->majorVersion, n);
-    swaps(&stuff->minorVersion, n);
+    swaps(&stuff->majorVersion);
+    swaps(&stuff->minorVersion);
     return ProcDPMSGetVersion(client);
 }
 
@@ -330,9 +325,8 @@ static int
 SProcDPMSCapable(register ClientPtr client)
 {
     REQUEST(xDPMSCapableReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSCapableReq);
 
     return ProcDPMSCapable(client);
@@ -343,9 +337,8 @@ SProcDPMSGetTimeouts(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSGetTimeoutsReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSGetTimeoutsReq);
 
     return ProcDPMSGetTimeouts(client);
@@ -356,14 +349,13 @@ SProcDPMSSetTimeouts(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSSetTimeoutsReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSSetTimeoutsReq);
 
-    swaps(&stuff->standby, n);
-    swaps(&stuff->suspend, n);
-    swaps(&stuff->off, n);
+    swaps(&stuff->standby);
+    swaps(&stuff->suspend);
+    swaps(&stuff->off);
     return ProcDPMSSetTimeouts(client);
 }
 
@@ -372,9 +364,8 @@ SProcDPMSEnable(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSEnableReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSEnableReq);
 
     return ProcDPMSEnable(client);
@@ -385,9 +376,8 @@ SProcDPMSDisable(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSDisableReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSDisableReq);
 
     return ProcDPMSDisable(client);
@@ -398,12 +388,11 @@ SProcDPMSForceLevel(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSForceLevelReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSForceLevelReq);
 
-    swaps(&stuff->level, n);
+    swaps(&stuff->level);
 
     return ProcDPMSForceLevel(client);
 }
@@ -413,9 +402,8 @@ SProcDPMSInfo(client)
     register ClientPtr client;
 {
     REQUEST(xDPMSInfoReq);
-    register int n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDPMSInfoReq);
 
     return ProcDPMSInfo(client);

--- a/nx-X11/programs/Xserver/Xext/panoramiX.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiX.c
@@ -936,7 +936,6 @@ ProcPanoramiXQueryVersion (ClientPtr client)
 {
     /* REQUEST(xPanoramiXQueryVersionReq); */
     xPanoramiXQueryVersionReply		rep;
-    register 	int			n;
 
     REQUEST_SIZE_MATCH (xPanoramiXQueryVersionReq);
     rep.type = X_Reply;
@@ -945,10 +944,10 @@ ProcPanoramiXQueryVersion (ClientPtr client)
     rep.majorVersion = SERVER_PANORAMIX_MAJOR_VERSION;
     rep.minorVersion = SERVER_PANORAMIX_MINOR_VERSION;
     if (client->swapped) { 
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);     
-        swaps(&rep.majorVersion, n);
-        swaps(&rep.minorVersion, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.majorVersion);
+        swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof (xPanoramiXQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -960,7 +959,6 @@ ProcPanoramiXGetState(ClientPtr client)
 	REQUEST(xPanoramiXGetStateReq);
     	WindowPtr			pWin;
 	xPanoramiXGetStateReply		rep;
-	register int			n;
 	
 	REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
 	pWin = LookupWindow (stuff->window, client);
@@ -971,9 +969,9 @@ ProcPanoramiXGetState(ClientPtr client)
 	rep.sequenceNumber = client->sequence;
 	rep.state = !noPanoramiXExtension;
     	if (client->swapped) {
-	    swaps (&rep.sequenceNumber, n);
-	    swapl (&rep.length, n);
-	    swaps (&rep.state, n);
+	    swaps (&rep.sequenceNumber);
+	    swapl (&rep.length);
+	    swapl ((int* )&rep.state);
 	}	
 	WriteToClient (client, sizeof (xPanoramiXGetStateReply), (char *) &rep);
 	return client->noClientException;
@@ -986,7 +984,6 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
 	REQUEST(xPanoramiXGetScreenCountReq);
     	WindowPtr			pWin;
 	xPanoramiXGetScreenCountReply	rep;
-	register int			n;
 
 	REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
 	pWin = LookupWindow (stuff->window, client);
@@ -997,9 +994,9 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
 	rep.sequenceNumber = client->sequence;
 	rep.ScreenCount = PanoramiXNumScreens;
     	if (client->swapped) {
-	    swaps (&rep.sequenceNumber, n);
-	    swapl (&rep.length, n);
-	    swaps (&rep.ScreenCount, n);
+	    swaps (&rep.sequenceNumber);
+	    swapl (&rep.length);
+	    swapl ((int* )&rep.ScreenCount);
 	}	
 	WriteToClient (client, sizeof (xPanoramiXGetScreenCountReply), (char *) &rep);
 	return client->noClientException;
@@ -1011,7 +1008,6 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
 	REQUEST(xPanoramiXGetScreenSizeReq);
     	WindowPtr			pWin;
 	xPanoramiXGetScreenSizeReply	rep;
-	register int			n;
 	
 	REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
 	pWin = LookupWindow (stuff->window, client);
@@ -1024,10 +1020,10 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
 	rep.width  = panoramiXdataPtr[stuff->screen].width; 
 	rep.height = panoramiXdataPtr[stuff->screen].height; 
     	if (client->swapped) {
-	    swaps (&rep.sequenceNumber, n);
-	    swapl (&rep.length, n);
-	    swaps (&rep.width, n);
-	    swaps (&rep.height, n);
+	    swaps (&rep.sequenceNumber);
+	    swapl (&rep.length);
+	    swapl (&rep.width);
+	    swapl (&rep.height);
 	}	
 	WriteToClient (client, sizeof (xPanoramiXGetScreenSizeReply), (char *) &rep);
 	return client->noClientException;
@@ -1047,10 +1043,9 @@ ProcXineramaIsActive(ClientPtr client)
     rep.sequenceNumber = client->sequence;
     rep.state = !noPanoramiXExtension;
     if (client->swapped) {
-	register int n;
-	swaps (&rep.sequenceNumber, n);
-	swapl (&rep.length, n);
-	swapl (&rep.state, n);
+	swaps (&rep.sequenceNumber);
+	swapl (&rep.length);
+	swapl (&rep.state);
     }	
     WriteToClient (client, sizeof (xXineramaIsActiveReply), (char *) &rep);
     return client->noClientException;
@@ -1070,10 +1065,9 @@ ProcXineramaQueryScreens(ClientPtr client)
     rep.number = (noPanoramiXExtension) ? 0 : PanoramiXNumScreens;
     rep.length = rep.number * sz_XineramaScreenInfo >> 2;
     if (client->swapped) {
-	register int n;
-	swaps (&rep.sequenceNumber, n);
-	swapl (&rep.length, n);
-	swapl (&rep.number, n);
+	swaps (&rep.sequenceNumber);
+	swapl (&rep.length);
+	swapl (&rep.number);
     }	
     WriteToClient (client, sizeof (xXineramaQueryScreensReply), (char *) &rep);
 
@@ -1088,11 +1082,10 @@ ProcXineramaQueryScreens(ClientPtr client)
 	    scratch.height = panoramiXdataPtr[i].height;
 	
 	    if(client->swapped) {
-		register int n;
-		swaps (&scratch.x_org, n);
-		swaps (&scratch.y_org, n);
-		swaps (&scratch.width, n);
-		swaps (&scratch.height, n);
+		swaps (&scratch.x_org);
+		swaps (&scratch.y_org);
+		swaps (&scratch.width);
+		swaps (&scratch.height);
 	    }
 	    WriteToClient (client, sz_XineramaScreenInfo, (char *) &scratch);
 	}

--- a/nx-X11/programs/Xserver/Xext/panoramiXSwap.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXSwap.c
@@ -57,9 +57,8 @@ static int
 SProcPanoramiXQueryVersion (ClientPtr client)
 {
 	REQUEST(xPanoramiXQueryVersionReq);
-	register int n;
 
-	swaps(&stuff->length,n);
+	swaps(&stuff->length);
 	REQUEST_SIZE_MATCH (xPanoramiXQueryVersionReq);
 	return ProcPanoramiXQueryVersion(client);
 }
@@ -68,9 +67,8 @@ static int
 SProcPanoramiXGetState(ClientPtr client)
 {
 	REQUEST(xPanoramiXGetStateReq);
-	register int n;
 
- 	swaps (&stuff->length, n);	
+	swaps (&stuff->length);
 	REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
 	return ProcPanoramiXGetState(client);
 }
@@ -79,9 +77,8 @@ static int
 SProcPanoramiXGetScreenCount(ClientPtr client)
 {
 	REQUEST(xPanoramiXGetScreenCountReq);
-	register int n;
 
-	swaps (&stuff->length, n);
+	swaps (&stuff->length);
 	REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
 	return ProcPanoramiXGetScreenCount(client);
 }
@@ -90,9 +87,8 @@ static int
 SProcPanoramiXGetScreenSize(ClientPtr client)
 {
 	REQUEST(xPanoramiXGetScreenSizeReq);
-	register int n;
 
-	swaps (&stuff->length, n);
+	swaps (&stuff->length);
 	REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
 	return ProcPanoramiXGetScreenSize(client);
 }
@@ -102,9 +98,8 @@ static int
 SProcXineramaIsActive(ClientPtr client)
 {
 	REQUEST(xXineramaIsActiveReq);
-	register int n;
 
-	swaps (&stuff->length, n);
+	swaps (&stuff->length);
 	REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
 	return ProcXineramaIsActive(client);
 }
@@ -114,9 +109,8 @@ static int
 SProcXineramaQueryScreens(ClientPtr client)
 {
 	REQUEST(xXineramaQueryScreensReq);
-	register int n;
 
-	swaps (&stuff->length, n);
+	swaps (&stuff->length);
 	REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
 	return ProcXineramaQueryScreens(client);
 }

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -490,9 +490,9 @@ SScreenSaverNotifyEvent (from, to)
     to->type = from->type;
     to->state = from->state;
     cpswaps (from->sequenceNumber, to->sequenceNumber);
-    cpswapl (from->timestamp, to->timestamp);    
-    cpswapl (from->root, to->root);    
-    cpswapl (from->window, to->window);    
+    cpswapl (from->timestamp, to->timestamp);
+    cpswapl (from->root, to->root);
+    cpswapl (from->window, to->window);
     to->kind = from->kind;
     to->forced = from->forced;
 }
@@ -704,8 +704,8 @@ ProcScreenSaverQueryVersion (client)
     rep.majorVersion = SERVER_SAVER_MAJOR_VERSION;
     rep.minorVersion = SERVER_SAVER_MINOR_VERSION;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
     }
     WriteToClient(client, sizeof (xScreenSaverQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -772,12 +772,12 @@ ProcScreenSaverQueryInfo (client)
 	rep.kind = ScreenSaverInternal;
     if (client->swapped)
     {
-	swaps (&rep.sequenceNumber, n);
-	swapl (&rep.length, n);
-	swapl (&rep.window, n);
-	swapl (&rep.tilOrSince, n);
-	swapl (&rep.idle, n);
-	swapl (&rep.eventMask, n);
+	swaps (&rep.sequenceNumber);
+	swapl (&rep.length);
+	swapl (&rep.window);
+	swapl (&rep.tilOrSince);
+	swapl (&rep.idle);
+	swapl (&rep.eventMask);
     }
     WriteToClient(client, sizeof (xScreenSaverQueryInfoReply), (char *)&rep);
     return (client->noClientException);
@@ -1331,7 +1331,7 @@ SProcScreenSaverQueryVersion (client)
     REQUEST(xScreenSaverQueryVersionReq);
     int	    n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xScreenSaverQueryVersionReq);
     return ProcScreenSaverQueryVersion (client);
 }
@@ -1343,9 +1343,9 @@ SProcScreenSaverQueryInfo (client)
     REQUEST(xScreenSaverQueryInfoReq);
     int	    n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xScreenSaverQueryInfoReq);
-    swapl (&stuff->drawable, n);
+    swapl (&stuff->drawable);
     return ProcScreenSaverQueryInfo (client);
 }
 
@@ -1356,10 +1356,10 @@ SProcScreenSaverSelectInput (client)
     REQUEST(xScreenSaverSelectInputReq);
     int	    n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xScreenSaverSelectInputReq);
-    swapl (&stuff->drawable, n);
-    swapl (&stuff->eventMask, n);
+    swapl (&stuff->drawable);
+    swapl (&stuff->eventMask);
     return ProcScreenSaverSelectInput (client);
 }
 
@@ -1370,16 +1370,16 @@ SProcScreenSaverSetAttributes (client)
     REQUEST(xScreenSaverSetAttributesReq);
     int	    n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_AT_LEAST_SIZE(xScreenSaverSetAttributesReq);
-    swapl (&stuff->drawable, n);
-    swaps (&stuff->x, n);
-    swaps (&stuff->y, n);
-    swaps (&stuff->width, n);
-    swaps (&stuff->height, n);
-    swaps (&stuff->borderWidth, n);
-    swapl (&stuff->visualID, n);
-    swapl (&stuff->mask, n);
+    swapl (&stuff->drawable);
+    swaps (&stuff->x);
+    swaps (&stuff->y);
+    swaps (&stuff->width);
+    swaps (&stuff->height);
+    swaps (&stuff->borderWidth);
+    swapl (&stuff->visualID);
+    swapl (&stuff->mask);
     SwapRestL(stuff);
     return ProcScreenSaverSetAttributes (client);
 }
@@ -1391,9 +1391,9 @@ SProcScreenSaverUnsetAttributes (client)
     REQUEST(xScreenSaverUnsetAttributesReq);
     int	    n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xScreenSaverUnsetAttributesReq);
-    swapl (&stuff->drawable, n);
+    swapl (&stuff->drawable);
     return ProcScreenSaverUnsetAttributes (client);
 }
 

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -491,10 +491,9 @@ ProcSecurityQueryVersion(
     rep.minorVersion  	= SERVER_SECURITY_MINOR_VERSION;
     if(client->swapped)
     {
-	register char n;
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.majorVersion, n);
-	swaps(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.majorVersion);
+	swaps(&rep.minorVersion);
     }
     (void)WriteToClient(client, SIZEOF(xSecurityQueryVersionReply),
 			(char *)&rep);
@@ -709,11 +708,10 @@ ProcSecurityGenerateAuthorization(
 
     if (client->swapped)
     {
-	register char n;
-    	swapl(&rep.length, n);
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.authId, n);
-    	swaps(&rep.dataLength, n);
+	swapl(&rep.length);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.authId);
+	swaps(&rep.dataLength);
     }
 
     WriteToClient(client, SIZEOF(xSecurityGenerateAuthorizationReply),
@@ -788,12 +786,11 @@ SProcSecurityQueryVersion(
     ClientPtr client)
 {
     REQUEST(xSecurityQueryVersionReq);
-    register char 	n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSecurityQueryVersionReq);
-    swaps(&stuff->majorVersion, n);
-    swaps(&stuff->minorVersion,n);
+    swaps(&stuff->majorVersion);
+    swaps(&stuff->minorVersion);
     return ProcSecurityQueryVersion(client);
 } /* SProcSecurityQueryVersion */
 
@@ -803,16 +800,15 @@ SProcSecurityGenerateAuthorization(
     ClientPtr client)
 {
     REQUEST(xSecurityGenerateAuthorizationReq);
-    register char 	n;
     CARD32 *values;
     unsigned long nvalues;
     int values_offset;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSecurityGenerateAuthorizationReq);
-    swaps(&stuff->nbytesAuthProto, n);
-    swaps(&stuff->nbytesAuthData, n);
-    swapl(&stuff->valueMask, n);
+    swaps(&stuff->nbytesAuthProto);
+    swaps(&stuff->nbytesAuthData);
+    swapl(&stuff->valueMask);
     values_offset = ((stuff->nbytesAuthProto + (unsigned)3) >> 2) +
 		    ((stuff->nbytesAuthData + (unsigned)3) >> 2);
     if (values_offset > 
@@ -830,11 +826,10 @@ SProcSecurityRevokeAuthorization(
     ClientPtr client)
 {
     REQUEST(xSecurityRevokeAuthorizationReq);
-    register char 	n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSecurityRevokeAuthorizationReq);
-    swapl(&stuff->authId, n);
+    swapl(&stuff->authId);
     return ProcSecurityRevokeAuthorization(client);
 } /* SProcSecurityRevokeAuthorization */
 

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -289,7 +289,6 @@ ProcShapeQueryVersion (client)
     register ClientPtr	client;
 {
     xShapeQueryVersionReply	rep;
-    register int		n;
 
     REQUEST_SIZE_MATCH (xShapeQueryVersionReq);
     memset(&rep, 0, sizeof(xShapeQueryVersionReply));
@@ -299,10 +298,10 @@ ProcShapeQueryVersion (client)
     rep.majorVersion = SERVER_SHAPE_MAJOR_VERSION;
     rep.minorVersion = SERVER_SHAPE_MINOR_VERSION;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swaps(&rep.majorVersion, n);
-	swaps(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.majorVersion);
+	swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof (xShapeQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -714,7 +713,6 @@ ProcShapeQueryExtents (client)
     WindowPtr		pWin;
     xShapeQueryExtentsReply	rep;
     BoxRec		extents, *pExtents;
-    register int	n;
     RegionPtr		region;
 
     REQUEST_SIZE_MATCH (xShapeQueryExtentsReq);
@@ -756,16 +754,16 @@ ProcShapeQueryExtents (client)
     rep.widthClipShape = extents.x2 - extents.x1;
     rep.heightClipShape = extents.y2 - extents.y1;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swaps(&rep.xBoundingShape, n);
-	swaps(&rep.yBoundingShape, n);
-	swaps(&rep.widthBoundingShape, n);
-	swaps(&rep.heightBoundingShape, n);
-	swaps(&rep.xClipShape, n);
-	swaps(&rep.yClipShape, n);
-	swaps(&rep.widthClipShape, n);
-	swaps(&rep.heightClipShape, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.xBoundingShape);
+	swaps(&rep.yBoundingShape);
+	swaps(&rep.widthBoundingShape);
+	swaps(&rep.heightBoundingShape);
+	swaps(&rep.xClipShape);
+	swaps(&rep.yClipShape);
+	swaps(&rep.widthClipShape);
+	swaps(&rep.heightClipShape);
     }
     WriteToClient(client, sizeof (xShapeQueryExtentsReply), (char *)&rep);
     return (client->noClientException);
@@ -998,7 +996,6 @@ ProcShapeInputSelected (client)
     ShapeEventPtr	pShapeEvent, *pHead;
     int			enabled;
     xShapeInputSelectedReply	rep;
-    register int		n;
 
     REQUEST_SIZE_MATCH (xShapeInputSelectedReq);
     pWin = LookupWindow (stuff->window, client);
@@ -1023,8 +1020,8 @@ ProcShapeInputSelected (client)
     rep.sequenceNumber = client->sequence;
     rep.enabled = enabled;
     if (client->swapped) {
-	swaps (&rep.sequenceNumber, n);
-	swapl (&rep.length, n);
+	swaps (&rep.sequenceNumber);
+	swapl (&rep.length);
     }
     WriteToClient (client, sizeof (xShapeInputSelectedReply), (char *) &rep);
     return (client->noClientException);
@@ -1040,7 +1037,6 @@ ProcShapeGetRectangles (client)
     xRectangle			*rects;
     int				nrects, i;
     RegionPtr			region;
-    register int		n;
 
     REQUEST_SIZE_MATCH(xShapeGetRectanglesReq);
     pWin = LookupWindow (stuff->window, client);
@@ -1105,9 +1101,9 @@ ProcShapeGetRectangles (client)
     rep.ordering = YXBanded;
     rep.nrects = nrects;
     if (client->swapped) {
-	swaps (&rep.sequenceNumber, n);
-	swapl (&rep.length, n);
-	swapl (&rep.nrects, n);
+	swaps (&rep.sequenceNumber);
+	swapl (&rep.length);
+	swapl (&rep.nrects);
 	SwapShorts ((short *)rects, (unsigned long)nrects * 4);
     }
     WriteToClient (client, sizeof (rep), (char *) &rep);
@@ -1185,10 +1181,9 @@ static int
 SProcShapeQueryVersion (client)
     register ClientPtr	client;
 {
-    register int    n;
     REQUEST (xShapeQueryVersionReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     return ProcShapeQueryVersion (client);
 }
 
@@ -1196,14 +1191,13 @@ static int
 SProcShapeRectangles (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeRectanglesReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_AT_LEAST_SIZE (xShapeRectanglesReq);
-    swapl (&stuff->dest, n);
-    swaps (&stuff->xOff, n);
-    swaps (&stuff->yOff, n);
+    swapl (&stuff->dest);
+    swaps (&stuff->xOff);
+    swaps (&stuff->yOff);
     SwapRestS(stuff);
     return ProcShapeRectangles (client);
 }
@@ -1212,15 +1206,14 @@ static int
 SProcShapeMask (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeMaskReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeMaskReq);
-    swapl (&stuff->dest, n);
-    swaps (&stuff->xOff, n);
-    swaps (&stuff->yOff, n);
-    swapl (&stuff->src, n);
+    swapl (&stuff->dest);
+    swaps (&stuff->xOff);
+    swaps (&stuff->yOff);
+    swapl (&stuff->src);
     return ProcShapeMask (client);
 }
 
@@ -1228,15 +1221,14 @@ static int
 SProcShapeCombine (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeCombineReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeCombineReq);
-    swapl (&stuff->dest, n);
-    swaps (&stuff->xOff, n);
-    swaps (&stuff->yOff, n);
-    swapl (&stuff->src, n);
+    swapl (&stuff->dest);
+    swaps (&stuff->xOff);
+    swaps (&stuff->yOff);
+    swapl (&stuff->src);
     return ProcShapeCombine (client);
 }
 
@@ -1244,14 +1236,13 @@ static int
 SProcShapeOffset (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeOffsetReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeOffsetReq);
-    swapl (&stuff->dest, n);
-    swaps (&stuff->xOff, n);
-    swaps (&stuff->yOff, n);
+    swapl (&stuff->dest);
+    swaps (&stuff->xOff);
+    swaps (&stuff->yOff);
     return ProcShapeOffset (client);
 }
 
@@ -1259,12 +1250,11 @@ static int
 SProcShapeQueryExtents (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeQueryExtentsReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeQueryExtentsReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return ProcShapeQueryExtents (client);
 }
 
@@ -1272,12 +1262,11 @@ static int
 SProcShapeSelectInput (client)
     register ClientPtr	client;
 {
-    register char   n;
     REQUEST (xShapeSelectInputReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeSelectInputReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return ProcShapeSelectInput (client);
 }
 
@@ -1285,12 +1274,11 @@ static int
 SProcShapeInputSelected (client)
     register ClientPtr	client;
 {
-    register int    n;
     REQUEST (xShapeInputSelectedReq);
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH (xShapeInputSelectedReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return ProcShapeInputSelected (client);
 }
 
@@ -1299,11 +1287,10 @@ SProcShapeGetRectangles (client)
     register ClientPtr	client;
 {
     REQUEST(xShapeGetRectanglesReq);
-    register char   n;
 
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xShapeGetRectanglesReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return ProcShapeGetRectangles (client);
 }
 

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -346,7 +346,6 @@ ProcShmQueryVersion(client)
     register ClientPtr client;
 {
     xShmQueryVersionReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xShmQueryVersionReq);
     memset(&rep, 0, sizeof(xShmQueryVersionReply));
@@ -360,12 +359,12 @@ ProcShmQueryVersion(client)
     rep.uid = geteuid();
     rep.gid = getegid();
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swaps(&rep.majorVersion, n);
-	swaps(&rep.minorVersion, n);
-	swaps(&rep.uid, n);
-	swaps(&rep.gid, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.majorVersion);
+	swaps(&rep.minorVersion);
+	swaps(&rep.uid);
+	swaps(&rep.gid);
     }
     WriteToClient(client, sizeof(xShmQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -712,11 +711,10 @@ ProcPanoramiXShmGetImage(ClientPtr client)
     }
     
     if (client->swapped) {
-	register int n;
-    	swaps(&xgi.sequenceNumber, n);
-    	swapl(&xgi.length, n);
-	swapl(&xgi.visual, n);
-	swapl(&xgi.size, n);
+	swaps(&xgi.sequenceNumber);
+	swapl(&xgi.length);
+	swapl(&xgi.visual);
+	swapl(&xgi.size);
     }
     WriteToClient(client, sizeof(xShmGetImageReply), (char *)&xgi);
 
@@ -952,7 +950,6 @@ ProcShmGetImage(client)
     Mask		plane = 0;
     xShmGetImageReply	xgi;
     ShmDescPtr		shmdesc;
-    int			n;
 
     REQUEST(xShmGetImageReq);
 
@@ -1043,10 +1040,10 @@ ProcShmGetImage(client)
     }
     
     if (client->swapped) {
-    	swaps(&xgi.sequenceNumber, n);
-    	swapl(&xgi.length, n);
-	swapl(&xgi.visual, n);
-	swapl(&xgi.size, n);
+	swaps(&xgi.sequenceNumber);
+	swapl(&xgi.length);
+	swapl(&xgi.visual);
+	swapl(&xgi.size);
     }
     WriteToClient(client, sizeof(xShmGetImageReply), (char *)&xgi);
 
@@ -1205,10 +1202,9 @@ static int
 SProcShmQueryVersion(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xShmQueryVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return ProcShmQueryVersion(client);
 }
 
@@ -1216,12 +1212,11 @@ static int
 SProcShmAttach(client)
     ClientPtr client;
 {
-    register int n;
     REQUEST(xShmAttachReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xShmAttachReq);
-    swapl(&stuff->shmseg, n);
-    swapl(&stuff->shmid, n);
+    swapl(&stuff->shmseg);
+    swapl(&stuff->shmid);
     return ProcShmAttach(client);
 }
 
@@ -1229,11 +1224,10 @@ static int
 SProcShmDetach(client)
     ClientPtr client;
 {
-    register int n;
     REQUEST(xShmDetachReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xShmDetachReq);
-    swapl(&stuff->shmseg, n);
+    swapl(&stuff->shmseg);
     return ProcShmDetach(client);
 }
 
@@ -1241,22 +1235,21 @@ static int
 SProcShmPutImage(client)
     ClientPtr client;
 {
-    register int n;
     REQUEST(xShmPutImageReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xShmPutImageReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->totalWidth, n);
-    swaps(&stuff->totalHeight, n);
-    swaps(&stuff->srcX, n);
-    swaps(&stuff->srcY, n);
-    swaps(&stuff->srcWidth, n);
-    swaps(&stuff->srcHeight, n);
-    swaps(&stuff->dstX, n);
-    swaps(&stuff->dstY, n);
-    swapl(&stuff->shmseg, n);
-    swapl(&stuff->offset, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->totalWidth);
+    swaps(&stuff->totalHeight);
+    swaps(&stuff->srcX);
+    swaps(&stuff->srcY);
+    swaps(&stuff->srcWidth);
+    swaps(&stuff->srcHeight);
+    swaps(&stuff->dstX);
+    swaps(&stuff->dstY);
+    swapl(&stuff->shmseg);
+    swapl(&stuff->offset);
     return ProcShmPutImage(client);
 }
 
@@ -1264,18 +1257,17 @@ static int
 SProcShmGetImage(client)
     ClientPtr client;
 {
-    register int n;
     REQUEST(xShmGetImageReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xShmGetImageReq);
-    swapl(&stuff->drawable, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swapl(&stuff->planeMask, n);
-    swapl(&stuff->shmseg, n);
-    swapl(&stuff->offset, n);
+    swapl(&stuff->drawable);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->planeMask);
+    swapl(&stuff->shmseg);
+    swapl(&stuff->offset);
     return ProcShmGetImage(client);
 }
 
@@ -1283,16 +1275,15 @@ static int
 SProcShmCreatePixmap(client)
     ClientPtr client;
 {
-    register int n;
     REQUEST(xShmCreatePixmapReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xShmCreatePixmapReq);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->drawable, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swapl(&stuff->shmseg, n);
-    swapl(&stuff->offset, n);
+    swapl(&stuff->pid);
+    swapl(&stuff->drawable);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->shmseg);
+    swapl(&stuff->offset);
     return ProcShmCreatePixmap(client);
 }
 

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -1343,7 +1343,6 @@ ProcSyncInitialize(client)
     ClientPtr       client;
 {
     xSyncInitializeReply  rep;
-    int   n;
 
     REQUEST_SIZE_MATCH(xSyncInitializeReq);
 
@@ -1356,7 +1355,7 @@ ProcSyncInitialize(client)
 
     if (client->swapped)
     {
-	swaps(&rep.sequenceNumber, n);
+	swaps(&rep.sequenceNumber);
     }
     WriteToClient(client, sizeof(rep), (char *) &rep);
     return (client->noClientException);
@@ -1397,10 +1396,9 @@ ProcSyncListSystemCounters(client)
 
     if (client->swapped)
     {
-	register char n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.length, n);
-	swapl(&rep.nCounters, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.nCounters);
     }
 
     for (i = 0; i < SyncNumSystemCounters; i++)
@@ -1417,11 +1415,10 @@ ProcSyncListSystemCounters(client)
 
 	if (client->swapped)
 	{
-	    register char n;
-	    swapl(&walklist->counter, n);
-	    swapl(&walklist->resolution_hi, n);
-	    swapl(&walklist->resolution_lo, n);
-	    swaps(&walklist->name_length, n);
+	    swapl(&walklist->counter);
+	    swapl(&walklist->resolution_hi);
+	    swapl(&walklist->resolution_lo);
+	    swaps(&walklist->name_length);
 	}
 
 	pname_in_reply = ((char *)walklist) + sz_xSyncSystemCounter;
@@ -1502,9 +1499,8 @@ ProcSyncGetPriority(client)
 
     if (client->swapped)
     {
-	register char n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.priority, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.priority);
     }
 
     WriteToClient(client, sizeof(xSyncGetPriorityReply), (char *) &rep);
@@ -1787,11 +1783,10 @@ ProcSyncQueryCounter(client)
     rep.value_lo = XSyncValueLow32(pCounter->value);
     if (client->swapped)
     {
-	register char n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.length, n);
-	swapl(&rep.value_hi, n);
-	swapl(&rep.value_lo, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.value_hi);
+	swapl(&rep.value_lo);
     }
     WriteToClient(client, sizeof(xSyncQueryCounterReply), (char *) &rep);
     return (client->noClientException);
@@ -1969,15 +1964,14 @@ ProcSyncQueryAlarm(client)
 
     if (client->swapped)
     {
-	register char n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.length, n);
-	swapl(&rep.counter, n);
-	swapl(&rep.wait_value_hi, n);
-	swapl(&rep.wait_value_lo, n);
-	swapl(&rep.test_type, n);
-	swapl(&rep.delta_hi, n);
-	swapl(&rep.delta_lo, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.counter);
+	swapl(&rep.wait_value_hi);
+	swapl(&rep.wait_value_lo);
+	swapl(&rep.test_type);
+	swapl(&rep.delta_hi);
+	swapl(&rep.delta_lo);
     }
 
     WriteToClient(client, sizeof(xSyncQueryAlarmReply), (char *) &rep);
@@ -2058,9 +2052,8 @@ SProcSyncInitialize(client)
     ClientPtr       client;
 {
     REQUEST(xSyncInitializeReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncInitializeReq);
 
     return ProcSyncInitialize(client);
@@ -2071,9 +2064,8 @@ SProcSyncListSystemCounters(client)
     ClientPtr       client;
 {
     REQUEST(xSyncListSystemCountersReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncListSystemCountersReq);
 
     return ProcSyncListSystemCounters(client);
@@ -2084,13 +2076,12 @@ SProcSyncCreateCounter(client)
     ClientPtr       client;
 {
     REQUEST(xSyncCreateCounterReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncCreateCounterReq);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->initial_value_lo, n);
-    swapl(&stuff->initial_value_hi, n);
+    swapl(&stuff->cid);
+    swapl(&stuff->initial_value_lo);
+    swapl(&stuff->initial_value_hi);
 
     return ProcSyncCreateCounter(client);
 }
@@ -2100,13 +2091,12 @@ SProcSyncSetCounter(client)
     ClientPtr       client;
 {
     REQUEST(xSyncSetCounterReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncSetCounterReq);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->value_lo, n);
-    swapl(&stuff->value_hi, n);
+    swapl(&stuff->cid);
+    swapl(&stuff->value_lo);
+    swapl(&stuff->value_hi);
 
     return ProcSyncSetCounter(client);
 }
@@ -2116,13 +2106,12 @@ SProcSyncChangeCounter(client)
     ClientPtr       client;
 {
     REQUEST(xSyncChangeCounterReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncChangeCounterReq);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->value_lo, n);
-    swapl(&stuff->value_hi, n);
+    swapl(&stuff->cid);
+    swapl(&stuff->value_lo);
+    swapl(&stuff->value_hi);
 
     return ProcSyncChangeCounter(client);
 }
@@ -2132,11 +2121,10 @@ SProcSyncQueryCounter(client)
     ClientPtr       client;
 {
     REQUEST(xSyncQueryCounterReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncQueryCounterReq);
-    swapl(&stuff->counter, n);
+    swapl(&stuff->counter);
 
     return ProcSyncQueryCounter(client);
 }
@@ -2146,11 +2134,10 @@ SProcSyncDestroyCounter(client)
     ClientPtr       client;
 {
     REQUEST(xSyncDestroyCounterReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncDestroyCounterReq);
-    swapl(&stuff->counter, n);
+    swapl(&stuff->counter);
 
     return ProcSyncDestroyCounter(client);
 }
@@ -2160,9 +2147,8 @@ SProcSyncAwait(client)
     ClientPtr       client;
 {
     REQUEST(xSyncAwaitReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSyncAwaitReq);
     SwapRestL(stuff);
 
@@ -2175,12 +2161,11 @@ SProcSyncCreateAlarm(client)
     ClientPtr       client;
 {
     REQUEST(xSyncCreateAlarmReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSyncCreateAlarmReq);
-    swapl(&stuff->id, n);
-    swapl(&stuff->valueMask, n);
+    swapl(&stuff->id);
+    swapl(&stuff->valueMask);
     SwapRestL(stuff);
 
     return ProcSyncCreateAlarm(client);
@@ -2191,12 +2176,11 @@ SProcSyncChangeAlarm(client)
     ClientPtr       client;
 {
     REQUEST(xSyncChangeAlarmReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSyncChangeAlarmReq);
-    swapl(&stuff->alarm, n);
-    swapl(&stuff->valueMask, n);
+    swapl(&stuff->alarm);
+    swapl(&stuff->valueMask);
     SwapRestL(stuff);
     return ProcSyncChangeAlarm(client);
 }
@@ -2206,11 +2190,10 @@ SProcSyncQueryAlarm(client)
     ClientPtr       client;
 {
     REQUEST(xSyncQueryAlarmReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncQueryAlarmReq);
-    swapl(&stuff->alarm, n);
+    swapl(&stuff->alarm);
 
     return ProcSyncQueryAlarm(client);
 }
@@ -2220,11 +2203,10 @@ SProcSyncDestroyAlarm(client)
     ClientPtr       client;
 {
     REQUEST(xSyncDestroyAlarmReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncDestroyAlarmReq);
-    swapl(&stuff->alarm, n);
+    swapl(&stuff->alarm);
 
     return ProcSyncDestroyAlarm(client);
 }
@@ -2234,12 +2216,11 @@ SProcSyncSetPriority(client)
     ClientPtr       client;
 {
     REQUEST(xSyncSetPriorityReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncSetPriorityReq);
-    swapl(&stuff->id, n);
-    swapl(&stuff->priority, n);
+    swapl(&stuff->id);
+    swapl(&stuff->priority);
 
     return ProcSyncSetPriority(client);
 }
@@ -2249,11 +2230,10 @@ SProcSyncGetPriority(client)
     ClientPtr       client;
 {
     REQUEST(xSyncGetPriorityReq);
-    register char   n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH (xSyncGetPriorityReq);
-    swapl(&stuff->id, n);
+    swapl(&stuff->id);
 
     return ProcSyncGetPriority(client);
 }

--- a/nx-X11/programs/Xserver/Xext/xcmisc.c
+++ b/nx-X11/programs/Xserver/Xext/xcmisc.c
@@ -98,7 +98,6 @@ ProcXCMiscGetVersion(client)
     register ClientPtr client;
 {
     xXCMiscGetVersionReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xXCMiscGetVersionReq);
     rep.type = X_Reply;
@@ -107,9 +106,9 @@ ProcXCMiscGetVersion(client)
     rep.majorVersion = XCMiscMajorVersion;
     rep.minorVersion = XCMiscMinorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.majorVersion, n);
-	swaps(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.majorVersion);
+	swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xXCMiscGetVersionReply), (char *)&rep);
     return(client->noClientException);
@@ -120,7 +119,6 @@ ProcXCMiscGetXIDRange(client)
     register ClientPtr client;
 {
     xXCMiscGetXIDRangeReply rep;
-    register int n;
     XID min_id, max_id;
 
     REQUEST_SIZE_MATCH(xXCMiscGetXIDRangeReq);
@@ -131,9 +129,9 @@ ProcXCMiscGetXIDRange(client)
     rep.start_id = min_id;
     rep.count = max_id - min_id + 1;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.start_id, n);
-	swapl(&rep.count, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.start_id);
+	swapl(&rep.count);
     }
     WriteToClient(client, sizeof(xXCMiscGetXIDRangeReply), (char *)&rep);
     return(client->noClientException);
@@ -145,7 +143,6 @@ ProcXCMiscGetXIDList(client)
 {
     REQUEST(xXCMiscGetXIDListReq);
     xXCMiscGetXIDListReply rep;
-    register int n;
     XID *pids;
     unsigned int count;
 
@@ -165,9 +162,9 @@ ProcXCMiscGetXIDList(client)
     rep.length = count;
     rep.count = count;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.length, n);
-	swapl(&rep.count, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.count);
     }
     WriteToClient(client, sizeof(xXCMiscGetXIDListReply), (char *)&rep);
     if (count)
@@ -201,13 +198,12 @@ static int
 SProcXCMiscGetVersion(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xXCMiscGetVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXCMiscGetVersionReq);
-    swaps(&stuff->majorVersion, n);
-    swaps(&stuff->minorVersion, n);
+    swaps(&stuff->majorVersion);
+    swaps(&stuff->minorVersion);
     return ProcXCMiscGetVersion(client);
 }
 
@@ -215,10 +211,9 @@ static int
 SProcXCMiscGetXIDRange(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return ProcXCMiscGetXIDRange(client);
 }
 
@@ -226,12 +221,11 @@ static int
 SProcXCMiscGetXIDList(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xXCMiscGetXIDListReq);
     REQUEST_SIZE_MATCH(xXCMiscGetXIDListReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->count, n);
+    swaps(&stuff->length);
+    swapl(&stuff->count);
     return ProcXCMiscGetXIDList(client);
 }
 

--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
@@ -375,14 +375,13 @@ ProcXF86BigfontQueryVersion(
 #endif
 	; /* may add more bits here in future versions */
     if (client->swapped) {
-	char tmp;
-	swaps(&reply.sequenceNumber, tmp);
-	swapl(&reply.length, tmp);
-	swaps(&reply.majorVersion, tmp);
-	swaps(&reply.minorVersion, tmp);
-	swapl(&reply.uid, tmp);
-	swapl(&reply.gid, tmp);
-	swapl(&reply.signature, tmp);
+	swaps(&reply.sequenceNumber);
+	swapl(&reply.length);
+	swaps(&reply.majorVersion);
+	swaps(&reply.minorVersion);
+	swapl(&reply.uid);
+	swapl(&reply.gid);
+	swapl(&reply.signature);
     }
     WriteToClient(client,
 		  sizeof(xXF86BigfontQueryVersionReply), (char *)&reply);
@@ -393,14 +392,12 @@ static void
 swapCharInfo(
     xCharInfo *pCI)
 {
-    char tmp;
-
-    swaps(&pCI->leftSideBearing, tmp);
-    swaps(&pCI->rightSideBearing, tmp);
-    swaps(&pCI->characterWidth, tmp);
-    swaps(&pCI->ascent, tmp);
-    swaps(&pCI->descent, tmp);
-    swaps(&pCI->attributes, tmp);
+    swaps(&pCI->leftSideBearing);
+    swaps(&pCI->rightSideBearing);
+    swaps(&pCI->characterWidth);
+    swaps(&pCI->ascent);
+    swaps(&pCI->descent);
+    swaps(&pCI->attributes);
 }
 
 /* static CARD32 hashCI (xCharInfo *p); */
@@ -671,21 +668,20 @@ ProcXF86BigfontQueryFont(
 	reply->shmid = shmid;
 	reply->shmsegoffset = 0;
 	if (client->swapped) {
-	    char tmp;
-	    swaps(&reply->sequenceNumber, tmp);
-	    swapl(&reply->length, tmp);
+	    swaps(&reply->sequenceNumber);
+	    swapl(&reply->length);
 	    swapCharInfo(&reply->minBounds);
 	    swapCharInfo(&reply->maxBounds);
-	    swaps(&reply->minCharOrByte2, tmp);
-	    swaps(&reply->maxCharOrByte2, tmp);
-	    swaps(&reply->defaultChar, tmp);
-	    swaps(&reply->nFontProps, tmp);
-	    swaps(&reply->fontAscent, tmp);
-	    swaps(&reply->fontDescent, tmp);
-	    swapl(&reply->nCharInfos, tmp);
-	    swapl(&reply->nUniqCharInfos, tmp);
-	    swapl(&reply->shmid, tmp);
-	    swapl(&reply->shmsegoffset, tmp);
+	    swaps(&reply->minCharOrByte2);
+	    swaps(&reply->maxCharOrByte2);
+	    swaps(&reply->defaultChar);
+	    swaps(&reply->nFontProps);
+	    swaps(&reply->fontAscent);
+	    swaps(&reply->fontDescent);
+	    swapl(&reply->nCharInfos);
+	    swapl(&reply->nUniqCharInfos);
+	    swapl(&reply->shmid);
+	    swapl(&reply->shmsegoffset);
 	}
 	p = (char*) &reply[1];
 	{
@@ -698,9 +694,8 @@ ProcXF86BigfontQueryFont(
 		prFP->name = pFP->name;
 		prFP->value = pFP->value;
 		if (client->swapped) {
-		    char tmp;
-		    swapl(&prFP->name, tmp);
-		    swapl(&prFP->value, tmp);
+		    swapl(&prFP->name);
+		    swapl(&prFP->value);
 		}
 	    }
 	    p = (char*) prFP;
@@ -719,8 +714,7 @@ ProcXF86BigfontQueryFont(
 	    for (j = 0; j < nCharInfos; j++, ps++) {
 		*ps = pIndex2UniqIndex[j];
 		if (client->swapped) {
-		    char tmp;
-		    swaps(ps, tmp);
+		    swaps(ps);
 		}
 	    }
 	}
@@ -755,9 +749,8 @@ SProcXF86BigfontQueryVersion(
     ClientPtr client)
 {
     REQUEST(xXF86BigfontQueryVersionReq);
-    char tmp;
 
-    swaps(&stuff->length, tmp);
+    swaps(&stuff->length);
     return ProcXF86BigfontQueryVersion(client);
 }
 
@@ -766,11 +759,10 @@ SProcXF86BigfontQueryFont(
     ClientPtr client)
 {
     REQUEST(xXF86BigfontQueryFontReq);
-    char tmp;
 
-    swaps(&stuff->length, tmp);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXF86BigfontQueryFontReq);
-    swapl(&stuff->id, tmp);
+    swapl(&stuff->id);
     return ProcXF86BigfontQueryFont(client);
 }
 

--- a/nx-X11/programs/Xserver/Xext/xres.c
+++ b/nx-X11/programs/Xserver/Xext/xres.c
@@ -27,14 +27,8 @@ ProcXResQueryVersion (ClientPtr client)
 {
     REQUEST(xXResQueryVersionReq);
     xXResQueryVersionReply rep;
-    CARD16 client_major, client_minor;  /* not used */
 
     REQUEST_SIZE_MATCH (xXResQueryVersionReq);
-
-    client_major = stuff->client_major;
-    client_minor = stuff->client_minor;
-    (void) client_major;
-    (void) client_minor;
 
     rep.type = X_Reply;
     rep.length = 0;
@@ -42,11 +36,10 @@ ProcXResQueryVersion (ClientPtr client)
     rep.server_major = SERVER_XRES_MAJOR_VERSION;
     rep.server_minor = SERVER_XRES_MINOR_VERSION;
     if (client->swapped) { 
-        int n;
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);     
-        swaps(&rep.server_major, n);
-        swaps(&rep.server_minor, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.server_major);
+        swaps(&rep.server_minor);
     }
     WriteToClient(client, sizeof (xXResQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -77,10 +70,9 @@ ProcXResQueryClients (ClientPtr client)
     rep.num_clients = num_clients;
     rep.length = rep.num_clients * sz_xXResClient >> 2;
     if (client->swapped) {
-        int n;
-        swaps (&rep.sequenceNumber, n);
-        swapl (&rep.length, n);
-        swapl (&rep.num_clients, n);
+        swaps (&rep.sequenceNumber);
+        swapl (&rep.length);
+        swapl (&rep.num_clients);
     }   
     WriteToClient (client, sizeof (xXResQueryClientsReply), (char *) &rep);
 
@@ -92,9 +84,8 @@ ProcXResQueryClients (ClientPtr client)
             scratch.resource_mask = RESOURCE_ID_MASK;
         
             if(client->swapped) {
-                register int n;
-                swapl (&scratch.resource_base, n);
-                swapl (&scratch.resource_mask, n);
+                swapl (&scratch.resource_base);
+                swapl (&scratch.resource_mask);
             }
             WriteToClient (client, sz_xXResClient, (char *) &scratch);
         }
@@ -150,10 +141,9 @@ ProcXResQueryClientResources (ClientPtr client)
     rep.num_types = num_types;
     rep.length = rep.num_types * sz_xXResType >> 2;
     if (client->swapped) {
-        int n;
-        swaps (&rep.sequenceNumber, n);
-        swapl (&rep.length, n);
-        swapl (&rep.num_types, n);
+        swaps (&rep.sequenceNumber);
+        swapl (&rep.length);
+        swapl (&rep.num_types);
     }   
     WriteToClient (client,sizeof(xXResQueryClientResourcesReply),(char*)&rep);
 
@@ -173,9 +163,8 @@ ProcXResQueryClientResources (ClientPtr client)
             scratch.count = counts[i];
 
             if(client->swapped) {
-                register int n;
-                swapl (&scratch.resource_type, n);
-                swapl (&scratch.count, n);
+                swapl (&scratch.resource_type);
+                swapl (&scratch.count);
             }
             WriteToClient (client, sz_xXResType, (char *) &scratch);
         }
@@ -229,11 +218,10 @@ ProcXResQueryClientPixmapBytes (ClientPtr client)
     rep.bytes_overflow = 0;
 #endif
     if (client->swapped) {
-        int n;
-        swaps (&rep.sequenceNumber, n);
-        swapl (&rep.length, n);
-        swapl (&rep.bytes, n);
-        swapl (&rep.bytes_overflow, n);
+        swaps (&rep.sequenceNumber);
+        swapl (&rep.length);
+        swapl (&rep.bytes);
+        swapl (&rep.bytes_overflow);
     }
     WriteToClient (client,sizeof(xXResQueryClientPixmapBytesReply),(char*)&rep);
 
@@ -266,12 +254,7 @@ ProcResDispatch (ClientPtr client)
 static int
 SProcXResQueryVersion (ClientPtr client)
 {
-    REQUEST(xXResQueryVersionReq);
-    int n;
-
     REQUEST_SIZE_MATCH (xXResQueryVersionReq);
-    swaps(&stuff->client_major,n);
-    swaps(&stuff->client_minor,n);
     return ProcXResQueryVersion(client);
 }
 
@@ -279,10 +262,9 @@ static int
 SProcXResQueryClientResources (ClientPtr client)
 {
     REQUEST(xXResQueryClientResourcesReq);
-    int n;
 
     REQUEST_SIZE_MATCH (xXResQueryClientResourcesReq);
-    swaps(&stuff->xid,n);
+    swapl(&stuff->xid);
     return ProcXResQueryClientResources(client);
 }
 
@@ -290,10 +272,9 @@ static int
 SProcXResQueryClientPixmapBytes (ClientPtr client)
 {
     REQUEST(xXResQueryClientPixmapBytesReq);
-    int n;
 
     REQUEST_SIZE_MATCH (xXResQueryClientPixmapBytesReq);
-    swaps(&stuff->xid,n);
+    swapl(&stuff->xid);
     return ProcXResQueryClientPixmapBytes(client);
 }
 
@@ -301,9 +282,8 @@ static int
 SProcResDispatch (ClientPtr client)
 {
     REQUEST(xReq);
-    int n;
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
 
     switch (stuff->data) {
     case X_XResQueryVersion:

--- a/nx-X11/programs/Xserver/Xext/xtest.c
+++ b/nx-X11/programs/Xserver/Xext/xtest.c
@@ -121,7 +121,6 @@ ProcXTestGetVersion(client)
     register ClientPtr client;
 {
     xXTestGetVersionReply rep;
-    register int n;
 
     REQUEST_SIZE_MATCH(xXTestGetVersionReq);
     rep.type = X_Reply;
@@ -130,8 +129,8 @@ ProcXTestGetVersion(client)
     rep.majorVersion = XTestMajorVersion;
     rep.minorVersion = XTestMinorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xXTestGetVersionReply), (char *)&rep);
     return(client->noClientException);
@@ -145,7 +144,6 @@ ProcXTestCompareCursor(client)
     xXTestCompareCursorReply rep;
     WindowPtr pWin;
     CursorPtr pCursor;
-    register int n;
 
     REQUEST_SIZE_MATCH(xXTestCompareCursorReq);
     pWin = (WindowPtr)LookupWindow(stuff->window, client);
@@ -168,7 +166,7 @@ ProcXTestCompareCursor(client)
     rep.sequenceNumber = client->sequence;
     rep.same = (wCursor(pWin) == pCursor);
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
+	swaps(&rep.sequenceNumber);
     }
     WriteToClient(client, sizeof(xXTestCompareCursorReply), (char *)&rep);
     return(client->noClientException);
@@ -180,7 +178,7 @@ ProcXTestFakeInput(client)
 {
     REQUEST(xXTestFakeInputReq);
     int nev;
-    int	n;
+    int        n;
     xEvent *ev;
     DeviceIntPtr dev = NULL;
     WindowPtr root;
@@ -285,7 +283,7 @@ ProcXTestFakeInput(client)
 	if (client->swapped)
 	{
     	    (void) XTestSwapFakeInput(client, (xReq *)stuff);
-	    swaps(&stuff->length, n);
+	    swaps(&stuff->length);
 	}
 	ResetCurrentRequest (client);
 	client->sequence--;
@@ -512,12 +510,11 @@ static int
 SProcXTestGetVersion(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xXTestGetVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXTestGetVersionReq);
-    swaps(&stuff->minorVersion, n);
+    swaps(&stuff->minorVersion);
     return ProcXTestGetVersion(client);
 }
 
@@ -525,13 +522,12 @@ static int
 SProcXTestCompareCursor(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xXTestCompareCursorReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXTestCompareCursorReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->cursor, n);
+    swapl(&stuff->window);
+    swapl(&stuff->cursor);
     return ProcXTestCompareCursor(client);
 }
 
@@ -568,7 +564,7 @@ SProcXTestFakeInput(client)
     register int n;
     REQUEST(xReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     n = XTestSwapFakeInput(client, stuff);
     if (n != Success)
 	return n;
@@ -579,10 +575,9 @@ static int
 SProcXTestGrabControl(client)
     register ClientPtr	client;
 {
-    register int n;
     REQUEST(xXTestGrabControlReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXTestGrabControlReq);
     return ProcXTestGrabControl(client);
 }

--- a/nx-X11/programs/Xserver/Xext/xtest1di.c
+++ b/nx-X11/programs/Xserver/Xext/xtest1di.c
@@ -319,10 +319,6 @@ SProcTestFakeInput(client)
 	register ClientPtr	client;
 {
 	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-	/*
 	 * index counter
 	 */
 	int		i;
@@ -339,8 +335,8 @@ SProcTestFakeInput(client)
 	/*
 	 * byte-swap the fields in the request
 	 */
-	swaps(&stuff->length, n);
-	swapl(&stuff->ack, n);
+	swaps(&stuff->length);
+	swapl(&stuff->ack);
 	/*
 	 * have to parse and then byte-swap the input action list here
 	 */
@@ -363,7 +359,7 @@ SProcTestFakeInput(client)
 			/*
 			 * byte-swap the delay_time field
 			 */
-			swaps(&(((XTestKeyInfo *) input_action_ptr)->delay_time), n);
+			swaps(&(((XTestKeyInfo *) input_action_ptr)->delay_time));
 			/*
 			 * advance to the next input action
 			 */
@@ -373,7 +369,7 @@ SProcTestFakeInput(client)
 			/*
 			 * byte-swap the delay_time field
 			 */
-			swaps(&(((XTestMotionInfo *) input_action_ptr)->delay_time), n);
+			swaps(&(((XTestMotionInfo *) input_action_ptr)->delay_time));
 			/*
 			 * advance to the next input action
 			 */
@@ -383,15 +379,15 @@ SProcTestFakeInput(client)
 			/*
 			 * byte-swap the jumpx field
 			 */
-			swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpx), n);
+			swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpx));
 			/*
 			 * byte-swap the jumpy field
 			 */
-			swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpy), n);
+			swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpy));
 			/*
 			 * byte-swap the delay_time field
 			 */
-			swaps(&(((XTestJumpInfo *) input_action_ptr)->delay_time), n);
+			swaps(&(((XTestJumpInfo *) input_action_ptr)->delay_time));
 			/*
 			 * advance to the next input action
 			 */
@@ -409,7 +405,7 @@ SProcTestFakeInput(client)
 				/*
 				 * byte-swap the delay_time field
 				 */
-				swapl(&(((XTestDelayInfo *) input_action_ptr)->delay_time), n);
+				swapl(&(((XTestDelayInfo *) input_action_ptr)->delay_time));
 				/*
 				 * advance to the next input action
 				 */
@@ -440,17 +436,12 @@ static int
 SProcTestGetInput(client)
 	register ClientPtr	client;
 {
-	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-
 	REQUEST(xTestGetInputReq);
 	/*
 	 * byte-swap the fields in the request
 	 */
-	swaps(&stuff->length, n);
-	swapl(&stuff->mode, n);
+	swaps(&stuff->length);
+	swapl(&stuff->mode);
 	return(ProcTestGetInput(client));
 }
 
@@ -464,16 +455,11 @@ static int
 SProcTestStopInput(client)
 	register ClientPtr	client;
 {
-	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-
 	REQUEST(xTestStopInputReq);
 	/*
 	 * byte-swap the length field in the request
 	 */
-	swaps(&stuff->length, n);
+	swaps(&stuff->length);
 	return(ProcTestStopInput(client));
 }
 
@@ -487,16 +473,11 @@ static int
 SProcTestReset(client)
 	register ClientPtr	client;
 {
-	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-
 	REQUEST(xTestResetReq);
 	/*
 	 * byte-swap the length field in the request
 	 */
-	swaps(&stuff->length, n);
+	swaps(&stuff->length);
 	return(ProcTestReset(client));
 }
 
@@ -510,16 +491,11 @@ static int
 SProcTestQueryInputSize(client)
 	register ClientPtr	client;
 {
-	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-
 	REQUEST(xTestQueryInputSizeReq);
 	/*
 	 * byte-swap the length field in the request
 	 */
-	swaps(&stuff->length, n);
+	swaps(&stuff->length);
 	return(ProcTestQueryInputSize(client));
 }
 
@@ -781,10 +757,6 @@ SReplyXTestDispatch(client_ptr, size, reply_ptr)
 	char		*reply_ptr;
 {
 	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
-	/*
 	 * pointer to xTestQueryInputSizeReply
 	 */
 	xTestQueryInputSizeReply	*rep_ptr;
@@ -793,9 +765,9 @@ SReplyXTestDispatch(client_ptr, size, reply_ptr)
 	 * there is only one reply in this extension, so byte-swap it
 	 */
 	rep_ptr = (xTestQueryInputSizeReply *) reply_ptr;
-	swaps(&(rep_ptr->sequenceNumber), n);
-	swapl(&(rep_ptr->length), n);
-	swapl(&(rep_ptr->size_return), n);
+	swaps(&(rep_ptr->sequenceNumber));
+	swapl(&(rep_ptr->length));
+	swapl(&(rep_ptr->size_return));
 	/*
 	 * now write the swapped reply to the client
 	 */
@@ -813,10 +785,6 @@ SEventXTestDispatch(from, to)
 	xEvent	*from;
 	xEvent	*to;
 {
-	/*
-	 * used in the swaps and swapl macros for temporary storage space
-	 */
-	register char	n;
 	/*
 	 * index counter
 	 */
@@ -845,7 +813,7 @@ SEventXTestDispatch(from, to)
 	/*
 	 * byte-swap the sequence number in the "to" event
 	 */
-	swaps(&(((xTestInputActionEvent *) to)->sequenceNumber), n);
+	swaps(&(((xTestInputActionEvent *) to)->sequenceNumber));
 	/*
 	 * If the event is an xTestInputActionEvent, then it needs more
 	 * processing.  Otherwise, it is an xTestFakeAckEvent, which
@@ -886,7 +854,7 @@ SEventXTestDispatch(from, to)
 				/*
 				 * byte-swap the delay_time field
 				 */
-				swaps(&(((XTestKeyInfo *) input_action_ptr)->delay_time), n);
+				swaps(&(((XTestKeyInfo *) input_action_ptr)->delay_time));
 				/*
 				 * advance to the next input action
 				 */
@@ -896,7 +864,7 @@ SEventXTestDispatch(from, to)
 				/*
 				 * byte-swap the delay_time field
 				 */
-				swaps(&(((XTestMotionInfo *) input_action_ptr)->delay_time), n);
+				swaps(&(((XTestMotionInfo *) input_action_ptr)->delay_time));
 				/*
 				 * advance to the next input action
 				 */
@@ -906,15 +874,15 @@ SEventXTestDispatch(from, to)
 				/*
 				 * byte-swap the jumpx field
 				 */
-				swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpx), n);
+				swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpx));
 				/*
 				 * byte-swap the jumpy field
 				 */
-				swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpy), n);
+				swaps(&(((XTestJumpInfo *) input_action_ptr)->jumpy));
 				/*
 				 * byte-swap the delay_time field
 				 */
-				swaps(&(((XTestJumpInfo *) input_action_ptr)->delay_time), n);
+				swaps(&(((XTestJumpInfo *) input_action_ptr)->delay_time));
 				/*
 				 * advance to the next input action
 				 */
@@ -932,7 +900,7 @@ SEventXTestDispatch(from, to)
 					/*
 					 * byte-swap the delay_time field
 					 */
-					swapl(&(((XTestDelayInfo *) input_action_ptr)->delay_time), n);
+					swapl(&(((XTestDelayInfo *) input_action_ptr)->delay_time));
 					/*
 					 * advance to the next input action
 					 */

--- a/nx-X11/programs/Xserver/Xext/xvdisp.c
+++ b/nx-X11/programs/Xserver/Xext/xvdisp.c
@@ -1349,164 +1349,154 @@ ProcXvListImageFormats(ClientPtr client)
 static int
 SProcXvQueryExtension(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryExtensionReq);
   REQUEST_SIZE_MATCH(xvQueryExtensionReq);
-  swaps(&stuff->length, n);
+  swaps(&stuff->length);
   return ProcXvQueryExtension(client);
 }
 
 static int
 SProcXvQueryAdaptors(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryAdaptorsReq);
   REQUEST_SIZE_MATCH(xvQueryAdaptorsReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->window, n);
+  swaps(&stuff->length);
+  swapl(&stuff->window);
   return ProcXvQueryAdaptors(client);
 }
 
 static int
 SProcXvQueryEncodings(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryEncodingsReq);
   REQUEST_SIZE_MATCH(xvQueryEncodingsReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
   return ProcXvQueryEncodings(client);
 }
 
 static int
 SProcXvGrabPort(ClientPtr client)
 {
-  register char n;
   REQUEST(xvGrabPortReq);
   REQUEST_SIZE_MATCH(xvGrabPortReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->time, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->time);
   return ProcXvGrabPort(client);
 }
 
 static int
 SProcXvUngrabPort(ClientPtr client)
 {
-  register char n;
   REQUEST(xvUngrabPortReq);
   REQUEST_SIZE_MATCH(xvUngrabPortReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->time, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->time);
   return ProcXvUngrabPort(client);
 }
 
 static int
 SProcXvPutVideo(ClientPtr client)
 {
-  register char n;
   REQUEST(xvPutVideoReq);
   REQUEST_SIZE_MATCH(xvPutVideoReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swaps(&stuff->vid_x, n);
-  swaps(&stuff->vid_y, n);
-  swaps(&stuff->vid_w, n);
-  swaps(&stuff->vid_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swaps(&stuff->vid_x);
+  swaps(&stuff->vid_y);
+  swaps(&stuff->vid_w);
+  swaps(&stuff->vid_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
   return ProcXvPutVideo(client);
 }
 
 static int
 SProcXvPutStill(ClientPtr client)
 {
-  register char n;
   REQUEST(xvPutStillReq);
   REQUEST_SIZE_MATCH(xvPutStillReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swaps(&stuff->vid_x, n);
-  swaps(&stuff->vid_y, n);
-  swaps(&stuff->vid_w, n);
-  swaps(&stuff->vid_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swaps(&stuff->vid_x);
+  swaps(&stuff->vid_y);
+  swaps(&stuff->vid_w);
+  swaps(&stuff->vid_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
   return ProcXvPutStill(client);
 }
 
 static int
 SProcXvGetVideo(ClientPtr client)
 {
-  register char n;
   REQUEST(xvGetVideoReq);
   REQUEST_SIZE_MATCH(xvGetVideoReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swaps(&stuff->vid_x, n);
-  swaps(&stuff->vid_y, n);
-  swaps(&stuff->vid_w, n);
-  swaps(&stuff->vid_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swaps(&stuff->vid_x);
+  swaps(&stuff->vid_y);
+  swaps(&stuff->vid_w);
+  swaps(&stuff->vid_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
   return ProcXvGetVideo(client);
 }
 
 static int
 SProcXvGetStill(ClientPtr client)
 {
-  register char n;
   REQUEST(xvGetStillReq);
   REQUEST_SIZE_MATCH(xvGetStillReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swaps(&stuff->vid_x, n);
-  swaps(&stuff->vid_y, n);
-  swaps(&stuff->vid_w, n);
-  swaps(&stuff->vid_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swaps(&stuff->vid_x);
+  swaps(&stuff->vid_y);
+  swaps(&stuff->vid_w);
+  swaps(&stuff->vid_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
   return ProcXvGetStill(client);
 }
 
 static int
 SProcXvPutImage(ClientPtr client)
 {
-  register char n;
   REQUEST(xvPutImageReq);
   REQUEST_AT_LEAST_SIZE(xvPutImageReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swapl(&stuff->id, n);
-  swaps(&stuff->src_x, n);
-  swaps(&stuff->src_y, n);
-  swaps(&stuff->src_w, n);
-  swaps(&stuff->src_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
-  swaps(&stuff->width, n);
-  swaps(&stuff->height, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swapl(&stuff->id);
+  swaps(&stuff->src_x);
+  swaps(&stuff->src_y);
+  swaps(&stuff->src_w);
+  swaps(&stuff->src_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
+  swaps(&stuff->width);
+  swaps(&stuff->height);
   return ProcXvPutImage(client);
 }
 
@@ -1514,26 +1504,25 @@ SProcXvPutImage(ClientPtr client)
 static int
 SProcXvShmPutImage(ClientPtr client)
 {
-  register char n;
   REQUEST(xvShmPutImageReq);
   REQUEST_SIZE_MATCH(xvShmPutImageReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
-  swapl(&stuff->gc, n);
-  swapl(&stuff->shmseg, n);
-  swapl(&stuff->id, n);
-  swaps(&stuff->src_x, n);
-  swaps(&stuff->src_y, n);
-  swaps(&stuff->src_w, n);
-  swaps(&stuff->src_h, n);
-  swaps(&stuff->drw_x, n);
-  swaps(&stuff->drw_y, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
-  swaps(&stuff->offset, n);
-  swaps(&stuff->width, n);
-  swaps(&stuff->height, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
+  swapl(&stuff->gc);
+  swapl(&stuff->shmseg);
+  swapl(&stuff->id);
+  swapl(&stuff->offset);
+  swaps(&stuff->src_x);
+  swaps(&stuff->src_y);
+  swaps(&stuff->src_w);
+  swaps(&stuff->src_h);
+  swaps(&stuff->drw_x);
+  swaps(&stuff->drw_y);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
+  swaps(&stuff->width);
+  swaps(&stuff->height);
   return ProcXvShmPutImage(client);
 }
 #endif
@@ -1542,108 +1531,101 @@ SProcXvShmPutImage(ClientPtr client)
 static int
 SProcXvSelectVideoNotify(ClientPtr client)
 {
-  register char n;
   REQUEST(xvSelectVideoNotifyReq);
   REQUEST_SIZE_MATCH(xvSelectVideoNotifyReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->drawable, n);
+  swaps(&stuff->length);
+  swapl(&stuff->drawable);
   return ProcXvSelectVideoNotify(client);
 }
 
 static int
 SProcXvSelectPortNotify(ClientPtr client)
 {
-  register char n;
   REQUEST(xvSelectPortNotifyReq);
   REQUEST_SIZE_MATCH(xvSelectPortNotifyReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
   return ProcXvSelectPortNotify(client);
 }
 
 static int
 SProcXvStopVideo(ClientPtr client)
 {
-  register char n;
   REQUEST(xvStopVideoReq);
   REQUEST_SIZE_MATCH(xvStopVideoReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->drawable, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->drawable);
   return ProcXvStopVideo(client);
 }
 
 static int
 SProcXvSetPortAttribute(ClientPtr client)
 {
-  register char n;
   REQUEST(xvSetPortAttributeReq);
   REQUEST_SIZE_MATCH(xvSetPortAttributeReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->attribute, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->attribute);
+  swapl(&stuff->value);
   return ProcXvSetPortAttribute(client);
 }
 
 static int
 SProcXvGetPortAttribute(ClientPtr client)
 {
-  register char n;
   REQUEST(xvGetPortAttributeReq);
   REQUEST_SIZE_MATCH(xvGetPortAttributeReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swapl(&stuff->attribute, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->attribute);
   return ProcXvGetPortAttribute(client);
 }
 
 static int
 SProcXvQueryBestSize(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryBestSizeReq);
   REQUEST_SIZE_MATCH(xvQueryBestSizeReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
-  swaps(&stuff->vid_w, n);
-  swaps(&stuff->vid_h, n);
-  swaps(&stuff->drw_w, n);
-  swaps(&stuff->drw_h, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swaps(&stuff->vid_w);
+  swaps(&stuff->vid_h);
+  swaps(&stuff->drw_w);
+  swaps(&stuff->drw_h);
   return ProcXvQueryBestSize(client);
 }
 
 static int
 SProcXvQueryPortAttributes(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryPortAttributesReq);
   REQUEST_SIZE_MATCH(xvQueryPortAttributesReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
   return ProcXvQueryPortAttributes(client);
 }
 
 static int
 SProcXvQueryImageAttributes(ClientPtr client)
 {
-  register char n;
   REQUEST(xvQueryImageAttributesReq);
   REQUEST_SIZE_MATCH(xvQueryImageAttributesReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->id, n);
-  swaps(&stuff->width, n);
-  swaps(&stuff->width, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
+  swapl(&stuff->id);
+  swaps(&stuff->width);
+  swaps(&stuff->height);
   return ProcXvQueryImageAttributes(client);
 }
 
 static int
 SProcXvListImageFormats(ClientPtr client)
 {
-  register char n;
   REQUEST(xvListImageFormatsReq);
   REQUEST_SIZE_MATCH(xvListImageFormatsReq);
-  swaps(&stuff->length, n);
-  swapl(&stuff->port, n);
+  swaps(&stuff->length);
+  swapl(&stuff->port);
   return ProcXvListImageFormats(client);
 }
 
@@ -1653,12 +1635,10 @@ SWriteQueryExtensionReply(
    ClientPtr client,
    xvQueryExtensionReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swaps(&rep->version, n);
-  swaps(&rep->revision, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swaps(&rep->version);
+  swaps(&rep->revision);
   
   (void)WriteToClient(client, sz_xvQueryExtensionReply, (char *)&rep);
 
@@ -1670,11 +1650,9 @@ SWriteQueryAdaptorsReply(
    ClientPtr client,
    xvQueryAdaptorsReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swaps(&rep->num_adaptors, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swaps(&rep->num_adaptors);
   
   (void)WriteToClient(client, sz_xvQueryAdaptorsReply, (char *)&rep);
 
@@ -1686,11 +1664,9 @@ SWriteQueryEncodingsReply(
    ClientPtr client,
    xvQueryEncodingsReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swaps(&rep->num_encodings, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swaps(&rep->num_encodings);
   
   (void)WriteToClient(client, sz_xvQueryEncodingsReply, (char *)&rep);
 
@@ -1702,12 +1678,10 @@ SWriteAdaptorInfo(
    ClientPtr client,
    xvAdaptorInfo *pAdaptor
 ){
-  register char n;
-
-  swapl(&pAdaptor->base_id, n);
-  swaps(&pAdaptor->name_size, n);
-  swaps(&pAdaptor->num_ports, n);
-  swaps(&pAdaptor->num_formats, n);
+  swapl(&pAdaptor->base_id);
+  swaps(&pAdaptor->name_size);
+  swaps(&pAdaptor->num_ports);
+  swaps(&pAdaptor->num_formats);
 
   (void)WriteToClient(client, sz_xvAdaptorInfo, (char *)pAdaptor);
 
@@ -1719,14 +1693,12 @@ SWriteEncodingInfo(
    ClientPtr client,
    xvEncodingInfo *pEncoding
 ){
-  register char n;
-  
-  swapl(&pEncoding->encoding, n);
-  swaps(&pEncoding->name_size, n);
-  swaps(&pEncoding->width, n);
-  swaps(&pEncoding->height, n);
-  swapl(&pEncoding->rate.numerator, n);
-  swapl(&pEncoding->rate.denominator, n);
+  swapl(&pEncoding->encoding);
+  swaps(&pEncoding->name_size);
+  swaps(&pEncoding->width);
+  swaps(&pEncoding->height);
+  swapl(&pEncoding->rate.numerator);
+  swapl(&pEncoding->rate.denominator);
   (void)WriteToClient(client, sz_xvEncodingInfo, (char *)pEncoding);
 
   return Success;
@@ -1737,9 +1709,7 @@ SWriteFormat(
    ClientPtr client,
    xvFormat *pFormat
 ){
-  register char n;
-
-  swapl(&pFormat->visual, n);
+  swapl(&pFormat->visual);
   (void)WriteToClient(client, sz_xvFormat, (char *)pFormat);
 
   return Success;
@@ -1750,12 +1720,10 @@ SWriteAttributeInfo(
    ClientPtr client,
    xvAttributeInfo *pAtt
 ){
-  register char n;
-
-  swapl(&pAtt->flags, n);
-  swapl(&pAtt->size, n);
-  swapl(&pAtt->min, n);
-  swapl(&pAtt->max, n);
+  swapl(&pAtt->flags);
+  swapl(&pAtt->size);
+  swapl(&pAtt->min);
+  swapl(&pAtt->max);
   (void)WriteToClient(client, sz_xvAttributeInfo, (char *)pAtt);
 
   return Success;
@@ -1766,21 +1734,19 @@ SWriteImageFormatInfo(
    ClientPtr client,
    xvImageFormatInfo *pImage
 ){
-  register char n;
-
-  swapl(&pImage->id, n);
-  swapl(&pImage->red_mask, n);
-  swapl(&pImage->green_mask, n);
-  swapl(&pImage->blue_mask, n);
-  swapl(&pImage->y_sample_bits, n);
-  swapl(&pImage->u_sample_bits, n);
-  swapl(&pImage->v_sample_bits, n);
-  swapl(&pImage->horz_y_period, n);
-  swapl(&pImage->horz_u_period, n);
-  swapl(&pImage->horz_v_period, n);
-  swapl(&pImage->vert_y_period, n);
-  swapl(&pImage->vert_u_period, n);
-  swapl(&pImage->vert_v_period, n);
+  swapl(&pImage->id);
+  swapl(&pImage->red_mask);
+  swapl(&pImage->green_mask);
+  swapl(&pImage->blue_mask);
+  swapl(&pImage->y_sample_bits);
+  swapl(&pImage->u_sample_bits);
+  swapl(&pImage->v_sample_bits);
+  swapl(&pImage->horz_y_period);
+  swapl(&pImage->horz_u_period);
+  swapl(&pImage->horz_v_period);
+  swapl(&pImage->vert_y_period);
+  swapl(&pImage->vert_u_period);
+  swapl(&pImage->vert_v_period);
 
   (void)WriteToClient(client, sz_xvImageFormatInfo, (char *)pImage);
 
@@ -1794,10 +1760,8 @@ SWriteGrabPortReply(
    ClientPtr client,
    xvGrabPortReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
 
   (void)WriteToClient(client, sz_xvGrabPortReply, (char *)&rep);
 
@@ -1809,11 +1773,9 @@ SWriteGetPortAttributeReply(
    ClientPtr client,
    xvGetPortAttributeReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swapl(&rep->value, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swapl(&rep->value);
 
   (void)WriteToClient(client, sz_xvGetPortAttributeReply, (char *)&rep);
 
@@ -1825,12 +1787,10 @@ SWriteQueryBestSizeReply(
    ClientPtr client,
    xvQueryBestSizeReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swaps(&rep->actual_width, n);
-  swaps(&rep->actual_height, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swaps(&rep->actual_width);
+  swaps(&rep->actual_height);
 
   (void)WriteToClient(client, sz_xvQueryBestSizeReply, (char *)&rep);
 
@@ -1842,12 +1802,10 @@ SWriteQueryPortAttributesReply(
    ClientPtr client,
    xvQueryPortAttributesReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swapl(&rep->num_attributes, n);
-  swapl(&rep->text_size, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swapl(&rep->num_attributes);
+  swapl(&rep->text_size);
 
   (void)WriteToClient(client, sz_xvQueryPortAttributesReply, (char *)&rep);
 
@@ -1859,14 +1817,12 @@ SWriteQueryImageAttributesReply(
    ClientPtr client,
    xvQueryImageAttributesReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swapl(&rep->num_planes, n);
-  swapl(&rep->data_size, n);
-  swaps(&rep->width, n);
-  swaps(&rep->height, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swapl(&rep->num_planes);
+  swapl(&rep->data_size);
+  swaps(&rep->width);
+  swaps(&rep->height);
 
   (void)WriteToClient(client, sz_xvQueryImageAttributesReply, (char *)&rep);
 
@@ -1879,11 +1835,9 @@ SWriteListImageFormatsReply(
    ClientPtr client,
    xvListImageFormatsReply *rep
 ){
-  register char n;
-
-  swaps(&rep->sequenceNumber, n);
-  swapl(&rep->length, n);
-  swapl(&rep->num_formats, n);
+  swaps(&rep->sequenceNumber);
+  swapl(&rep->length);
+  swapl(&rep->num_formats);
 
   (void)WriteToClient(client, sz_xvListImageFormatsReply, (char *)&rep);
 

--- a/nx-X11/programs/Xserver/Xi/allowev.c
+++ b/nx-X11/programs/Xserver/Xi/allowev.c
@@ -82,12 +82,10 @@ int
 SProcXAllowDeviceEvents(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xAllowDeviceEventsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xAllowDeviceEventsReq);
-    swapl(&stuff->time, n);
+    swapl(&stuff->time);
     return(ProcXAllowDeviceEvents(client));
     }
 

--- a/nx-X11/programs/Xserver/Xi/chgdctl.c
+++ b/nx-X11/programs/Xserver/Xi/chgdctl.c
@@ -83,12 +83,10 @@ int
 SProcXChangeDeviceControl(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xChangeDeviceControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_EXTRA_SIZE(xChangeDeviceControlReq, sizeof(xDeviceCtl));
-    swaps(&stuff->control, n);
+    swaps(&stuff->control);
     return(ProcXChangeDeviceControl(client));
     }
 
@@ -210,10 +208,8 @@ SRepXChangeDeviceControl (client, size, rep)
     int		size;
     xChangeDeviceControlReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/chgfctl.c
+++ b/nx-X11/programs/Xserver/Xi/chgfctl.c
@@ -84,12 +84,10 @@ int
 SProcXChangeFeedbackControl(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xChangeFeedbackControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeFeedbackControlReq);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->mask);
     return(ProcXChangeFeedbackControl(client));
     }
 
@@ -156,13 +154,12 @@ ProcXChangeFeedbackControl(client)
 	    break;
 	case StringFeedbackClass:
 	    {
-	    register char n;
 	    xStringFeedbackCtl *f = ((xStringFeedbackCtl *) &stuff[1]);
 	    if (client->swapped)
 		{
 		if (len < (sizeof(xStringFeedbackCtl) + 3) >> 2)
 		    return BadLength;
-		swaps(&f->num_keysyms,n);
+		swaps(&f->num_keysyms);
 		}
 	    if (len != ((sizeof(xStringFeedbackCtl)>>2) + f->num_keysyms))
 		{
@@ -242,18 +239,17 @@ ChangeKbdFeedback (client, dev, mask, k, f)
     KbdFeedbackPtr	k;
     xKbdFeedbackCtl 	*f;
     {
-    register char n;
     KeybdCtrl kctrl;
     int t;
     int key = DO_ALL;
 
     if (client->swapped)
 	{
-	swaps(&f->length,n);
-	swaps(&f->pitch,n);
-	swaps(&f->duration,n);
-	swapl(&f->led_mask,n);
-	swapl(&f->led_values,n);
+	swaps(&f->length);
+	swaps(&f->pitch);
+	swaps(&f->duration);
+	swapl(&f->led_mask);
+	swapl(&f->led_values);
 	}
 
     kctrl = k->ctrl;
@@ -398,15 +394,14 @@ ChangePtrFeedback (client, dev, mask, p, f)
     PtrFeedbackPtr 	p;
     xPtrFeedbackCtl 	*f;
     {
-    register char n;
     PtrCtrl pctrl;		/* might get BadValue part way through */
 
     if (client->swapped)
 	{
-	swaps(&f->length,n);
-	swaps(&f->num,n);
-	swaps(&f->denom,n);
-	swaps(&f->thresh,n);
+	swaps(&f->length);
+	swaps(&f->num);
+	swaps(&f->denom);
+	swaps(&f->thresh);
 	}
 
     pctrl = p->ctrl;
@@ -480,12 +475,10 @@ ChangeIntegerFeedback (client, dev, mask, i, f)
     IntegerFeedbackPtr 		i;
     xIntegerFeedbackCtl 	*f;
     {
-    register char n;
-
     if (client->swapped)
 	{
-	swaps(&f->length,n);
-	swapl(&f->int_to_display,n);
+	swaps(&f->length);
+	swapl(&f->int_to_display);
 	}
 
     i->ctrl.integer_displayed = f->int_to_display;
@@ -507,14 +500,13 @@ ChangeStringFeedback (client, dev, mask, s, f)
     StringFeedbackPtr 	s;
     xStringFeedbackCtl 	*f;
     {
-    register char n;
     int		i, j;
     KeySym	*syms, *sup_syms;
 
     syms = (KeySym *) (f+1);
     if (client->swapped)
 	{
-	swaps(&f->length,n);	/* swapped num_keysyms in calling proc */
+	swaps(&f->length);	/* swapped num_keysyms in calling proc */
 	SwapLongs((CARD32 *) syms, f->num_keysyms);
 	}
 
@@ -559,15 +551,14 @@ ChangeBellFeedback (client, dev, mask, b, f)
     BellFeedbackPtr 	b;
     xBellFeedbackCtl 	*f;
     {
-    register char n;
     int t;
     BellCtrl bctrl;		/* might get BadValue part way through */
 
     if (client->swapped)
 	{
-	swaps(&f->length,n);
-	swaps(&f->pitch,n);
-	swaps(&f->duration,n);
+	swaps(&f->length);
+	swaps(&f->pitch);
+	swaps(&f->duration);
 	}
 
     bctrl = b->ctrl;
@@ -634,14 +625,13 @@ ChangeLedFeedback (client, dev, mask, l, f)
     LedFeedbackPtr 	l;
     xLedFeedbackCtl 	*f;
     {
-    register char n;
     LedCtrl lctrl;		/* might get BadValue part way through */
 
     if (client->swapped)
 	{
-	swaps(&f->length,n);
-	swapl(&f->led_values,n);
-	swapl(&f->led_mask,n);
+	swaps(&f->length);
+	swapl(&f->led_values);
+	swapl(&f->led_mask);
 	}
 
     f->led_mask &= l->ctrl.led_mask;	/* set only supported leds */

--- a/nx-X11/programs/Xserver/Xi/chgkbd.c
+++ b/nx-X11/programs/Xserver/Xi/chgkbd.c
@@ -85,10 +85,8 @@ int
 SProcXChangeKeyboardDevice(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xChangeKeyboardDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xChangeKeyboardDeviceReq);
     return(ProcXChangeKeyboardDevice(client));
     }
@@ -208,9 +206,7 @@ SRepXChangeKeyboardDevice (client, size, rep)
     int		size;
     xChangeKeyboardDeviceReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/chgkmap.c
+++ b/nx-X11/programs/Xserver/Xi/chgkmap.c
@@ -82,11 +82,10 @@ int
 SProcXChangeDeviceKeyMapping(client)
     register ClientPtr client;
     {
-    register char n;
     unsigned int count;
 
     REQUEST(xChangeDeviceKeyMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeDeviceKeyMappingReq);
     count = stuff->keyCodes * stuff->keySymsPerKeyCode;
     REQUEST_FIXED_SIZE(xChangeDeviceKeyMappingReq, count * sizeof(CARD32));

--- a/nx-X11/programs/Xserver/Xi/chgprop.c
+++ b/nx-X11/programs/Xserver/Xi/chgprop.c
@@ -84,13 +84,11 @@ int
 SProcXChangeDeviceDontPropagateList(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xChangeDeviceDontPropagateListReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeDeviceDontPropagateListReq);
-    swapl(&stuff->window, n);
-    swaps(&stuff->count, n);
+    swapl(&stuff->window);
+    swaps(&stuff->count);
     REQUEST_FIXED_SIZE(xChangeDeviceDontPropagateListReq,
                       stuff->count * sizeof(CARD32));
     SwapLongs((CARD32 *) (&stuff[1]), stuff->count);

--- a/nx-X11/programs/Xserver/Xi/chgptr.c
+++ b/nx-X11/programs/Xserver/Xi/chgptr.c
@@ -88,10 +88,8 @@ int
 SProcXChangePointerDevice(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xChangePointerDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xChangePointerDeviceReq);
     return(ProcXChangePointerDevice(client));
     }
@@ -254,9 +252,7 @@ SRepXChangePointerDevice (client, size, rep)
     int		size;
     xChangePointerDeviceReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/closedev.c
+++ b/nx-X11/programs/Xserver/Xi/closedev.c
@@ -83,10 +83,8 @@ int
 SProcXCloseDevice(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xCloseDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCloseDeviceReq);
     return(ProcXCloseDevice(client));
     }

--- a/nx-X11/programs/Xserver/Xi/devbell.c
+++ b/nx-X11/programs/Xserver/Xi/devbell.c
@@ -81,10 +81,8 @@ int
 SProcXDeviceBell(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xDeviceBellReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXDeviceBell(client));
     }
 

--- a/nx-X11/programs/Xserver/Xi/extinit.c
+++ b/nx-X11/programs/Xserver/Xi/extinit.c
@@ -586,17 +586,16 @@ SEventDeviceValuator (from, to)
     deviceValuator	*from;
     deviceValuator	*to;
     {
-    register char	n;
     register int	i;
     INT32 *ip B32;
 
     *to = *from;
-    swaps(&to->sequenceNumber,n);
-    swaps(&to->device_state,n);
+    swaps(&to->sequenceNumber);
+    swaps(&to->device_state);
     ip = &to->valuator0;
     for (i=0; i<6; i++)
 	{
-        swapl((ip+i),n);	/* macro - braces are required	    */
+        swapl((ip+i));	/* macro - braces are required	    */
 	}
     }
 
@@ -605,12 +604,10 @@ SEventFocus (from, to)
     deviceFocus	*from;
     deviceFocus	*to;
 {
-    register char	n;
-
     *to = *from;
-    swaps(&to->sequenceNumber,n);
-    swapl(&to->time, n);
-    swapl(&to->window, n);
+    swaps(&to->sequenceNumber);
+    swapl(&to->time);
+    swapl(&to->window);
     }
 
 void
@@ -619,16 +616,15 @@ SDeviceStateNotifyEvent (from, to)
     deviceStateNotify	*to;
 {
     register int	i;
-    register char	n;
     INT32 *ip B32;
 
     *to = *from;
-    swaps(&to->sequenceNumber,n);
-    swapl(&to->time, n);
+    swaps(&to->sequenceNumber);
+    swapl(&to->time);
     ip = &to->valuator0;
     for (i=0; i<3; i++)
 	{
-        swapl((ip+i),n);	/* macro - braces are required	    */
+        swapl((ip+i));	/* macro - braces are required	    */
 	}
     }
 
@@ -637,10 +633,8 @@ SDeviceKeyStateNotifyEvent (from, to)
     deviceKeyStateNotify	*from;
     deviceKeyStateNotify	*to;
 {
-    register char	n;
-
     *to = *from;
-    swaps(&to->sequenceNumber,n);
+    swaps(&to->sequenceNumber);
     }
 
 void
@@ -648,10 +642,8 @@ SDeviceButtonStateNotifyEvent (from, to)
     deviceButtonStateNotify	*from;
     deviceButtonStateNotify	*to;
 {
-    register char	n;
-
     *to = *from;
-    swaps(&to->sequenceNumber,n);
+    swaps(&to->sequenceNumber);
     }
 
 void
@@ -659,11 +651,9 @@ SChangeDeviceNotifyEvent (from, to)
     changeDeviceNotify	*from;
     changeDeviceNotify	*to;
 {
-    register char	n;
-
     *to = *from;
-    swaps(&to->sequenceNumber,n);
-    swapl(&to->time, n);
+    swaps(&to->sequenceNumber);
+    swapl(&to->time);
     }
 
 void
@@ -671,11 +661,9 @@ SDeviceMappingNotifyEvent (from, to)
     deviceMappingNotify	*from;
     deviceMappingNotify	*to;
 {
-    register char	n;
-
     *to = *from;
-    swaps(&to->sequenceNumber,n);
-    swapl(&to->time, n);
+    swaps(&to->sequenceNumber);
+    swapl(&to->time);
     }
 
 /************************************************************************

--- a/nx-X11/programs/Xserver/Xi/getbmap.c
+++ b/nx-X11/programs/Xserver/Xi/getbmap.c
@@ -80,10 +80,8 @@ int
 SProcXGetDeviceButtonMapping(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceButtonMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXGetDeviceButtonMapping(client));
     }
 
@@ -146,9 +144,7 @@ SRepXGetDeviceButtonMapping (client, size, rep)
     int		size;
     xGetDeviceButtonMappingReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getdctl.c
+++ b/nx-X11/programs/Xserver/Xi/getdctl.c
@@ -81,12 +81,10 @@ int
 SProcXGetDeviceControl(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetDeviceControlReq);
-    swaps(&stuff->control, n);
+    swaps(&stuff->control);
     return(ProcXGetDeviceControl(client));
     }
 
@@ -178,7 +176,6 @@ CopySwapDeviceResolution (client, v, buf, length)
     char 		*buf;
     int			length;
     {
-    register char 	n;
     AxisInfoPtr	a;
     xDeviceResolutionState *r;
     int i, *iptr;
@@ -197,13 +194,13 @@ CopySwapDeviceResolution (client, v, buf, length)
 	*iptr++ = a->max_resolution;
     if (client->swapped)
 	{
-	swaps (&r->control,n);
-	swaps (&r->length,n);
-	swapl (&r->num_valuators,n);
+	swaps (&r->control);
+	swaps (&r->length);
+	swapl (&r->num_valuators);
 	iptr = (int *) buf;
 	for (i=0; i < (3 * v->numAxes); i++,iptr++)
 	    {
-	    swapl (iptr,n);
+	    swapl (iptr);
 	    }
 	}
     }
@@ -221,10 +218,8 @@ SRepXGetDeviceControl (client, size, rep)
     int		size;
     xGetDeviceControlReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/getfctl.c
+++ b/nx-X11/programs/Xserver/Xi/getfctl.c
@@ -81,10 +81,8 @@ int
 SProcXGetFeedbackControl(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetFeedbackControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXGetFeedbackControl(client));
     }
 
@@ -207,7 +205,6 @@ CopySwapKbdFeedback (client, k, buf)
     char 		**buf;
     {
     int	i;
-    register char 	n;
     xKbdFeedbackState	*k2;
 
     k2 = (xKbdFeedbackState *) *buf;
@@ -224,11 +221,11 @@ CopySwapKbdFeedback (client, k, buf)
 	k2->auto_repeats[i] = k->ctrl.autoRepeats[i];
     if (client->swapped)
 	{
-	swaps(&k2->length,n);
-	swaps(&k2->pitch,n);
-	swaps(&k2->duration,n);
-	swapl(&k2->led_mask,n);
-	swapl(&k2->led_values,n);
+	swaps(&k2->length);
+	swaps(&k2->pitch);
+	swaps(&k2->duration);
+	swapl(&k2->led_mask);
+	swapl(&k2->led_values);
 	}
     *buf += sizeof (xKbdFeedbackState);
     }
@@ -245,7 +242,6 @@ CopySwapPtrFeedback (client, p, buf)
     PtrFeedbackPtr 	p;
     char 		**buf;
     {
-    register char 	n;
     xPtrFeedbackState	*p2;
 
     p2 = (xPtrFeedbackState *) *buf;
@@ -257,10 +253,10 @@ CopySwapPtrFeedback (client, p, buf)
     p2->threshold = p->ctrl.threshold;
     if (client->swapped)
 	{
-	swaps(&p2->length,n);
-	swaps(&p2->accelNum,n);
-	swaps(&p2->accelDenom,n);
-	swaps(&p2->threshold,n);
+	swaps(&p2->length);
+	swaps(&p2->accelNum);
+	swaps(&p2->accelDenom);
+	swaps(&p2->threshold);
 	}
     *buf += sizeof (xPtrFeedbackState);
     }
@@ -277,7 +273,6 @@ CopySwapIntegerFeedback (client, i, buf)
     IntegerFeedbackPtr 	i;
     char 		**buf;
     {
-    register char 		n;
     xIntegerFeedbackState	*i2;
 
     i2 = (xIntegerFeedbackState *) *buf;
@@ -289,10 +284,10 @@ CopySwapIntegerFeedback (client, i, buf)
     i2->max_value = i->ctrl.max_value;
     if (client->swapped)
 	{
-	swaps(&i2->length,n);
-	swapl(&i2->resolution,n);
-	swapl(&i2->min_value,n);
-	swapl(&i2->max_value,n);
+	swaps(&i2->length);
+	swapl(&i2->resolution);
+	swapl(&i2->min_value);
+	swapl(&i2->max_value);
 	}
     *buf += sizeof (xIntegerFeedbackState);
     }
@@ -310,7 +305,6 @@ CopySwapStringFeedback (client, s, buf)
     char 		**buf;
     {
     int i;
-    register char 		n;
     xStringFeedbackState	*s2;
     KeySym			*kptr;
 
@@ -327,13 +321,13 @@ CopySwapStringFeedback (client, s, buf)
 	*kptr++ = *(s->ctrl.symbols_supported+i);
     if (client->swapped)
 	{
-	swaps(&s2->length,n);
-	swaps(&s2->max_symbols,n);
-	swaps(&s2->num_syms_supported,n);
+	swaps(&s2->length);
+	swaps(&s2->max_symbols);
+	swaps(&s2->num_syms_supported);
         kptr = (KeySym *) (*buf);
 	for (i=0; i<s->ctrl.num_symbols_supported; i++,kptr++)
 	    {
-	    swapl(kptr,n);
+	    swapl(kptr);
 	    }
 	}
     *buf += (s->ctrl.num_symbols_supported * sizeof (KeySym));
@@ -351,7 +345,6 @@ CopySwapLedFeedback (client, l, buf)
     LedFeedbackPtr 	l;
     char 		**buf;
     {
-    register char 	n;
     xLedFeedbackState	*l2;
 
     l2 = (xLedFeedbackState *) *buf;
@@ -362,9 +355,9 @@ CopySwapLedFeedback (client, l, buf)
     l2->led_mask = l->ctrl.led_mask;
     if (client->swapped)
 	{
-	swaps(&l2->length,n);
-	swapl(&l2->led_values,n);
-	swapl(&l2->led_mask,n);
+	swaps(&l2->length);
+	swapl(&l2->led_values);
+	swapl(&l2->led_mask);
 	}
     *buf += sizeof (xLedFeedbackState);
     }
@@ -381,7 +374,6 @@ CopySwapBellFeedback (client, b, buf)
     BellFeedbackPtr 	b;
     char 		**buf;
     {
-    register char 	n;
     xBellFeedbackState	*b2;
 
     b2 = (xBellFeedbackState *) *buf;
@@ -393,9 +385,9 @@ CopySwapBellFeedback (client, b, buf)
     b2->duration = b->ctrl.duration;
     if (client->swapped)
 	{
-	swaps(&b2->length,n);
-	swaps(&b2->pitch,n);
-	swaps(&b2->duration,n);
+	swaps(&b2->length);
+	swaps(&b2->pitch);
+	swaps(&b2->duration);
 	}
     *buf += sizeof (xBellFeedbackState);
     }
@@ -413,10 +405,8 @@ SRepXGetFeedbackControl (client, size, rep)
     int		size;
     xGetFeedbackControlReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swaps(&rep->num_feedbacks, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swaps(&rep->num_feedbacks);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getfocus.c
+++ b/nx-X11/programs/Xserver/Xi/getfocus.c
@@ -81,10 +81,8 @@ int
 SProcXGetDeviceFocus(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceFocusReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXGetDeviceFocus(client));
     }
 
@@ -147,11 +145,9 @@ SRepXGetDeviceFocus (client, size, rep)
     int		size;
     xGetDeviceFocusReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swapl(&rep->focus, n);
-    swapl(&rep->time, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swapl(&rep->focus);
+    swapl(&rep->time);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getkmap.c
+++ b/nx-X11/programs/Xserver/Xi/getkmap.c
@@ -82,10 +82,8 @@ int
 SProcXGetDeviceKeyMapping(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceKeyMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXGetDeviceKeyMapping(client));
     }
 
@@ -169,10 +167,8 @@ SRepXGetDeviceKeyMapping (client, size, rep)
     int		size;
     xGetDeviceKeyMappingReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/getmmap.c
+++ b/nx-X11/programs/Xserver/Xi/getmmap.c
@@ -81,10 +81,8 @@ int
 SProcXGetDeviceModifierMapping(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceModifierMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXGetDeviceModifierMapping(client));
     }
 
@@ -150,9 +148,7 @@ SRepXGetDeviceModifierMapping (client, size, rep)
     int		size;
     xGetDeviceModifierMappingReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getprop.c
+++ b/nx-X11/programs/Xserver/Xi/getprop.c
@@ -85,12 +85,10 @@ int
 SProcXGetDeviceDontPropagateList(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceDontPropagateListReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetDeviceDontPropagateListReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return(ProcXGetDeviceDontPropagateList(client));
     }
 
@@ -206,10 +204,8 @@ SRepXGetDeviceDontPropagateList (client, size, rep)
     int		size;
     xGetDeviceDontPropagateListReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swaps(&rep->count, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swaps(&rep->count);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getselev.c
+++ b/nx-X11/programs/Xserver/Xi/getselev.c
@@ -83,12 +83,10 @@ int
 SProcXGetSelectedExtensionEvents(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetSelectedExtensionEventsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetSelectedExtensionEventsReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return(ProcXGetSelectedExtensionEvents(client));
     }
 
@@ -186,11 +184,9 @@ SRepXGetSelectedExtensionEvents (client, size, rep)
     int		size;
     xGetSelectedExtensionEventsReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swaps(&rep->this_client_count, n);
-    swaps(&rep->all_clients_count, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swaps(&rep->this_client_count);
+    swaps(&rep->all_clients_count);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getvers.c
+++ b/nx-X11/programs/Xserver/Xi/getvers.c
@@ -82,12 +82,10 @@ int
 SProcXGetExtensionVersion(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetExtensionVersionReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xGetExtensionVersionReq);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->nbytes);
     return(ProcXGetExtensionVersion(client));
     }
 
@@ -148,11 +146,9 @@ SRepXGetExtensionVersion (client, size, rep)
     int		size;
     xGetExtensionVersionReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swaps(&rep->major_version, n);
-    swaps(&rep->minor_version, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swaps(&rep->major_version);
+    swaps(&rep->minor_version);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/grabdev.c
+++ b/nx-X11/programs/Xserver/Xi/grabdev.c
@@ -86,14 +86,12 @@ int
 SProcXGrabDevice(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGrabDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xGrabDeviceReq);
-    swapl(&stuff->grabWindow, n);
-    swapl(&stuff->time, n);
-    swaps(&stuff->event_count, n);
+    swapl(&stuff->grabWindow);
+    swapl(&stuff->time);
+    swaps(&stuff->event_count);
 
     if (stuff->length != (sizeof(xGrabDeviceReq) >> 2) + stuff->event_count)
        return BadLength;
@@ -221,9 +219,7 @@ SRepXGrabDevice (client, size, rep)
     int		size;
     xGrabDeviceReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/grabdevb.c
+++ b/nx-X11/programs/Xserver/Xi/grabdevb.c
@@ -83,14 +83,12 @@ int
 SProcXGrabDeviceButton(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGrabDeviceButtonReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xGrabDeviceButtonReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
-    swaps(&stuff->event_count, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
+    swaps(&stuff->event_count);
     REQUEST_FIXED_SIZE(xGrabDeviceButtonReq,
                       stuff->event_count * sizeof(CARD32));
     SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);

--- a/nx-X11/programs/Xserver/Xi/grabdevk.c
+++ b/nx-X11/programs/Xserver/Xi/grabdevk.c
@@ -83,14 +83,12 @@ int
 SProcXGrabDeviceKey(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGrabDeviceKeyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xGrabDeviceKeyReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
-    swaps(&stuff->event_count, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
+    swaps(&stuff->event_count);
     REQUEST_FIXED_SIZE(xGrabDeviceKeyReq, stuff->event_count * sizeof(CARD32));
     SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
     return(ProcXGrabDeviceKey(client));

--- a/nx-X11/programs/Xserver/Xi/gtmotion.c
+++ b/nx-X11/programs/Xserver/Xi/gtmotion.c
@@ -81,13 +81,11 @@ int
 SProcXGetDeviceMotionEvents(client)
 register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xGetDeviceMotionEventsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetDeviceMotionEventsReq);
-    swapl(&stuff->start, n);
-    swapl(&stuff->stop, n);
+    swapl(&stuff->start);
+    swapl(&stuff->stop);
     return(ProcXGetDeviceMotionEvents(client));
     }
 
@@ -175,12 +173,10 @@ ProcXGetDeviceMotionEvents(client)
         {
 	if (client->swapped)
 	    {
-    	    register 	char n;
-
 	    bufptr = coords;
 	    for (i=0; i<nEvents * (axes+1); i++)
 		{
-    		swapl(bufptr, n);
+		swapl(bufptr);
 		bufptr++;
 		}
 	    }
@@ -204,10 +200,8 @@ SRepXGetDeviceMotionEvents (client, size, rep)
     int		size;
     xGetDeviceMotionEventsReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
-    swapl(&rep->nEvents, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
+    swapl(&rep->nEvents);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/listdev.c
+++ b/nx-X11/programs/Xserver/Xi/listdev.c
@@ -83,10 +83,8 @@ int
 SProcXListInputDevices(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xListInputDevicesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXListInputDevices(client));
     }
 
@@ -254,7 +252,6 @@ CopySwapDevice (client, d, num_classes, buf)
     int			num_classes;
     char 		**buf;
     {
-    register char 	n;
     xDeviceInfoPtr dev;
 
     dev = (xDeviceInfoPtr) *buf;
@@ -270,7 +267,7 @@ CopySwapDevice (client, d, num_classes, buf)
 	dev->use = IsXExtensionDevice;
     if (client->swapped)
 	{
-	swapl(&dev->type, n);	/* macro - braces are required */
+	swapl(&dev->type);	/* macro - braces are required */
 	}
     *buf += sizeof (xDeviceInfo);
     }
@@ -287,7 +284,6 @@ CopySwapKeyClass (client, k, buf)
     KeyClassPtr 	k;
     char 		**buf;
     {
-    register char 	n;
     xKeyInfoPtr 	k2;
 
     k2 = (xKeyInfoPtr) *buf;
@@ -298,7 +294,7 @@ CopySwapKeyClass (client, k, buf)
     k2->num_keys = k2->max_keycode - k2->min_keycode + 1;
     if (client->swapped)
 	{
-	swaps(&k2->num_keys,n);
+	swaps(&k2->num_keys);
 	}
     *buf += sizeof (xKeyInfo);
     }
@@ -315,7 +311,6 @@ CopySwapButtonClass (client, b, buf)
     ButtonClassPtr 	b;
     char 		**buf;
     {
-    register char 	n;
     xButtonInfoPtr 	b2;
 
     b2 = (xButtonInfoPtr) *buf;
@@ -324,7 +319,7 @@ CopySwapButtonClass (client, b, buf)
     b2->num_buttons = b->numButtons;
     if (client->swapped)
 	{
-	swaps(&b2->num_buttons,n);	/* macro - braces are required */
+	swaps(&b2->num_buttons);	/* macro - braces are required */
 	}
     *buf += sizeof (xButtonInfo);
     }
@@ -348,7 +343,6 @@ CopySwapValuatorClass (client, v, buf)
     char 		**buf;
 {
     int			i, j, axes, t_axes;
-    register char 	n;
     xValuatorInfoPtr 	v2;
     AxisInfo 		*a;
     xAxisInfoPtr 	a2;
@@ -365,7 +359,7 @@ CopySwapValuatorClass (client, v, buf)
 	v2->motion_buffer_size  = v->numMotionEvents;
 	if (client->swapped)
 	    {
-	    swapl(&v2->motion_buffer_size,n);
+	    swapl(&v2->motion_buffer_size);
 	    }
 	*buf += sizeof (xValuatorInfo);
 	a = v->axes + (VPC * i);
@@ -375,9 +369,9 @@ CopySwapValuatorClass (client, v, buf)
 	    a2->max_value = a->max_value;
 	    a2->resolution = a->resolution;
 	    if (client->swapped) {
-		swapl(&a2->min_value,n);
-		swapl(&a2->max_value,n);
-		swapl(&a2->resolution,n);
+		swapl(&a2->min_value);
+		swapl(&a2->max_value);
+		swapl(&a2->resolution);
 	    }
 	    a2++;
 	    a++;
@@ -400,9 +394,7 @@ SRepXListInputDevices (client, size, rep)
     int		size;
     xListInputDevicesReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/opendev.c
+++ b/nx-X11/programs/Xserver/Xi/opendev.c
@@ -85,10 +85,8 @@ int
 SProcXOpenDevice(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xOpenDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXOpenDevice(client));
     }
 
@@ -198,9 +196,7 @@ SRepXOpenDevice (client, size, rep)
     int		size;
     xOpenDeviceReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/queryst.c
+++ b/nx-X11/programs/Xserver/Xi/queryst.c
@@ -63,10 +63,8 @@ int
 SProcXQueryDeviceState(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xQueryDeviceStateReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXQueryDeviceState(client));
     }
 
@@ -80,7 +78,6 @@ int
 ProcXQueryDeviceState(client)
     register ClientPtr client;
     {
-    register char 		n;
     int 			i;
     int 			num_classes = 0;
     int 			total_length = 0;
@@ -179,7 +176,7 @@ ProcXQueryDeviceState(client)
 	    *((int *) buf) = *values++;
 	    if (client->swapped)
 		{
-		swapl ((int *) buf, n);/* macro - braces needed */
+		swapl ((int *) buf);/* macro - braces needed */
 		}
 	    buf += sizeof(int);
 	    }
@@ -207,9 +204,7 @@ SRepXQueryDeviceState (client, size, rep)
     int		size;
     xQueryDeviceStateReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/selectev.c
+++ b/nx-X11/programs/Xserver/Xi/selectev.c
@@ -87,13 +87,11 @@ int
 SProcXSelectExtensionEvent (client)
 register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSelectExtensionEventReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSelectExtensionEventReq);
-    swapl(&stuff->window, n);
-    swaps(&stuff->count, n);
+    swapl(&stuff->window);
+    swaps(&stuff->count);
     REQUEST_FIXED_SIZE(xSelectExtensionEventReq,
                       stuff->count * sizeof(CARD32));
     SwapLongs((CARD32 *) (&stuff[1]), stuff->count);

--- a/nx-X11/programs/Xserver/Xi/sendexev.c
+++ b/nx-X11/programs/Xserver/Xi/sendexev.c
@@ -86,7 +86,6 @@ int
 SProcXSendExtensionEvent(client)
     register ClientPtr client;
     {
-    register char n;
     CARD32 *p;
     register int i;
     xEvent eventT;
@@ -94,10 +93,10 @@ SProcXSendExtensionEvent(client)
     EventSwapPtr proc;
 
     REQUEST(xSendExtensionEventReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSendExtensionEventReq);
-    swapl(&stuff->destination, n);
-    swaps(&stuff->count, n);
+    swapl(&stuff->destination);
+    swaps(&stuff->count);
 
     if (stuff->length != (sizeof(xSendExtensionEventReq) >> 2) + stuff->count +
        (stuff->num_events * (sizeof(xEvent) >> 2)))
@@ -153,6 +152,8 @@ ProcXSendExtensionEvent (client)
 		BadDevice);
 	return Success;
 	}
+
+    // FIXME: ret is not initialized and should not be returned...
 
     if (stuff->num_events == 0)
         return ret;

--- a/nx-X11/programs/Xserver/Xi/setbmap.c
+++ b/nx-X11/programs/Xserver/Xi/setbmap.c
@@ -84,10 +84,8 @@ int
 SProcXSetDeviceButtonMapping(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSetDeviceButtonMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXSetDeviceButtonMapping(client));
     }
 
@@ -162,9 +160,7 @@ SRepXSetDeviceButtonMapping (client, size, rep)
     int		size;
     xSetDeviceButtonMappingReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/setdval.c
+++ b/nx-X11/programs/Xserver/Xi/setdval.c
@@ -81,10 +81,8 @@ int
 SProcXSetDeviceValuators(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSetDeviceValuatorsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXSetDeviceValuators(client));
     }
 
@@ -166,9 +164,7 @@ SRepXSetDeviceValuators (client, size, rep)
     int		size;
     xSetDeviceValuatorsReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/setfocus.c
+++ b/nx-X11/programs/Xserver/Xi/setfocus.c
@@ -84,13 +84,11 @@ int
 SProcXSetDeviceFocus(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSetDeviceFocusReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSetDeviceFocusReq);
-    swapl(&stuff->focus, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->focus);
+    swapl(&stuff->time);
     return(ProcXSetDeviceFocus(client));
     }
 

--- a/nx-X11/programs/Xserver/Xi/setmmap.c
+++ b/nx-X11/programs/Xserver/Xi/setmmap.c
@@ -82,10 +82,8 @@ int
 SProcXSetDeviceModifierMapping(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSetDeviceModifierMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXSetDeviceModifierMapping(client));
     }
 
@@ -155,10 +153,8 @@ SRepXSetDeviceModifierMapping (client, size, rep)
     int		size;
     xSetDeviceModifierMappingReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/setmode.c
+++ b/nx-X11/programs/Xserver/Xi/setmode.c
@@ -81,10 +81,8 @@ int
 SProcXSetDeviceMode(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xSetDeviceModeReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcXSetDeviceMode(client));
     }
 
@@ -150,9 +148,7 @@ SRepXSetDeviceMode (client, size, rep)
     int		size;
     xSetDeviceModeReply	*rep;
     {
-    register char n;
-
-    swaps(&rep->sequenceNumber, n);
-    swapl(&rep->length, n);
+    swaps(&rep->sequenceNumber);
+    swapl(&rep->length);
     WriteToClient(client, size, (char *)rep);
     }

--- a/nx-X11/programs/Xserver/Xi/ungrdev.c
+++ b/nx-X11/programs/Xserver/Xi/ungrdev.c
@@ -80,12 +80,10 @@ int
 SProcXUngrabDevice(client)
 register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xUngrabDeviceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xUngrabDeviceReq);
-    swapl(&stuff->time, n);
+    swapl(&stuff->time);
     return(ProcXUngrabDevice(client));
     }
 

--- a/nx-X11/programs/Xserver/Xi/ungrdevb.c
+++ b/nx-X11/programs/Xserver/Xi/ungrdevb.c
@@ -86,13 +86,11 @@ int
 SProcXUngrabDeviceButton(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xUngrabDeviceButtonReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xUngrabDeviceButtonReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
     return(ProcXUngrabDeviceButton(client));
     }
 

--- a/nx-X11/programs/Xserver/Xi/ungrdevk.c
+++ b/nx-X11/programs/Xserver/Xi/ungrdevk.c
@@ -86,13 +86,11 @@ int
 SProcXUngrabDeviceKey(client)
     register ClientPtr client;
     {
-    register char n;
-
     REQUEST(xUngrabDeviceKeyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xUngrabDeviceKeyReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
     return(ProcXUngrabDeviceKey(client));
     }
 

--- a/nx-X11/programs/Xserver/composite/compext.c
+++ b/nx-X11/programs/Xserver/composite/compext.c
@@ -113,7 +113,6 @@ ProcCompositeQueryVersion (ClientPtr client)
         .sequenceNumber = client->sequence,
         .length = 0
     };
-    register int n;
 
     REQUEST(xCompositeQueryVersionReq);
 
@@ -128,10 +127,10 @@ ProcCompositeQueryVersion (ClientPtr client)
     pCompositeClient->major_version = rep.majorVersion;
     pCompositeClient->minor_version = rep.minorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swapl(&rep.majorVersion, n);
-	swapl(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.majorVersion);
+	swapl(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xCompositeQueryVersionReply), (char *)&rep);
     return Success;
@@ -352,7 +351,6 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     CompScreenPtr cs;
     CompOverlayClientPtr pOc;
     int rc;
-    int n = 0;
 
     REQUEST_SIZE_MATCH(xCompositeGetOverlayWindowReq);
     /* Unsupported by current architecture and porting is too much effort. */
@@ -403,9 +401,9 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.overlayWin, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.overlayWin);
     }
     WriteToClient(client, sz_xCompositeGetOverlayWindowReply, (char *)&rep);
 
@@ -470,111 +468,102 @@ ProcCompositeDispatch (ClientPtr client)
 static int
 SProcCompositeQueryVersion (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeQueryVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeQueryVersionReq);
-    swapl(&stuff->majorVersion, n);
-    swapl(&stuff->minorVersion, n);
+    swapl(&stuff->majorVersion);
+    swapl(&stuff->minorVersion);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeRedirectWindow (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeRedirectWindowReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeRedirectWindowReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeRedirectSubwindows (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeRedirectSubwindowsReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeRedirectSubwindowsReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeUnredirectWindow (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeUnredirectWindowReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeUnredirectWindowReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeUnredirectSubwindows (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeUnredirectSubwindowsReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeUnredirectSubwindowsReq);
-    swapl (&stuff->window, n);
+    swapl (&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeCreateRegionFromBorderClip (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeCreateRegionFromBorderClipReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeCreateRegionFromBorderClipReq);
-    swapl (&stuff->region, n);
-    swapl (&stuff->window, n);
+    swapl (&stuff->region);
+    swapl (&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeNameWindowPixmap (ClientPtr client)
 {
-    int n;
     REQUEST(xCompositeNameWindowPixmapReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeNameWindowPixmapReq);
-    swapl (&stuff->window, n);
-    swapl (&stuff->pixmap, n);
+    swapl (&stuff->window);
+    swapl (&stuff->pixmap);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeGetOverlayWindow(ClientPtr client)
 {
-    int n = 0;
     REQUEST(xCompositeGetOverlayWindowReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeGetOverlayWindowReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
 static int
 SProcCompositeReleaseOverlayWindow(ClientPtr client)
 {
-    int n = 0;
     REQUEST(xCompositeReleaseOverlayWindowReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCompositeReleaseOverlayWindowReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return (*ProcCompositeVector[stuff->compositeReqType]) (client);
 }
 
@@ -903,7 +892,6 @@ PanoramiXCompositeGetOverlayWindow(ClientPtr client)
     int rc;
     PanoramiXRes *win, *overlayWin = NULL;
     int i;
-    int n = 0;
 
     REQUEST_SIZE_MATCH(xCompositeGetOverlayWindowReq);
 
@@ -986,9 +974,9 @@ PanoramiXCompositeGetOverlayWindow(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.overlayWin, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.overlayWin);
     }
     WriteToClient(client, sz_xCompositeGetOverlayWindowReply, &rep);
 

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -137,7 +137,6 @@ ProcDamageQueryVersion(ClientPtr client)
 {
     DamageClientPtr pDamageClient = GetDamageClient (client);
     xDamageQueryVersionReply rep;
-    register int n;
     REQUEST(xDamageQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xDamageQueryVersionReq);
@@ -158,10 +157,10 @@ ProcDamageQueryVersion(ClientPtr client)
     pDamageClient->major_version = rep.majorVersion;
     pDamageClient->minor_version = rep.minorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swapl(&rep.majorVersion, n);
-	swapl(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.majorVersion);
+	swapl(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xDamageQueryVersionReply), (char *)&rep);
     return(client->noClientException);
@@ -309,52 +308,48 @@ ProcDamageDispatch (ClientPtr client)
 static int
 SProcDamageQueryVersion(ClientPtr client)
 {
-    register int n;
     REQUEST(xDamageQueryVersionReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDamageQueryVersionReq);
-    swapl(&stuff->majorVersion, n);
-    swapl(&stuff->minorVersion, n);
+    swapl(&stuff->majorVersion);
+    swapl(&stuff->minorVersion);
     return (*ProcDamageVector[stuff->damageReqType]) (client);
 }
 
 static int
 SProcDamageCreate (ClientPtr client)
 {
-    register int n;
     REQUEST(xDamageCreateReq);
     
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xDamageCreateReq);
-    swapl (&stuff->damage, n);
-    swapl (&stuff->drawable, n);
+    swapl (&stuff->damage);
+    swapl (&stuff->drawable);
     return (*ProcDamageVector[stuff->damageReqType]) (client);
 }
 
 static int
 SProcDamageDestroy (ClientPtr client)
 {
-    register int n;
     REQUEST(xDamageDestroyReq);
     
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xDamageDestroyReq);
-    swapl (&stuff->damage, n);
+    swapl (&stuff->damage);
     return (*ProcDamageVector[stuff->damageReqType]) (client);
 }
 
 static int
 SProcDamageSubtract (ClientPtr client)
 {
-    register int n;
     REQUEST(xDamageSubtractReq);
     
-    swaps (&stuff->length, n);
+    swaps (&stuff->length);
     REQUEST_SIZE_MATCH(xDamageSubtractReq);
-    swapl (&stuff->damage, n);
-    swapl (&stuff->repair, n);
-    swapl (&stuff->parts, n);
+    swapl (&stuff->damage);
+    swapl (&stuff->repair);
+    swapl (&stuff->parts);
     return (*ProcDamageVector[stuff->damageReqType]) (client);
 }
 

--- a/nx-X11/programs/Xserver/dbe/dbe.c
+++ b/nx-X11/programs/Xserver/dbe/dbe.c
@@ -362,8 +362,6 @@ ProcDbeGetVersion(client)
 {
     /* REQUEST(xDbeGetVersionReq); */
     xDbeGetVersionReply	rep;
-    register int	n;
-
 
     REQUEST_SIZE_MATCH(xDbeGetVersionReq);
 
@@ -375,7 +373,7 @@ ProcDbeGetVersion(client)
 
     if (client->swapped)
     {
-        swaps(&rep.sequenceNumber, n);
+        swaps(&rep.sequenceNumber);
     }
 
     WriteToClient(client, sizeof(xDbeGetVersionReply), (char *)&rep);
@@ -898,7 +896,7 @@ ProcDbeGetVisualInfo(client)
     xDbeGetVisualInfoReply	rep;
     Drawable			*drawables;
     DrawablePtr			*pDrawables = NULL;
-    register int		i, j, n;
+    register int		i, j;
     register int		count;  /* number of visual infos in reply */
     register int		length; /* length of reply */
     ScreenPtr			pScreen;
@@ -984,9 +982,9 @@ ProcDbeGetVisualInfo(client)
 
     if (client->swapped)
     {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.m, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.m);
     }
 
     /* Send off reply. */
@@ -1003,7 +1001,7 @@ ProcDbeGetVisualInfo(client)
 
         if (client->swapped)
         {
-            swapl(&data32, n);
+            swapl(&data32);
         }
 
         WriteToClient(client, sizeof(CARD32), (char *)&data32);
@@ -1024,7 +1022,7 @@ ProcDbeGetVisualInfo(client)
 
             if (client->swapped)
             {
-                swapl(&visInfo.visualID, n);
+                swapl(&visInfo.visualID);
 
                 /* We do not need to swap depth and perfLevel since they are
                  * already 1 byte quantities.
@@ -1075,8 +1073,6 @@ ProcDbeGetBackBufferAttributes(client)
     REQUEST(xDbeGetBackBufferAttributesReq);
     xDbeGetBackBufferAttributesReply	rep;
     DbeWindowPrivPtr			pDbeWindowPriv;
-    int					n;
-
 
     REQUEST_SIZE_MATCH(xDbeGetBackBufferAttributesReq);
 
@@ -1096,9 +1092,9 @@ ProcDbeGetBackBufferAttributes(client)
     
     if (client->swapped)
     {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.attributes, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.attributes);
     }
 
     WriteToClient(client, sizeof(xDbeGetBackBufferAttributesReply),
@@ -1179,10 +1175,8 @@ SProcDbeGetVersion(client)
     ClientPtr client;
 {
     REQUEST(xDbeGetVersionReq);
-    register int	n;
 
-
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcDbeGetVersion(client));
 
 } /* SProcDbeGetVersion() */
@@ -1216,13 +1210,12 @@ SProcDbeAllocateBackBufferName(client)
     ClientPtr client;
 {
     REQUEST(xDbeAllocateBackBufferNameReq);
-    register int	n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDbeAllocateBackBufferNameReq);
 
-    swapl(&stuff->window, n);
-    swapl(&stuff->buffer, n);
+    swapl(&stuff->window);
+    swapl(&stuff->buffer);
     /* stuff->swapAction is a byte.  We do not need to swap this field. */
 
     return(ProcDbeAllocateBackBufferName(client));
@@ -1252,13 +1245,11 @@ SProcDbeDeallocateBackBufferName(client)
     ClientPtr client;
 {
     REQUEST (xDbeDeallocateBackBufferNameReq);
-    register int	n;
 
-
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDbeDeallocateBackBufferNameReq);
 
-    swapl(&stuff->buffer, n);
+    swapl(&stuff->buffer);
 
     return(ProcDbeDeallocateBackBufferName(client));
 
@@ -1291,14 +1282,14 @@ SProcDbeSwapBuffers(client)
     ClientPtr client;
 {
     REQUEST(xDbeSwapBuffersReq);
-    unsigned int	i, n;
+    unsigned int	i;
     xDbeSwapInfo	*pSwapInfo;
 
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xDbeSwapBuffersReq);
 
-    swapl(&stuff->n, n);
+    swapl(&stuff->n);
     if (stuff->n > UINT32_MAX / sizeof(DbeSwapInfoRec))
         return BadAlloc;
     REQUEST_FIXED_SIZE(xDbeSwapBuffersReq, stuff->n * sizeof(xDbeSwapInfo));
@@ -1313,7 +1304,7 @@ SProcDbeSwapBuffers(client)
          */
         for (i = 0; i < stuff->n; i++)
         {
-            swapl(&pSwapInfo->window, n);
+            swapl(&pSwapInfo->window);
         }
     }
 
@@ -1343,9 +1334,8 @@ SProcDbeBeginIdiom(client)
     ClientPtr client;
 {
     REQUEST(xDbeBeginIdiomReq);
-    register int	n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(ProcDbeBeginIdiom(client));
 
 } /* SProcDbeBeginIdiom() */
@@ -1373,13 +1363,11 @@ SProcDbeGetVisualInfo(client)
     ClientPtr client;
 {
     REQUEST(xDbeGetVisualInfoReq);
-    register int	n;
 
-
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xDbeGetVisualInfoReq);
 
-    swapl(&stuff->n, n);
+    swapl(&stuff->n);
     SwapRestL(stuff);
 
     return(ProcDbeGetVisualInfo(client));
@@ -1408,12 +1396,11 @@ SProcDbeGetBackBufferAttributes(client)
     ClientPtr client;
 {
     REQUEST (xDbeGetBackBufferAttributesReq);
-    register int	n;
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDbeGetBackBufferAttributesReq);
 
-    swapl(&stuff->buffer, n);
+    swapl(&stuff->buffer);
 
     return(ProcDbeGetBackBufferAttributes(client));
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -3808,7 +3808,7 @@ ProcInitialConnection(register ClientPtr client)
 		     ((prefix->nbytesAuthString + (unsigned)3) >> 2);
     if (client->swapped)
     {
-	swaps(&stuff->length, whichbyte);
+	swaps(&stuff->length);
     }
     ResetCurrentRequest(client);
     return (client->noClientException);

--- a/nx-X11/programs/Xserver/dix/swaprep.c
+++ b/nx-X11/programs/Xserver/dix/swaprep.c
@@ -78,14 +78,13 @@ void
 Swap32Write(ClientPtr pClient, int size, register CARD32 *pbuf)
 {
     register int i;
-    register char n;
 
     size >>= 2;
     for(i = 0; i < size; i++)
     /* brackets are mandatory here, because "swapl" macro expands
        to several statements */
     {   
-	swapl(&pbuf[i], n);
+	swapl(&pbuf[i]);
     }
     (void)WriteToClient(pClient, size << 2, (char *) pbuf);
 }
@@ -191,9 +190,7 @@ CopySwap16Write(ClientPtr pClient, int size, short *pbuf)
 void
 SGenericReply(ClientPtr pClient, int size, xGenericReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
+    swaps(&pRep->sequenceNumber);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -202,67 +199,57 @@ void
 SGetWindowAttributesReply(ClientPtr pClient, int size,
                           xGetWindowAttributesReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->visualID, n);
-    swaps(&pRep->class, n);
-    swapl(&pRep->backingBitPlanes, n);
-    swapl(&pRep->backingPixel, n);
-    swapl(&pRep->colormap, n);
-    swapl(&pRep->allEventMasks, n);
-    swapl(&pRep->yourEventMask, n);
-    swaps(&pRep->doNotPropagateMask, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->visualID);
+    swaps(&pRep->class);
+    swapl(&pRep->backingBitPlanes);
+    swapl(&pRep->backingPixel);
+    swapl(&pRep->colormap);
+    swapl(&pRep->allEventMasks);
+    swapl(&pRep->yourEventMask);
+    swaps(&pRep->doNotPropagateMask);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetGeometryReply(ClientPtr pClient, int size, xGetGeometryReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->root, n);
-    swaps(&pRep->x, n);
-    swaps(&pRep->y, n);
-    swaps(&pRep->width, n);
-    swaps(&pRep->height, n);
-    swaps(&pRep->borderWidth, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->root);
+    swaps(&pRep->x);
+    swaps(&pRep->y);
+    swaps(&pRep->width);
+    swaps(&pRep->height);
+    swaps(&pRep->borderWidth);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SQueryTreeReply(ClientPtr pClient, int size, xQueryTreeReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->root, n);
-    swapl(&pRep->parent, n);
-    swaps(&pRep->nChildren, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->root);
+    swapl(&pRep->parent);
+    swaps(&pRep->nChildren);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SInternAtomReply(ClientPtr pClient, int size, xInternAtomReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->atom, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->atom);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetAtomNameReply(ClientPtr pClient, int size, xGetAtomNameReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nameLength, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nameLength);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -270,24 +257,20 @@ SGetAtomNameReply(ClientPtr pClient, int size, xGetAtomNameReply *pRep)
 void
 SGetPropertyReply(ClientPtr pClient, int size, xGetPropertyReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->propertyType, n);
-    swapl(&pRep->bytesAfter, n);
-    swapl(&pRep->nItems, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->propertyType);
+    swapl(&pRep->bytesAfter);
+    swapl(&pRep->nItems);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SListPropertiesReply(ClientPtr pClient, int size, xListPropertiesReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nProperties, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nProperties);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -295,10 +278,8 @@ void
 SGetSelectionOwnerReply(ClientPtr pClient, int size,
                         xGetSelectionOwnerReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->owner, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->owner);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -306,27 +287,23 @@ SGetSelectionOwnerReply(ClientPtr pClient, int size,
 void
 SQueryPointerReply(ClientPtr pClient, int size, xQueryPointerReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->root, n);
-    swapl(&pRep->child, n);
-    swaps(&pRep->rootX, n);
-    swaps(&pRep->rootY, n);
-    swaps(&pRep->winX, n);
-    swaps(&pRep->winY, n);
-    swaps(&pRep->mask, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->root);
+    swapl(&pRep->child);
+    swaps(&pRep->rootX);
+    swaps(&pRep->rootY);
+    swaps(&pRep->winX);
+    swaps(&pRep->winY);
+    swaps(&pRep->mask);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SwapTimecoord(xTimecoord* pCoord)
 {
-    register char n;
-
-    swapl(&pCoord->time, n);
-    swaps(&pCoord->x, n);
-    swaps(&pCoord->y, n);
+    swapl(&pCoord->time);
+    swaps(&pCoord->x);
+    swaps(&pCoord->y);
 }
 
 void
@@ -348,33 +325,27 @@ SwapTimeCoordWrite(ClientPtr pClient, int size, xTimecoord *pRep)
 void
 SGetMotionEventsReply(ClientPtr pClient, int size, xGetMotionEventsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->nEvents, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->nEvents);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 STranslateCoordsReply(ClientPtr pClient, int size, xTranslateCoordsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->child, n);
-    swaps(&pRep->dstX, n);
-    swaps(&pRep->dstY, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->child);
+    swaps(&pRep->dstX);
+    swaps(&pRep->dstY);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetInputFocusReply(ClientPtr pClient, int size, xGetInputFocusReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->focus, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->focus);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -382,10 +353,8 @@ SGetInputFocusReply(ClientPtr pClient, int size, xGetInputFocusReply *pRep)
 void
 SQueryKeymapReply(ClientPtr pClient, int size, xQueryKeymapReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -393,30 +362,26 @@ static
 void
 SwapCharInfo(xCharInfo *pInfo)
 {
-    register char n;
-
-    swaps(&pInfo->leftSideBearing, n);
-    swaps(&pInfo->rightSideBearing, n);
-    swaps(&pInfo->characterWidth, n);
-    swaps(&pInfo->ascent, n);
-    swaps(&pInfo->descent, n);
-    swaps(&pInfo->attributes, n);
+    swaps(&pInfo->leftSideBearing);
+    swaps(&pInfo->rightSideBearing);
+    swaps(&pInfo->characterWidth);
+    swaps(&pInfo->ascent);
+    swaps(&pInfo->descent);
+    swaps(&pInfo->attributes);
 }
 
 static void
 SwapFontInfo(xQueryFontReply *pr)
 {
-    register char		n;
-
-    swaps(&pr->minCharOrByte2, n);
-    swaps(&pr->maxCharOrByte2, n);
-    swaps(&pr->defaultChar, n);
-    swaps(&pr->nFontProps, n);
-    swaps(&pr->fontAscent, n);
-    swaps(&pr->fontDescent, n);
+    swaps(&pr->minCharOrByte2);
+    swaps(&pr->maxCharOrByte2);
+    swaps(&pr->defaultChar);
+    swaps(&pr->nFontProps);
+    swaps(&pr->fontAscent);
+    swaps(&pr->fontDescent);
     SwapCharInfo( &pr->minBounds);
     SwapCharInfo( &pr->maxBounds);
-    swapl(&pr->nCharInfos, n);
+    swapl(&pr->nCharInfos);
 }
 
 static
@@ -427,10 +392,9 @@ SwapFont(xQueryFontReply *pr, Bool hasGlyphs)
     xCharInfo *	pxci;
     unsigned	nchars, nprops;
     char	*pby;
-    register char n;
 
-    swaps(&pr->sequenceNumber, n);
-    swapl(&pr->length, n);
+    swaps(&pr->sequenceNumber);
+    swapl(&pr->length);
     nchars = pr->nCharInfos;
     nprops = pr->nFontProps;
     SwapFontInfo(pr);
@@ -439,9 +403,9 @@ SwapFont(xQueryFontReply *pr, Bool hasGlyphs)
      * they are always 2 4 byte values */
     for(i = 0; i < nprops; i++)
     {
-	swapl(pby, n);
+	swapl((int *)pby);
 	pby += 4;
-	swapl(pby, n);
+	swapl((int *)pby);
 	pby += 4;
     }
     if (hasGlyphs)
@@ -462,27 +426,23 @@ SQueryFontReply(ClientPtr pClient, int size, xQueryFontReply *pRep)
 void
 SQueryTextExtentsReply(ClientPtr pClient, int size, xQueryTextExtentsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->fontAscent, n);
-    swaps(&pRep->fontDescent, n);
-    swaps(&pRep->overallAscent, n);
-    swaps(&pRep->overallDescent, n);
-    swapl(&pRep->overallWidth, n);
-    swapl(&pRep->overallLeft, n);
-    swapl(&pRep->overallRight, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->fontAscent);
+    swaps(&pRep->fontDescent);
+    swaps(&pRep->overallAscent);
+    swaps(&pRep->overallDescent);
+    swapl(&pRep->overallWidth);
+    swapl(&pRep->overallLeft);
+    swapl(&pRep->overallRight);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SListFontsReply(ClientPtr pClient, int size, xListFontsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nFonts, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nFonts);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -497,22 +457,18 @@ SListFontsWithInfoReply(ClientPtr pClient, int size,
 void
 SGetFontPathReply(ClientPtr pClient, int size, xGetFontPathReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nPaths, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nPaths);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetImageReply(ClientPtr pClient, int size, xGetImageReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->visual, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->visual);
     (void)WriteToClient(pClient, size, (char *) pRep);
     /* Fortunately, image doesn't need swapping */
 }
@@ -521,11 +477,9 @@ void
 SListInstalledColormapsReply(ClientPtr pClient, int size,
                              xListInstalledColormapsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nColormaps, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nColormaps);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -535,41 +489,35 @@ SAllocColorReply(pClient, size, pRep)
     int			size;
     xAllocColorReply	*pRep;
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->red, n);
-    swaps(&pRep->green, n);
-    swaps(&pRep->blue, n);
-    swapl(&pRep->pixel, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->red);
+    swaps(&pRep->green);
+    swaps(&pRep->blue);
+    swapl(&pRep->pixel);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SAllocNamedColorReply(ClientPtr pClient, int size, xAllocNamedColorReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->pixel, n);
-    swaps(&pRep->exactRed, n);
-    swaps(&pRep->exactGreen, n);
-    swaps(&pRep->exactBlue, n);
-    swaps(&pRep->screenRed, n);
-    swaps(&pRep->screenGreen, n);
-    swaps(&pRep->screenBlue, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->pixel);
+    swaps(&pRep->exactRed);
+    swaps(&pRep->exactGreen);
+    swaps(&pRep->exactBlue);
+    swaps(&pRep->screenRed);
+    swaps(&pRep->screenGreen);
+    swaps(&pRep->screenBlue);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SAllocColorCellsReply(ClientPtr pClient, int size, xAllocColorCellsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nPixels, n);
-    swaps(&pRep->nMasks, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nPixels);
+    swaps(&pRep->nMasks);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -577,25 +525,21 @@ SAllocColorCellsReply(ClientPtr pClient, int size, xAllocColorCellsReply *pRep)
 void
 SAllocColorPlanesReply(ClientPtr pClient, int size, xAllocColorPlanesReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nPixels, n);
-    swapl(&pRep->redMask, n);
-    swapl(&pRep->greenMask, n);
-    swapl(&pRep->blueMask, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nPixels);
+    swapl(&pRep->redMask);
+    swapl(&pRep->greenMask);
+    swapl(&pRep->blueMask);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SwapRGB(xrgb *prgb)
 {
-    register char n;
-
-    swaps(&prgb->red, n);
-    swaps(&prgb->green, n);
-    swaps(&prgb->blue, n);
+    swaps(&prgb->red);
+    swaps(&prgb->green);
+    swaps(&prgb->blue);
 }
 
 void
@@ -617,47 +561,39 @@ SQColorsExtend(ClientPtr pClient, int size, xrgb *prgb)
 void
 SQueryColorsReply(ClientPtr pClient, int size, xQueryColorsReply* pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nColors, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nColors);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SLookupColorReply(ClientPtr pClient, int size, xLookupColorReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->exactRed, n);
-    swaps(&pRep->exactGreen, n);
-    swaps(&pRep->exactBlue, n);
-    swaps(&pRep->screenRed, n);
-    swaps(&pRep->screenGreen, n);
-    swaps(&pRep->screenBlue, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->exactRed);
+    swaps(&pRep->exactGreen);
+    swaps(&pRep->exactBlue);
+    swaps(&pRep->screenRed);
+    swaps(&pRep->screenGreen);
+    swaps(&pRep->screenBlue);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SQueryBestSizeReply(ClientPtr pClient, int size, xQueryBestSizeReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->width, n);
-    swaps(&pRep->height, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->width);
+    swaps(&pRep->height);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SListExtensionsReply(ClientPtr pClient, int size, xListExtensionsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -665,10 +601,8 @@ void
 SGetKeyboardMappingReply(ClientPtr pClient, int size,
                          xGetKeyboardMappingReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -676,10 +610,8 @@ void
 SGetPointerMappingReply(ClientPtr pClient, int size,
                         xGetPointerMappingReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -687,46 +619,38 @@ void
 SGetModifierMappingReply(ClientPtr pClient, int size,
                          xGetModifierMappingReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetKeyboardControlReply(ClientPtr pClient, int size, xGetKeyboardControlReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swapl(&pRep->ledMask, n);
-    swaps(&pRep->bellPitch, n);
-    swaps(&pRep->bellDuration, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swapl(&pRep->ledMask);
+    swaps(&pRep->bellPitch);
+    swaps(&pRep->bellDuration);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetPointerControlReply(ClientPtr pClient, int size, xGetPointerControlReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->accelNumerator, n);
-    swaps(&pRep->accelDenominator, n);
-    swaps(&pRep->threshold, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->accelNumerator);
+    swaps(&pRep->accelDenominator);
+    swaps(&pRep->threshold);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
 void
 SGetScreenSaverReply(ClientPtr pClient, int size, xGetScreenSaverReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swaps(&pRep->timeout, n);
-    swaps(&pRep->interval, n);
+    swaps(&pRep->sequenceNumber);
+    swaps(&pRep->timeout);
+    swaps(&pRep->interval);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 
@@ -738,8 +662,7 @@ SLHostsExtend(ClientPtr pClient, int size, char *buf)
     while (bufT < endbuf) {
 	xHostEntry *host = (xHostEntry *) bufT;
 	int len = host->length;
-        register char n;
-	swaps (&host->length, n);
+	swaps (&host->length);
 	bufT += sizeof (xHostEntry) + (((len + 3) >> 2) << 2);
 	}
     (void)WriteToClient (pClient, size, buf);
@@ -748,11 +671,9 @@ SLHostsExtend(ClientPtr pClient, int size, char *buf)
 void
 SListHostsReply(ClientPtr pClient, int size, xListHostsReply *pRep)
 {
-    register char n;
-
-    swaps(&pRep->sequenceNumber, n);
-    swapl(&pRep->length, n);
-    swaps(&pRep->nHosts, n);
+    swaps(&pRep->sequenceNumber);
+    swapl(&pRep->length);
+    swaps(&pRep->nHosts);
     (void)WriteToClient(pClient, size, (char *) pRep);
 }
 

--- a/nx-X11/programs/Xserver/dix/swapreq.c
+++ b/nx-X11/programs/Xserver/dix/swapreq.c
@@ -68,23 +68,21 @@ SOFTWARE.
 void
 SwapLongs (register CARD32 *list, register unsigned long count)
 {
-	register char n;
-
 	while (count >= 8) {
-	    swapl(list+0, n);
-	    swapl(list+1, n);
-	    swapl(list+2, n);
-	    swapl(list+3, n);
-	    swapl(list+4, n);
-	    swapl(list+5, n);
-	    swapl(list+6, n);
-	    swapl(list+7, n);
+	    swapl(list+0);
+	    swapl(list+1);
+	    swapl(list+2);
+	    swapl(list+3);
+	    swapl(list+4);
+	    swapl(list+5);
+	    swapl(list+6);
+	    swapl(list+7);
 	    list += 8;
 	    count -= 8;
 	}
 	if (count != 0) {
 	    do {
-		swapl(list, n);
+		swapl(list);
 		list++;
 	    } while (--count != 0);
 	}
@@ -95,31 +93,29 @@ SwapLongs (register CARD32 *list, register unsigned long count)
 void
 SwapShorts (register short *list, register unsigned long count)
 {
-	register char n;
-
 	while (count >= 16) {
-	    swaps(list+0, n);
-	    swaps(list+1, n);
-	    swaps(list+2, n);
-	    swaps(list+3, n);
-	    swaps(list+4, n);
-	    swaps(list+5, n);
-	    swaps(list+6, n);
-	    swaps(list+7, n);
-	    swaps(list+8, n);
-	    swaps(list+9, n);
-	    swaps(list+10, n);
-	    swaps(list+11, n);
-	    swaps(list+12, n);
-	    swaps(list+13, n);
-	    swaps(list+14, n);
-	    swaps(list+15, n);
+	    swaps(list+0);
+	    swaps(list+1);
+	    swaps(list+2);
+	    swaps(list+3);
+	    swaps(list+4);
+	    swaps(list+5);
+	    swaps(list+6);
+	    swaps(list+7);
+	    swaps(list+8);
+	    swaps(list+9);
+	    swaps(list+10);
+	    swaps(list+11);
+	    swaps(list+12);
+	    swaps(list+13);
+	    swaps(list+14);
+	    swaps(list+15);
 	    list += 16;
 	    count -= 16;
 	}
 	if (count != 0) {
 	    do {
-		swaps(list, n);
+		swaps(list);
 		list++;
 	    } while (--count != 0);
 	}
@@ -130,10 +126,8 @@ SwapShorts (register short *list, register unsigned long count)
 int
 SProcSimpleReq(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return(*ProcVector[stuff->reqType])(client);
 }
 
@@ -143,33 +137,29 @@ SProcSimpleReq(register ClientPtr client)
 int
 SProcResourceReq(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xResourceReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xResourceReq); /* not EXACT */
-    swapl(&stuff->id, n);
+    swapl(&stuff->id);
     return(*ProcVector[stuff->reqType])(client);
 }
 
 int
 SProcCreateWindow(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xCreateWindowReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xCreateWindowReq);
-    swapl(&stuff->wid, n);
-    swapl(&stuff->parent, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swaps(&stuff->borderWidth, n);
-    swaps(&stuff->class, n);
-    swapl(&stuff->visual, n);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->wid);
+    swapl(&stuff->parent);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swaps(&stuff->borderWidth);
+    swaps(&stuff->class);
+    swapl(&stuff->visual);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return((* ProcVector[X_CreateWindow])(client));
 }
@@ -177,13 +167,11 @@ SProcCreateWindow(register ClientPtr client)
 int
 SProcChangeWindowAttributes(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xChangeWindowAttributesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeWindowAttributesReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->valueMask, n);
+    swapl(&stuff->window);
+    swapl(&stuff->valueMask);
     SwapRestL(stuff);
     return((* ProcVector[X_ChangeWindowAttributes])(client));
 }
@@ -191,26 +179,24 @@ SProcChangeWindowAttributes(register ClientPtr client)
 int
 SProcReparentWindow(register ClientPtr client)
 {
-    register char n;
     REQUEST(xReparentWindowReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xReparentWindowReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->parent, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
+    swapl(&stuff->window);
+    swapl(&stuff->parent);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
     return((* ProcVector[X_ReparentWindow])(client));
 }
 
 int
 SProcConfigureWindow(register ClientPtr client)
 {
-    register char n;
     REQUEST(xConfigureWindowReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xConfigureWindowReq);
-    swapl(&stuff->window, n);
-    swaps(&stuff->mask, n);
+    swapl(&stuff->window);
+    swaps(&stuff->mask);
     SwapRestL(stuff);
     return((* ProcVector[X_ConfigureWindow])(client));
 
@@ -220,25 +206,23 @@ SProcConfigureWindow(register ClientPtr client)
 int
 SProcInternAtom(register ClientPtr client)
 {
-    register char n;
     REQUEST(xInternAtomReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xInternAtomReq);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_InternAtom])(client));
 }
 
 int
 SProcChangeProperty(register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangePropertyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangePropertyReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->nUnits, n);
+    swapl(&stuff->window);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->nUnits);
     switch ( stuff->format ) {
         case 8 :
 	    break;
@@ -255,12 +239,11 @@ SProcChangeProperty(register ClientPtr client)
 int 
 SProcDeleteProperty(register ClientPtr client)
 {
-    register char n;
     REQUEST(xDeletePropertyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xDeletePropertyReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->property, n);
+    swapl(&stuff->window);
+    swapl(&stuff->property);
     return((* ProcVector[X_DeleteProperty])(client));
               
 }
@@ -268,57 +251,53 @@ SProcDeleteProperty(register ClientPtr client)
 int 
 SProcGetProperty(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGetPropertyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetPropertyReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->longOffset, n);
-    swapl(&stuff->longLength, n);
+    swapl(&stuff->window);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->longOffset);
+    swapl(&stuff->longLength);
     return((* ProcVector[X_GetProperty])(client));
 }
 
 int
 SProcSetSelectionOwner(register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetSelectionOwnerReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSetSelectionOwnerReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->selection, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->window);
+    swapl(&stuff->selection);
+    swapl(&stuff->time);
     return((* ProcVector[X_SetSelectionOwner])(client));
 }
 
 int
 SProcConvertSelection(register ClientPtr client)
 {
-    register char n;
     REQUEST(xConvertSelectionReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xConvertSelectionReq);
-    swapl(&stuff->requestor, n);
-    swapl(&stuff->selection, n);
-    swapl(&stuff->target, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->requestor);
+    swapl(&stuff->selection);
+    swapl(&stuff->target);
+    swapl(&stuff->property);
+    swapl(&stuff->time);
     return((* ProcVector[X_ConvertSelection])(client));
 }
 
 int
 SProcSendEvent(register ClientPtr client)
 {
-    register char n;
     xEvent eventT;
     EventSwapPtr proc;
     REQUEST(xSendEventReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSendEventReq);
-    swapl(&stuff->destination, n);
-    swapl(&stuff->eventMask, n);
+    swapl(&stuff->destination);
+    swapl(&stuff->eventMask);
 
     /* Swap event */
     proc = EventSwapVector[stuff->event.u.u.type & 0177];
@@ -333,223 +312,206 @@ SProcSendEvent(register ClientPtr client)
 int
 SProcGrabPointer(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGrabPointerReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGrabPointerReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->eventMask, n);
-    swapl(&stuff->confineTo, n);
-    swapl(&stuff->cursor, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->eventMask);
+    swapl(&stuff->confineTo);
+    swapl(&stuff->cursor);
+    swapl(&stuff->time);
     return((* ProcVector[X_GrabPointer])(client));
 }
 
 int
 SProcGrabButton(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGrabButtonReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGrabButtonReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->eventMask, n);
-    swapl(&stuff->confineTo, n);
-    swapl(&stuff->cursor, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->eventMask);
+    swapl(&stuff->confineTo);
+    swapl(&stuff->cursor);
+    swaps(&stuff->modifiers);
     return((* ProcVector[X_GrabButton])(client));
 }
 
 int
 SProcUngrabButton(register ClientPtr client)
 {
-    register char n;
     REQUEST(xUngrabButtonReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xUngrabButtonReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
     return((* ProcVector[X_UngrabButton])(client));
 }
 
 int
 SProcChangeActivePointerGrab(register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangeActivePointerGrabReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xChangeActivePointerGrabReq);
-    swapl(&stuff->cursor, n);
-    swapl(&stuff->time, n);
-    swaps(&stuff->eventMask, n);
+    swapl(&stuff->cursor);
+    swapl(&stuff->time);
+    swaps(&stuff->eventMask);
     return((* ProcVector[X_ChangeActivePointerGrab])(client));
 }
 
 int
 SProcGrabKeyboard(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGrabKeyboardReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGrabKeyboardReq);
-    swapl(&stuff->grabWindow, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->grabWindow);
+    swapl(&stuff->time);
     return((* ProcVector[X_GrabKeyboard])(client));
 }
 
 int
 SProcGrabKey(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGrabKeyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGrabKeyReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
     return((* ProcVector[X_GrabKey])(client));
 }
 
 int
 SProcUngrabKey(register ClientPtr client)
 {
-    register char n;
     REQUEST(xUngrabKeyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xUngrabKeyReq);
-    swapl(&stuff->grabWindow, n);
-    swaps(&stuff->modifiers, n);
+    swapl(&stuff->grabWindow);
+    swaps(&stuff->modifiers);
     return((* ProcVector[X_UngrabKey])(client));
 }
 
 int
 SProcGetMotionEvents(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGetMotionEventsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetMotionEventsReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->start, n);
-    swapl(&stuff->stop, n);
+    swapl(&stuff->window);
+    swapl(&stuff->start);
+    swapl(&stuff->stop);
     return((* ProcVector[X_GetMotionEvents])(client));
 }
 
 int
 SProcTranslateCoords(register ClientPtr client)
 {
-    register char n;
     REQUEST(xTranslateCoordsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xTranslateCoordsReq);
-    swapl(&stuff->srcWid, n);
-    swapl(&stuff->dstWid, n);
-    swaps(&stuff->srcX, n);
-    swaps(&stuff->srcY, n);
+    swapl(&stuff->srcWid);
+    swapl(&stuff->dstWid);
+    swaps(&stuff->srcX);
+    swaps(&stuff->srcY);
     return((* ProcVector[X_TranslateCoords])(client));
 }
 
 int
 SProcWarpPointer(register ClientPtr client)
 {
-    register char n;
     REQUEST(xWarpPointerReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xWarpPointerReq);
-    swapl(&stuff->srcWid, n);
-    swapl(&stuff->dstWid, n);
-    swaps(&stuff->srcX, n);
-    swaps(&stuff->srcY, n);
-    swaps(&stuff->srcWidth, n);
-    swaps(&stuff->srcHeight, n);
-    swaps(&stuff->dstX, n);
-    swaps(&stuff->dstY, n);
+    swapl(&stuff->srcWid);
+    swapl(&stuff->dstWid);
+    swaps(&stuff->srcX);
+    swaps(&stuff->srcY);
+    swaps(&stuff->srcWidth);
+    swaps(&stuff->srcHeight);
+    swaps(&stuff->dstX);
+    swaps(&stuff->dstY);
     return((* ProcVector[X_WarpPointer])(client));
 }
 
 int
 SProcSetInputFocus(register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetInputFocusReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSetInputFocusReq);
-    swapl(&stuff->focus, n);
-    swapl(&stuff->time, n);
+    swapl(&stuff->focus);
+    swapl(&stuff->time);
     return((* ProcVector[X_SetInputFocus])(client));
 }
 
 int
 SProcOpenFont(register ClientPtr client)
 {
-    register char n;
     REQUEST(xOpenFontReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xOpenFontReq);
-    swapl(&stuff->fid, n);
-    swaps(&stuff->nbytes, n);
+    swapl(&stuff->fid);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_OpenFont])(client));
 }
 
 int
 SProcListFonts(register ClientPtr client)
 {
-    register char n;
     REQUEST(xListFontsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xListFontsReq);
-    swaps(&stuff->maxNames, n);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->maxNames);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_ListFonts])(client));
 }
 
 int
 SProcListFontsWithInfo(register ClientPtr client)
 {
-    register char n;
     REQUEST(xListFontsWithInfoReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xListFontsWithInfoReq);
-    swaps(&stuff->maxNames, n);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->maxNames);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_ListFontsWithInfo])(client));
 }
 
 int
 SProcSetFontPath(register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetFontPathReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSetFontPathReq);
-    swaps(&stuff->nFonts, n);
+    swaps(&stuff->nFonts);
     return((* ProcVector[X_SetFontPath])(client));
 }
 
 int
 SProcCreatePixmap(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCreatePixmapReq);
 
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCreatePixmapReq);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->drawable, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swapl(&stuff->pid);
+    swapl(&stuff->drawable);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return((* ProcVector[X_CreatePixmap])(client));
 }
 
 int
 SProcCreateGC(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCreateGCReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xCreateGCReq);
-    swapl(&stuff->gc, n);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->gc);
+    swapl(&stuff->drawable);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return((* ProcVector[X_CreateGC])(client));
 }
@@ -557,12 +519,11 @@ SProcCreateGC(register ClientPtr client)
 int
 SProcChangeGC(register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangeGCReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeGCReq);
-    swapl(&stuff->gc, n);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->gc);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return((* ProcVector[X_ChangeGC])(client));
 }
@@ -570,26 +531,24 @@ SProcChangeGC(register ClientPtr client)
 int
 SProcCopyGC(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCopyGCReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCopyGCReq);
-    swapl(&stuff->srcGC, n);
-    swapl(&stuff->dstGC, n);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->srcGC);
+    swapl(&stuff->dstGC);
+    swapl(&stuff->mask);
     return((* ProcVector[X_CopyGC])(client));
 }
 
 int
 SProcSetDashes(register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetDashesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSetDashesReq);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->dashOffset, n);
-    swaps(&stuff->nDashes, n);
+    swapl(&stuff->gc);
+    swaps(&stuff->dashOffset);
+    swaps(&stuff->nDashes);
     return((* ProcVector[X_SetDashes])(client));
 
 }
@@ -597,13 +556,12 @@ SProcSetDashes(register ClientPtr client)
 int
 SProcSetClipRectangles(register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetClipRectanglesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xSetClipRectanglesReq);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->xOrigin, n);
-    swaps(&stuff->yOrigin, n);
+    swapl(&stuff->gc);
+    swaps(&stuff->xOrigin);
+    swaps(&stuff->yOrigin);
     SwapRestS(stuff);
     return((* ProcVector[X_SetClipRectangles])(client));
 }
@@ -611,54 +569,51 @@ SProcSetClipRectangles(register ClientPtr client)
 int
 SProcClearToBackground(register ClientPtr client)
 {
-    register char n;
     REQUEST(xClearAreaReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xClearAreaReq);
-    swapl(&stuff->window, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swapl(&stuff->window);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return((* ProcVector[X_ClearArea])(client));
 }
 
 int
 SProcCopyArea(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCopyAreaReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCopyAreaReq);
-    swapl(&stuff->srcDrawable, n);
-    swapl(&stuff->dstDrawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->srcX, n);
-    swaps(&stuff->srcY, n);
-    swaps(&stuff->dstX, n);
-    swaps(&stuff->dstY, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swapl(&stuff->srcDrawable);
+    swapl(&stuff->dstDrawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->srcX);
+    swaps(&stuff->srcY);
+    swaps(&stuff->dstX);
+    swaps(&stuff->dstY);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return((* ProcVector[X_CopyArea])(client));
 }
 
 int
 SProcCopyPlane(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCopyPlaneReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCopyPlaneReq);
-    swapl(&stuff->srcDrawable, n);
-    swapl(&stuff->dstDrawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->srcX, n);
-    swaps(&stuff->srcY, n);
-    swaps(&stuff->dstX, n);
-    swaps(&stuff->dstY, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swapl(&stuff->bitPlane, n);
+    swapl(&stuff->srcDrawable);
+    swapl(&stuff->dstDrawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->srcX);
+    swaps(&stuff->srcY);
+    swaps(&stuff->dstX);
+    swaps(&stuff->dstY);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->bitPlane);
     return((* ProcVector[X_CopyPlane])(client));
 }
 
@@ -667,13 +622,11 @@ SProcCopyPlane(register ClientPtr client)
 int
 SProcPoly(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xPolyPointReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xPolyPointReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
     SwapRestS(stuff);
     return((* ProcVector[stuff->reqType])(client));
 }
@@ -684,13 +637,11 @@ SProcPoly(register ClientPtr client)
 int
 SProcFillPoly(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xFillPolyReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xFillPolyReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
     SwapRestS(stuff);
     return((* ProcVector[X_FillPoly])(client));
 }
@@ -698,16 +649,15 @@ SProcFillPoly(register ClientPtr client)
 int
 SProcPutImage(register ClientPtr client)
 {
-    register char n;
     REQUEST(xPutImageReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xPutImageReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swaps(&stuff->dstX, n);
-    swaps(&stuff->dstY, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swaps(&stuff->dstX);
+    swaps(&stuff->dstY);
     /* Image should already be swapped */
     return((* ProcVector[X_PutImage])(client));
 
@@ -716,16 +666,15 @@ SProcPutImage(register ClientPtr client)
 int
 SProcGetImage(register ClientPtr client)
 {
-    register char n;
     REQUEST(xGetImageReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xGetImageReq);
-    swapl(&stuff->drawable, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swapl(&stuff->planeMask, n);
+    swapl(&stuff->drawable);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->planeMask);
     return((* ProcVector[X_GetImage])(client));
 }
 
@@ -734,14 +683,13 @@ SProcGetImage(register ClientPtr client)
 int
 SProcPolyText(register ClientPtr client)
 {
-    register char n;
     REQUEST(xPolyTextReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xPolyTextReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
     return((* ProcVector[stuff->reqType])(client));
 }
 
@@ -750,27 +698,25 @@ SProcPolyText(register ClientPtr client)
 int
 SProcImageText(register ClientPtr client)
 {
-    register char n;
     REQUEST(xImageTextReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xImageTextReq);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->gc, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
+    swapl(&stuff->drawable);
+    swapl(&stuff->gc);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
     return((* ProcVector[stuff->reqType])(client));
 }
 
 int
 SProcCreateColormap(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCreateColormapReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCreateColormapReq);
-    swapl(&stuff->mid, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->visual, n);
+    swapl(&stuff->mid);
+    swapl(&stuff->window);
+    swapl(&stuff->visual);
     return((* ProcVector[X_CreateColormap])(client));
 }
 
@@ -778,12 +724,11 @@ SProcCreateColormap(register ClientPtr client)
 int
 SProcCopyColormapAndFree(register ClientPtr client)
 {
-    register char n;
     REQUEST(xCopyColormapAndFreeReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCopyColormapAndFreeReq);
-    swapl(&stuff->mid, n);
-    swapl(&stuff->srcCmap, n);
+    swapl(&stuff->mid);
+    swapl(&stuff->srcCmap);
     return((* ProcVector[X_CopyColormapAndFree])(client));
 
 }
@@ -791,67 +736,61 @@ SProcCopyColormapAndFree(register ClientPtr client)
 int
 SProcAllocColor(register ClientPtr client)
 {
-    register char n;
     REQUEST(xAllocColorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xAllocColorReq);
-    swapl(&stuff->cmap, n);
-    swaps(&stuff->red, n);
-    swaps(&stuff->green, n);
-    swaps(&stuff->blue, n);
+    swapl(&stuff->cmap);
+    swaps(&stuff->red);
+    swaps(&stuff->green);
+    swaps(&stuff->blue);
     return((* ProcVector[X_AllocColor])(client));
 }
 
 int
 SProcAllocNamedColor(register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xAllocNamedColorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xAllocNamedColorReq);
-    swapl(&stuff->cmap, n);
-    swaps(&stuff->nbytes, n);
+    swapl(&stuff->cmap);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_AllocNamedColor])(client));
 }
 
 int
 SProcAllocColorCells(register ClientPtr client)
 {
-    register char n;
     REQUEST(xAllocColorCellsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xAllocColorCellsReq);
-    swapl(&stuff->cmap, n);
-    swaps(&stuff->colors, n);
-    swaps(&stuff->planes, n);
+    swapl(&stuff->cmap);
+    swaps(&stuff->colors);
+    swaps(&stuff->planes);
     return((* ProcVector[X_AllocColorCells])(client));
 }
 
 int
 SProcAllocColorPlanes(register ClientPtr client)
 {
-    register char n;
     REQUEST(xAllocColorPlanesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xAllocColorPlanesReq);
-    swapl(&stuff->cmap, n);
-    swaps(&stuff->colors, n);
-    swaps(&stuff->red, n);
-    swaps(&stuff->green, n);
-    swaps(&stuff->blue, n);
+    swapl(&stuff->cmap);
+    swaps(&stuff->colors);
+    swaps(&stuff->red);
+    swaps(&stuff->green);
+    swaps(&stuff->blue);
     return((* ProcVector[X_AllocColorPlanes])(client));
 }
 
 int
 SProcFreeColors(register ClientPtr client)
 {
-    register char n;
     REQUEST(xFreeColorsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xFreeColorsReq);
-    swapl(&stuff->cmap, n);
-    swapl(&stuff->planeMask, n);
+    swapl(&stuff->cmap);
+    swapl(&stuff->planeMask);
     SwapRestL(stuff);
     return((* ProcVector[X_FreeColors])(client));
 
@@ -860,25 +799,22 @@ SProcFreeColors(register ClientPtr client)
 void
 SwapColorItem(xColorItem *pItem)
 {
-    register char n;
-
-    swapl(&pItem->pixel, n);
-    swaps(&pItem->red, n);
-    swaps(&pItem->green, n);
-    swaps(&pItem->blue, n);
+    swapl(&pItem->pixel);
+    swaps(&pItem->red);
+    swaps(&pItem->green);
+    swaps(&pItem->blue);
 }
 
 int
 SProcStoreColors(register ClientPtr client)
 {
-    register char n;
     long count;
     xColorItem 	*pItem;
 
     REQUEST(xStoreColorsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xStoreColorsReq);
-    swapl(&stuff->cmap, n);
+    swapl(&stuff->cmap);
     pItem = (xColorItem *) &stuff[1];
     for(count = LengthRestB(stuff)/sizeof(xColorItem); --count >= 0; )
 	SwapColorItem(pItem++);
@@ -888,24 +824,22 @@ SProcStoreColors(register ClientPtr client)
 int
 SProcStoreNamedColor (register ClientPtr client)
 {
-    register char n;
     REQUEST(xStoreNamedColorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xStoreNamedColorReq);
-    swapl(&stuff->cmap, n);
-    swapl(&stuff->pixel, n);
-    swaps(&stuff->nbytes, n);
+    swapl(&stuff->cmap);
+    swapl(&stuff->pixel);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_StoreNamedColor])(client));
 }
 
 int
 SProcQueryColors (register ClientPtr client)
 {
-    register char n;
     REQUEST(xQueryColorsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xQueryColorsReq);
-    swapl(&stuff->cmap, n);
+    swapl(&stuff->cmap);
     SwapRestL(stuff);
     return((* ProcVector[X_QueryColors])(client));
 } 
@@ -913,54 +847,51 @@ SProcQueryColors (register ClientPtr client)
 int
 SProcLookupColor (register ClientPtr client)
 {
-    register char n;
     REQUEST(xLookupColorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xLookupColorReq);
-    swapl(&stuff->cmap, n);
-    swaps(&stuff->nbytes, n);
+    swapl(&stuff->cmap);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_LookupColor])(client));
 }
 
 int
 SProcCreateCursor (register ClientPtr client)
 {
-    register char n;
     REQUEST(xCreateCursorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCreateCursorReq);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->source, n);
-    swapl(&stuff->mask, n);
-    swaps(&stuff->foreRed, n);
-    swaps(&stuff->foreGreen, n);
-    swaps(&stuff->foreBlue, n);
-    swaps(&stuff->backRed, n);
-    swaps(&stuff->backGreen, n);
-    swaps(&stuff->backBlue, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
+    swapl(&stuff->cid);
+    swapl(&stuff->source);
+    swapl(&stuff->mask);
+    swaps(&stuff->foreRed);
+    swaps(&stuff->foreGreen);
+    swaps(&stuff->foreBlue);
+    swaps(&stuff->backRed);
+    swaps(&stuff->backGreen);
+    swaps(&stuff->backBlue);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
     return((* ProcVector[X_CreateCursor])(client));
 }
 
 int
 SProcCreateGlyphCursor (register ClientPtr client)
 {
-    register char n;
     REQUEST(xCreateGlyphCursorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xCreateGlyphCursorReq);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->source, n);
-    swapl(&stuff->mask, n);
-    swaps(&stuff->sourceChar, n);
-    swaps(&stuff->maskChar, n);
-    swaps(&stuff->foreRed, n);
-    swaps(&stuff->foreGreen, n);
-    swaps(&stuff->foreBlue, n);
-    swaps(&stuff->backRed, n);
-    swaps(&stuff->backGreen, n);
-    swaps(&stuff->backBlue, n);
+    swapl(&stuff->cid);
+    swapl(&stuff->source);
+    swapl(&stuff->mask);
+    swaps(&stuff->sourceChar);
+    swaps(&stuff->maskChar);
+    swaps(&stuff->foreRed);
+    swaps(&stuff->foreGreen);
+    swaps(&stuff->foreBlue);
+    swaps(&stuff->backRed);
+    swaps(&stuff->backGreen);
+    swaps(&stuff->backBlue);
     return((* ProcVector[X_CreateGlyphCursor])(client));
 }
 
@@ -968,30 +899,28 @@ SProcCreateGlyphCursor (register ClientPtr client)
 int
 SProcRecolorCursor (register ClientPtr client)
 {
-    register char n;
     REQUEST(xRecolorCursorReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xRecolorCursorReq);
-    swapl(&stuff->cursor, n);
-    swaps(&stuff->foreRed, n);
-    swaps(&stuff->foreGreen, n);
-    swaps(&stuff->foreBlue, n);
-    swaps(&stuff->backRed, n);
-    swaps(&stuff->backGreen, n);
-    swaps(&stuff->backBlue, n);
+    swapl(&stuff->cursor);
+    swaps(&stuff->foreRed);
+    swaps(&stuff->foreGreen);
+    swaps(&stuff->foreBlue);
+    swaps(&stuff->backRed);
+    swaps(&stuff->backGreen);
+    swaps(&stuff->backBlue);
     return((* ProcVector[X_RecolorCursor])(client));
 }
 
 int
 SProcQueryBestSize (register ClientPtr client)
 {
-    register char n;
     REQUEST(xQueryBestSizeReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xQueryBestSizeReq);
-    swapl(&stuff->drawable, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swapl(&stuff->drawable);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return((* ProcVector[X_QueryBestSize])(client));
 
 }
@@ -999,20 +928,18 @@ SProcQueryBestSize (register ClientPtr client)
 int
 SProcQueryExtension (register ClientPtr client)
 {
-    register char n;
     REQUEST(xQueryExtensionReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xQueryExtensionReq);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->nbytes);
     return((* ProcVector[X_QueryExtension])(client));
 }
 
 int
 SProcChangeKeyboardMapping (register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangeKeyboardMappingReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeKeyboardMappingReq);
     SwapRestL(stuff);
     return((* ProcVector[X_ChangeKeyboardMapping])(client));
@@ -1022,11 +949,10 @@ SProcChangeKeyboardMapping (register ClientPtr client)
 int
 SProcChangeKeyboardControl (register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangeKeyboardControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeKeyboardControlReq);
-    swapl(&stuff->mask, n);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return((* ProcVector[X_ChangeKeyboardControl])(client));
 }
@@ -1034,13 +960,12 @@ SProcChangeKeyboardControl (register ClientPtr client)
 int
 SProcChangePointerControl (register ClientPtr client)
 {
-    register char n;
     REQUEST(xChangePointerControlReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xChangePointerControlReq);
-    swaps(&stuff->accelNum, n);
-    swaps(&stuff->accelDenum, n);
-    swaps(&stuff->threshold, n);
+    swaps(&stuff->accelNum);
+    swaps(&stuff->accelDenum);
+    swaps(&stuff->threshold);
     return((* ProcVector[X_ChangePointerControl])(client));
 }
 
@@ -1048,37 +973,33 @@ SProcChangePointerControl (register ClientPtr client)
 int
 SProcSetScreenSaver (register ClientPtr client)
 {
-    register char n;
     REQUEST(xSetScreenSaverReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xSetScreenSaverReq);
-    swaps(&stuff->timeout, n);
-    swaps(&stuff->interval, n);
+    swaps(&stuff->timeout);
+    swaps(&stuff->interval);
     return((* ProcVector[X_SetScreenSaver])(client));
 }
 
 int
 SProcChangeHosts (register ClientPtr client)
 {
-    register char n;
-
     REQUEST(xChangeHostsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xChangeHostsReq);
-    swaps(&stuff->hostLength, n);
+    swaps(&stuff->hostLength);
     return((* ProcVector[X_ChangeHosts])(client));
 
 }
 
 int SProcRotateProperties (register ClientPtr client)
 {
-    register char n;
     REQUEST(xRotatePropertiesReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xRotatePropertiesReq);
-    swapl(&stuff->window, n);
-    swaps(&stuff->nAtoms, n);
-    swaps(&stuff->nPositions, n);
+    swapl(&stuff->window);
+    swaps(&stuff->nAtoms);
+    swaps(&stuff->nPositions);
     SwapRestL(stuff);
     return ((* ProcVector[X_RotateProperties])(client));
 }
@@ -1086,19 +1007,16 @@ int SProcRotateProperties (register ClientPtr client)
 int
 SProcNoOperation(register ClientPtr client)
 {
-    register char n;
     REQUEST(xReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return ((* ProcVector[X_NoOperation])(client));
 }
 
 void
 SwapConnClientPrefix(xConnClientPrefix *pCCP)
 {
-    register char n;
-
-    swaps(&pCCP->majorVersion, n);
-    swaps(&pCCP->minorVersion, n);
-    swaps(&pCCP->nbytesAuthProto, n);
-    swaps(&pCCP->nbytesAuthString, n);
+    swaps(&pCCP->majorVersion);
+    swaps(&pCCP->minorVersion);
+    swaps(&pCCP->nbytesAuthProto);
+    swaps(&pCCP->nbytesAuthString);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -131,7 +131,6 @@ ProcRenderQueryVersion (ClientPtr client)
 {
     RenderClientPtr pRenderClient = GetRenderClient (client);
     xRenderQueryVersionReply rep;
-    register int n;
     REQUEST(xRenderQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRenderQueryVersionReq);
@@ -146,10 +145,10 @@ ProcRenderQueryVersion (ClientPtr client)
     rep.majorVersion = nxagentRenderVersionMajor;
     rep.minorVersion = nxagentRenderVersionMinor;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swapl(&rep.majorVersion, n);
-	swapl(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.majorVersion);
+	swapl(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xRenderQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -176,7 +175,6 @@ ProcRenderQueryPictFormats (ClientPtr client)
     int				    nvisual;
     int				    rlength;
     int				    s;
-    int				    n;
     int				    numScreens;
     int				    numSubpixel;
 
@@ -266,16 +264,16 @@ ProcRenderQueryPictFormats (ClientPtr client)
 		    pictForm->colormap = None;
 		if (client->swapped)
 		{
-		    swapl (&pictForm->id, n);
-		    swaps (&pictForm->direct.red, n);
-		    swaps (&pictForm->direct.redMask, n);
-		    swaps (&pictForm->direct.green, n);
-		    swaps (&pictForm->direct.greenMask, n);
-		    swaps (&pictForm->direct.blue, n);
-		    swaps (&pictForm->direct.blueMask, n);
-		    swaps (&pictForm->direct.alpha, n);
-		    swaps (&pictForm->direct.alphaMask, n);
-		    swapl (&pictForm->colormap, n);
+		    swapl (&pictForm->id);
+		    swaps (&pictForm->direct.red);
+		    swaps (&pictForm->direct.redMask);
+		    swaps (&pictForm->direct.green);
+		    swaps (&pictForm->direct.greenMask);
+		    swaps (&pictForm->direct.blue);
+		    swaps (&pictForm->direct.blueMask);
+		    swaps (&pictForm->direct.alpha);
+		    swaps (&pictForm->direct.alphaMask);
+		    swapl (&pictForm->colormap);
 		}
 		pictForm++;
 	    }
@@ -305,8 +303,8 @@ ProcRenderQueryPictFormats (ClientPtr client)
 		    pictVisual->format = pFormat->id;
 		    if (client->swapped)
 		    {
-			swapl (&pictVisual->visual, n);
-			swapl (&pictVisual->format, n);
+			swapl (&pictVisual->visual);
+			swapl (&pictVisual->format);
 		    }
 		    pictVisual++;
 		    nvisual++;
@@ -316,7 +314,7 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    pictDepth->nPictVisuals = nvisual;
 	    if (client->swapped)
 	    {
-		swaps (&pictDepth->nPictVisuals, n);
+		swaps (&pictDepth->nPictVisuals);
 	    }
 	    ndepth++;
 	    pictDepth = (xPictDepth *) pictVisual;
@@ -329,8 +327,8 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    pictScreen->fallback = 0;
 	if (client->swapped)
 	{
-	    swapl (&pictScreen->nDepth, n);
-	    swapl (&pictScreen->fallback, n);
+	    swapl (&pictScreen->nDepth);
+	    swapl (&pictScreen->fallback);
 	}
 	pictScreen = (xPictScreen *) pictDepth;
     }
@@ -346,20 +344,20 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    *pictSubpixel = SubPixelUnknown;
 	if (client->swapped)
 	{
-	    swapl (pictSubpixel, n);
+	    swapl (pictSubpixel);
 	}
 	++pictSubpixel;
     }
     
     if (client->swapped)
     {
-	swaps (&reply->sequenceNumber, n);
-	swapl (&reply->length, n);
-	swapl (&reply->numFormats, n);
-	swapl (&reply->numScreens, n);
-	swapl (&reply->numDepths, n);
-	swapl (&reply->numVisuals, n);
-	swapl (&reply->numSubpixel, n);
+	swaps (&reply->sequenceNumber);
+	swapl (&reply->length);
+	swapl (&reply->numFormats);
+	swapl (&reply->numScreens);
+	swapl (&reply->numDepths);
+	swapl (&reply->numVisuals);
+	swapl (&reply->numSubpixel);
     }
     WriteToClient(client, rlength, (char *) reply);
     free (reply);

--- a/nx-X11/programs/Xserver/include/misc.h
+++ b/nx-X11/programs/Xserver/include/misc.h
@@ -277,32 +277,107 @@ version_compare(uint32_t a_major, uint32_t a_minor,
 #define SwapRestL(stuff) \
     SwapLongs((CARD32 *)(stuff + 1), LengthRestL(stuff))
 
-/* byte swap a 32-bit value */
-#define swapl(x, n) { \
-		 n = ((char *) (x))[0];\
-		 ((char *) (x))[0] = ((char *) (x))[3];\
-		 ((char *) (x))[3] = n;\
-		 n = ((char *) (x))[1];\
-		 ((char *) (x))[1] = ((char *) (x))[2];\
-		 ((char *) (x))[2] = n; }
+#if defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+void __attribute__ ((error("wrong sized variable passed to swap")))
+wrong_size(void);
+#else
+static inline void
+wrong_size(void)
+{
+}
+#endif
 
-/* byte swap a short */
-#define swaps(x, n) { \
-		 n = ((char *) (x))[0];\
-		 ((char *) (x))[0] = ((char *) (x))[1];\
-		 ((char *) (x))[1] = n; }
+#if !(defined(__GNUC__) || (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)))
+static inline int
+__builtin_constant_p(int x)
+{
+    return 0;
+}
+#endif
+
+/* byte swap a 64-bit value */
+static inline void
+swap_uint64(uint64_t *x)
+{
+    char n;
+
+    n = ((char *) x)[0];
+    ((char *) x)[0] = ((char *) x)[7];
+    ((char *) x)[7] = n;
+
+    n = ((char *) x)[1];
+    ((char *) x)[1] = ((char *) x)[6];
+    ((char *) x)[6] = n;
+
+    n = ((char *) x)[2];
+    ((char *) x)[2] = ((char *) x)[5];
+    ((char *) x)[5] = n;
+
+    n = ((char *) x)[3];
+    ((char *) x)[3] = ((char *) x)[4];
+    ((char *) x)[4] = n;
+}
+
+#define swapll(x) do { \
+	if (sizeof(*(x)) != 8) \
+	    wrong_size(); \
+                swap_uint64((uint64_t *)(x));   \
+    } while (0)
+
+/* byte swap a 32-bit value */
+static inline void
+swap_uint32(uint32_t * x)
+{
+    char n = ((char *) x)[0];
+
+    ((char *) x)[0] = ((char *) x)[3];
+    ((char *) x)[3] = n;
+    n = ((char *) x)[1];
+    ((char *) x)[1] = ((char *) x)[2];
+    ((char *) x)[2] = n;
+}
+
+#define swapl(x) do { \
+	if (sizeof(*(x)) != 4) \
+	    wrong_size(); \
+	if (__builtin_constant_p((uintptr_t)(x) & 3) && ((uintptr_t)(x) & 3) == 0) \
+	    *(x) = lswapl(*(x)); \
+	else \
+	    swap_uint32((uint32_t *)(x)); \
+    } while (0)
+
+/* byte swap a 16-bit value */
+static inline void
+swap_uint16(uint16_t * x)
+{
+    char n = ((char *) x)[0];
+
+    ((char *) x)[0] = ((char *) x)[1];
+    ((char *) x)[1] = n;
+}
+
+#define swaps(x) do { \
+	if (sizeof(*(x)) != 2) \
+	    wrong_size(); \
+	if (__builtin_constant_p((uintptr_t)(x) & 1) && ((uintptr_t)(x) & 1) == 0) \
+	    *(x) = lswaps(*(x)); \
+	else \
+	    swap_uint16((uint16_t *)(x)); \
+    } while (0)
 
 /* copy 32-bit value from src to dst byteswapping on the way */
-#define cpswapl(src, dst) { \
-                 ((char *)&(dst))[0] = ((char *) &(src))[3];\
-                 ((char *)&(dst))[1] = ((char *) &(src))[2];\
-                 ((char *)&(dst))[2] = ((char *) &(src))[1];\
-                 ((char *)&(dst))[3] = ((char *) &(src))[0]; }
+#define cpswapl(src, dst) do { \
+	if (sizeof((src)) != 4 || sizeof((dst)) != 4) \
+	    wrong_size(); \
+	(dst) = lswapl((src)); \
+    } while (0)
 
 /* copy short from src to dst byteswapping on the way */
-#define cpswaps(src, dst) { \
-		 ((char *) &(dst))[0] = ((char *) &(src))[1];\
-		 ((char *) &(dst))[1] = ((char *) &(src))[0]; }
+#define cpswaps(src, dst) do { \
+	if (sizeof((src)) != 2 || sizeof((dst)) != 2) \
+	    wrong_size(); \
+	(dst) = lswaps((src)); \
+    } while (0)
 
 extern void SwapLongs(
     CARD32 *list,

--- a/nx-X11/programs/Xserver/os/connection.c
+++ b/nx-X11/programs/Xserver/os/connection.c
@@ -933,9 +933,9 @@ ErrorConnMax(XtransConnInfo trans_conn)
 	if (((*(char *) &whichbyte) && (byteOrder == 'B')) ||
 	    (!(*(char *) &whichbyte) && (byteOrder == 'l')))
 	{
-	    swaps(&csp.majorVersion, whichbyte);
-	    swaps(&csp.minorVersion, whichbyte);
-	    swaps(&csp.length, whichbyte);
+	    swaps(&csp.majorVersion);
+	    swaps(&csp.minorVersion);
+	    swaps(&csp.length);
 	}
 	iov[0].iov_len = sz_xConnSetupPrefix;
 	iov[0].iov_base = (char *) &csp;

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -591,8 +591,7 @@ ResetCurrentRequest(ClientPtr client)
 	    ((xBigReq *)oci->bufptr)->length = client->req_len;
 	    if (client->swapped)
 	    {
-		char n;
-		swapl(&((xBigReq *)oci->bufptr)->length, n);
+		swapl(&((xBigReq *)oci->bufptr)->length);
 	    }
 	}
 #endif
@@ -948,11 +947,10 @@ WriteToClient (ClientPtr who, int count, char *buf)
         { /* start of new reply */
 	    CARD32 replylen;
 	    unsigned long bytesleft;
-	    char n;
 
 	    replylen = ((xGenericReply *)buf)->length;
 	    if (who->swapped)
-		swapl(&replylen, n);
+		swapl(&replylen);
 	    bytesleft = (replylen * 4) + SIZEOF(xReply) - count - padBytes;
 	    replyinfo.startOfReply = TRUE;
 	    replyinfo.bytesRemaining = who->replyBytesRemaining = bytesleft;

--- a/nx-X11/programs/Xserver/randr/rrcrtc.c
+++ b/nx-X11/programs/Xserver/randr/rrcrtc.c
@@ -997,7 +997,6 @@ ProcRRGetCrtcInfo(ClientPtr client)
     int i, j, k;
     int width, height;
     BoxRec panned_area;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetCrtcInfoReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1060,7 +1059,7 @@ ProcRRGetCrtcInfo(ClientPtr client)
     for (i = 0; i < crtc->numOutputs; i++) {
         outputs[i] = crtc->outputs[i]->id;
         if (client->swapped)
-            swapl(&outputs[i], n);
+            swapl(&outputs[i]);
     }
     k = 0;
     for (i = 0; i < pScrPriv->numOutputs; i++)
@@ -1068,23 +1067,23 @@ ProcRRGetCrtcInfo(ClientPtr client)
             if (pScrPriv->outputs[i]->crtcs[j] == crtc) {
                 possible[k] = pScrPriv->outputs[i]->id;
                 if (client->swapped)
-                    swapl(&possible[k], n);
+                    swapl(&possible[k]);
                 k++;
             }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swaps(&rep.x, n);
-        swaps(&rep.y, n);
-        swaps(&rep.width, n);
-        swaps(&rep.height, n);
-        swapl(&rep.mode, n);
-        swaps(&rep.rotation, n);
-        swaps(&rep.rotations, n);
-        swaps(&rep.nOutput, n);
-        swaps(&rep.nPossibleOutput, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swaps(&rep.x);
+        swaps(&rep.y);
+        swaps(&rep.width);
+        swaps(&rep.height);
+        swapl(&rep.mode);
+        swaps(&rep.rotation);
+        swaps(&rep.rotations);
+        swaps(&rep.nOutput);
+        swaps(&rep.nPossibleOutput);
     }
     WriteToClient(client, sizeof(xRRGetCrtcInfoReply), (char *) &rep);
     if (extraLen) {
@@ -1115,7 +1114,6 @@ ProcRRSetCrtcConfig(ClientPtr client)
 #endif
      i, j;
     CARD8 status;
-    int n;
 
     REQUEST_AT_LEAST_SIZE(xRRSetCrtcConfigReq);
     numOutputs = (stuff->length - bytes_to_int32(SIZEOF(xRRSetCrtcConfigReq)));
@@ -1314,9 +1312,9 @@ ProcRRSetCrtcConfig(ClientPtr client)
         .newTimestamp = pScrPriv->lastSetTime.milliseconds
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.newTimestamp, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.newTimestamp);
     }
     WriteToClient(client, sizeof(xRRSetCrtcConfigReply), (char *) &rep);
 
@@ -1334,7 +1332,6 @@ ProcRRGetPanning(ClientPtr client)
     BoxRec total;
     BoxRec tracking;
     INT16 border[4];
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1372,21 +1369,21 @@ ProcRRGetPanning(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swaps(&rep.left, n);
-        swaps(&rep.top, n);
-        swaps(&rep.width, n);
-        swaps(&rep.height, n);
-        swaps(&rep.track_left, n);
-        swaps(&rep.track_top, n);
-        swaps(&rep.track_width, n);
-        swaps(&rep.track_height, n);
-        swaps(&rep.border_left, n);
-        swaps(&rep.border_top, n);
-        swaps(&rep.border_right, n);
-        swaps(&rep.border_bottom, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swaps(&rep.left);
+        swaps(&rep.top);
+        swaps(&rep.width);
+        swaps(&rep.height);
+        swaps(&rep.track_left);
+        swaps(&rep.track_top);
+        swaps(&rep.track_width);
+        swaps(&rep.track_height);
+        swaps(&rep.border_left);
+        swaps(&rep.border_top);
+        swaps(&rep.border_right);
+        swaps(&rep.border_bottom);
     }
     WriteToClient(client, sizeof(xRRGetPanningReply), (char *) &rep);
     return Success;
@@ -1405,7 +1402,6 @@ ProcRRSetPanning(ClientPtr client)
     BoxRec tracking;
     INT16 border[4];
     CARD8 status;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRSetPanningReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1456,9 +1452,9 @@ ProcRRSetPanning(ClientPtr client)
         .newTimestamp = pScrPriv->lastSetTime.milliseconds
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.newTimestamp, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.newTimestamp);
     }
     WriteToClient(client, sizeof(xRRSetPanningReply), (char *) &rep);
     return Success;
@@ -1470,7 +1466,6 @@ ProcRRGetCrtcGammaSize(ClientPtr client)
     REQUEST(xRRGetCrtcGammaSizeReq);
     xRRGetCrtcGammaSizeReply reply;
     RRCrtcPtr crtc;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaSizeReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1486,9 +1481,9 @@ ProcRRGetCrtcGammaSize(ClientPtr client)
         .size = crtc->gammaSize
     };
     if (client->swapped) {
-        swaps(&reply.sequenceNumber, n);
-        swapl(&reply.length, n);
-        swaps(&reply.size, n);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swaps(&reply.size);
     }
     WriteToClient(client, sizeof(xRRGetCrtcGammaSizeReply), (char *) &reply);
     return Success;
@@ -1502,7 +1497,6 @@ ProcRRGetCrtcGamma(ClientPtr client)
     RRCrtcPtr crtc;
     unsigned long len;
     char *extra = NULL;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1526,9 +1520,9 @@ ProcRRGetCrtcGamma(ClientPtr client)
         .size = crtc->gammaSize
     };
     if (client->swapped) {
-        swaps(&reply.sequenceNumber, n);
-        swapl(&reply.length, n);
-        swaps(&reply.size, n);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swaps(&reply.size);
     }
     WriteToClient(client, sizeof(xRRGetCrtcGammaReply), (char *) &reply);
     if (crtc->gammaSize) {
@@ -1620,7 +1614,6 @@ transform_filter_encode(ClientPtr client, char *output,
                         CARD16 *nparamsFilter, RRTransformPtr transform)
 {
     int nbytes, nparams;
-    int n;
 
     if (transform->filter == NULL) {
         *nbytesFilter = 0;
@@ -1636,8 +1629,8 @@ transform_filter_encode(ClientPtr client, char *output,
         output[nbytes++] = 0;
     memcpy(output + nbytes, transform->params, nparams * sizeof(xFixed));
     if (client->swapped) {
-        swaps(nbytesFilter, n);
-        swaps(nparamsFilter, n);
+        swaps(nbytesFilter);
+        swaps(nparamsFilter);
         SwapLongs((CARD32 *) (output + nbytes), nparams);
     }
     nbytes += nparams * sizeof(xFixed);
@@ -1662,7 +1655,6 @@ ProcRRGetCrtcTransform(ClientPtr client)
     int nextra;
     RRTransformPtr current, pending;
     char *extra;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetCrtcTransformReq);
     VERIFY_RR_CRTC(stuff->crtc, crtc, DixReadAccess);
@@ -1695,8 +1687,8 @@ ProcRRGetCrtcTransform(ClientPtr client)
                                      &reply->currentNparamsFilter, current);
 
     if (client->swapped) {
-        swaps(&reply->sequenceNumber, n);
-        swapl(&reply->length, n);
+        swaps(&reply->sequenceNumber);
+        swapl(&reply->length);
     }
     WriteToClient(client, sizeof(xRRGetCrtcTransformReply) + nextra,
                   (char *) reply);

--- a/nx-X11/programs/Xserver/randr/rrdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrdispatch.c
@@ -35,8 +35,6 @@ RRClientKnowsRates(ClientPtr pClient)
 static int
 ProcRRQueryVersion(ClientPtr client)
 {
-    int n;
-
     xRRQueryVersionReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
@@ -61,10 +59,10 @@ ProcRRQueryVersion(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.majorVersion, n);
-        swapl(&rep.minorVersion, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.majorVersion);
+        swapl(&rep.minorVersion);
     }
 #ifndef NXAGENT_SERVER
     WriteToClient(client, sizeof(xRRQueryVersionReply), &rep);

--- a/nx-X11/programs/Xserver/randr/rrmode.c
+++ b/nx-X11/programs/Xserver/randr/rrmode.c
@@ -344,7 +344,6 @@ ProcRRCreateMode(ClientPtr client)
     char *name;
     int error, rc;
     RRModePtr mode;
-    int n;
 
     REQUEST_AT_LEAST_SIZE(xRRCreateModeReq);
 #ifndef NXAGENT_SERVER
@@ -377,9 +376,9 @@ ProcRRCreateMode(ClientPtr client)
         .mode = mode->mode.id
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.mode, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.mode);
     }
     WriteToClient(client, sizeof(xRRCreateModeReply), (char *) &rep);
     /* Drop out reference to this mode */

--- a/nx-X11/programs/Xserver/randr/rrmonitor.c
+++ b/nx-X11/programs/Xserver/randr/rrmonitor.c
@@ -629,7 +629,7 @@ ProcRRGetMonitors(ClientPtr client)
     RRMonitorPtr monitors;
     int nmonitors;
     int noutputs;
-    int m, n;
+    int m;
     Bool get_active;
 
     REQUEST_SIZE_MATCH(xRRGetMonitorsReq);
@@ -661,11 +661,11 @@ ProcRRGetMonitors(ClientPtr client)
     rep.noutputs = noutputs;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swapl(&rep.nmonitors, n);
-        swapl(&rep.noutputs, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swapl(&rep.nmonitors);
+        swapl(&rep.noutputs);
     }
     WriteToClient(client, sizeof(xRRGetMonitorsReply), (char *) &rep);
 
@@ -686,14 +686,14 @@ ProcRRGetMonitors(ClientPtr client)
             .heightInMillimeters = monitor->geometry.mmHeight,
         };
         if (client->swapped) {
-            swapl(&info.name, n);
-            swaps(&info.noutput, n);
-            swaps(&info.x, n);
-            swaps(&info.y, n);
-            swaps(&info.width, n);
-            swaps(&info.height, n);
-            swapl(&info.widthInMillimeters, n);
-            swapl(&info.heightInMillimeters, n);
+            swapl(&info.name);
+            swaps(&info.noutput);
+            swaps(&info.x);
+            swaps(&info.y);
+            swaps(&info.width);
+            swaps(&info.height);
+            swapl(&info.widthInMillimeters);
+            swapl(&info.heightInMillimeters);
         }
 
         WriteToClient(client, sizeof(xRRMonitorInfo), (char *) &info);

--- a/nx-X11/programs/Xserver/randr/rroutput.c
+++ b/nx-X11/programs/Xserver/randr/rroutput.c
@@ -463,7 +463,6 @@ ProcRRGetOutputInfo(ClientPtr client)
     RROutput *clones;
     char *name;
     int i;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetOutputInfoReq);
     VERIFY_RR_OUTPUT(stuff->output, output, DixReadAccess);
@@ -509,7 +508,7 @@ ProcRRGetOutputInfo(ClientPtr client)
     for (i = 0; i < output->numCrtcs; i++) {
         crtcs[i] = output->crtcs[i]->id;
         if (client->swapped)
-            swapl(&crtcs[i], n);
+            swapl(&crtcs[i]);
     }
     for (i = 0; i < output->numModes + output->numUserModes; i++) {
         if (i < output->numModes)
@@ -517,26 +516,26 @@ ProcRRGetOutputInfo(ClientPtr client)
         else
             modes[i] = output->userModes[i - output->numModes]->mode.id;
         if (client->swapped)
-            swapl(&modes[i], n);
+            swapl(&modes[i]);
     }
     for (i = 0; i < output->numClones; i++) {
         clones[i] = output->clones[i]->id;
         if (client->swapped)
-            swapl(&clones[i], n);
+            swapl(&clones[i]);
     }
     memcpy(name, output->name, output->nameLength);
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swapl(&rep.crtc, n);
-        swapl(&rep.mmWidth, n);
-        swapl(&rep.mmHeight, n);
-        swaps(&rep.nCrtcs, n);
-        swaps(&rep.nModes, n);
-        swaps(&rep.nPreferred, n);
-        swaps(&rep.nClones, n);
-        swaps(&rep.nameLength, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swapl(&rep.crtc);
+        swapl(&rep.mmWidth);
+        swapl(&rep.mmHeight);
+        swaps(&rep.nCrtcs);
+        swaps(&rep.nModes);
+        swaps(&rep.nPreferred);
+        swaps(&rep.nClones);
+        swaps(&rep.nameLength);
     }
     WriteToClient(client, sizeof(xRRGetOutputInfoReply), (char *) &rep);
     if (extraLen) {
@@ -639,7 +638,6 @@ ProcRRGetOutputPrimary(ClientPtr client)
     xRRGetOutputPrimaryReply rep;
     RROutputPtr primary = NULL;
     int rc;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetOutputPrimaryReq);
 
@@ -663,8 +661,8 @@ ProcRRGetOutputPrimary(ClientPtr client)
         .output = primary ? primary->id : None
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.output, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.output);
     }
 
     WriteToClient(client, sizeof(xRRGetOutputPrimaryReply), (char *) &rep);

--- a/nx-X11/programs/Xserver/randr/rrproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproperty.c
@@ -405,7 +405,6 @@ ProcRRListOutputProperties(ClientPtr client)
     int numProps = 0;
     RROutputPtr output;
     RRPropertyPtr prop;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRListOutputPropertiesReq);
 
@@ -428,9 +427,9 @@ ProcRRListOutputProperties(ClientPtr client)
         .nAtoms = numProps
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swaps(&rep.nAtoms, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.nAtoms);
     }
     WriteToClient(client, sizeof(xRRListOutputPropertiesReply), (char *) &rep);
 
@@ -455,7 +454,6 @@ ProcRRQueryOutputProperty(ClientPtr client)
     RROutputPtr output;
     RRPropertyPtr prop;
     char *extra = NULL;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRQueryOutputPropertyReq);
 
@@ -484,8 +482,8 @@ ProcRRQueryOutputProperty(ClientPtr client)
         .immutable = prop->immutable
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
     }
     WriteToClient(client, sizeof(xRRQueryOutputPropertyReply), (char *) &rep);
     if (prop->num_valid) {
@@ -609,7 +607,6 @@ ProcRRGetOutputProperty(ClientPtr client)
     RROutputPtr output;
     xRRGetOutputPropertyReply reply;
     char *extra = NULL;
-    int m;
 
     REQUEST_SIZE_MATCH(xRRGetOutputPropertyReq);
     if (stuff->delete)
@@ -645,11 +642,11 @@ ProcRRGetOutputProperty(ClientPtr client)
         reply.propertyType = None;
         reply.format = 0;
         if (client->swapped) {
-            swaps(&reply.sequenceNumber, m);
-            swapl(&reply.length, m);
-            swapl(&reply.propertyType, m);
-            swapl(&reply.bytesAfter, m);
-            swapl(&reply.nItems, m);
+            swaps(&reply.sequenceNumber);
+            swapl(&reply.length);
+            swapl(&reply.propertyType);
+            swapl(&reply.bytesAfter);
+            swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetOutputPropertyReply),
                       (char *) &reply);
@@ -674,11 +671,11 @@ ProcRRGetOutputProperty(ClientPtr client)
         reply.nItems = 0;
         reply.propertyType = prop_value->type;
         if (client->swapped) {
-            swaps(&reply.sequenceNumber, n);
-            swapl(&reply.length, n);
-            swapl(&reply.propertyType, n);
-            swapl(&reply.bytesAfter, n);
-            swapl(&reply.nItems, n);
+            swaps(&reply.sequenceNumber);
+            swapl(&reply.length);
+            swapl(&reply.propertyType);
+            swapl(&reply.bytesAfter);
+            swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetOutputPropertyReply),
                       (char *) &reply);
@@ -728,11 +725,11 @@ ProcRRGetOutputProperty(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&reply.sequenceNumber, n);
-        swapl(&reply.length, n);
-        swapl(&reply.propertyType, n);
-        swapl(&reply.bytesAfter, n);
-        swapl(&reply.nItems, n);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swapl(&reply.propertyType);
+        swapl(&reply.bytesAfter);
+        swapl(&reply.nItems);
     }
     WriteToClient(client, sizeof(xGenericReply), (char *) &reply);
     if (len) {

--- a/nx-X11/programs/Xserver/randr/rrprovider.c
+++ b/nx-X11/programs/Xserver/randr/rrprovider.c
@@ -43,7 +43,7 @@ RRProviderInitErrorValue(void)
     if (pScrPriv->provider) {                                   \
         providers[count_providers] = pScrPriv->provider->id;    \
         if (client->swapped)                                    \
-            swapl(&providers[count_providers], n);                 \
+            swapl(&providers[count_providers]);                 \
         count_providers++;                                      \
     }                                                           \
     } while(0)
@@ -64,7 +64,6 @@ ProcRRGetProviders(ClientPtr client)
 #ifndef NXAGENT_SERVER
     ScreenPtr iter;
 #endif
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetProvidersReq);
 #ifndef NXAGENT_SERVER
@@ -143,10 +142,10 @@ ProcRRGetProviders(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swaps(&rep.nProviders, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swaps(&rep.nProviders);
     }
     WriteToClient(client, sizeof(xRRGetProvidersReply), (char *) &rep);
     if (extraLen)
@@ -179,7 +178,6 @@ ProcRRGetProviderInfo(ClientPtr client)
 #endif
     RRProvider *providers;
     uint32_t *prov_cap;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetProviderInfoReq);
     VERIFY_RR_PROVIDER(stuff->provider, provider, DixReadAccess);
@@ -233,31 +231,31 @@ ProcRRGetProviderInfo(ClientPtr client)
     for (i = 0; i < pScrPriv->numCrtcs; i++) {
         crtcs[i] = pScrPriv->crtcs[i]->id;
         if (client->swapped)
-            swapl(&crtcs[i], n);
+            swapl(&crtcs[i]);
     }
 
     for (i = 0; i < pScrPriv->numOutputs; i++) {
         outputs[i] = pScrPriv->outputs[i]->id;
         if (client->swapped)
-            swapl(&outputs[i], n);
+            swapl(&outputs[i]);
     }
 
     i = 0;
     if (provider->offload_sink) {
         providers[i] = provider->offload_sink->id;
         if (client->swapped)
-            swapl(&providers[i], n);
+            swapl(&providers[i]);
         prov_cap[i] = RR_Capability_SinkOffload;
         if (client->swapped)
-            swapl(&prov_cap[i], n);
+            swapl(&prov_cap[i]);
         i++;
     }
     if (provider->output_source) {
         providers[i] = provider->output_source->id;
         if (client->swapped)
-            swapl(&providers[i], n);
+            swapl(&providers[i]);
         prov_cap[i] = RR_Capability_SourceOutput;
-        swapl(&prov_cap[i], n);
+        swapl(&prov_cap[i]);
         i++;
     }
 #ifndef NXAGENT_SERVER
@@ -284,12 +282,12 @@ ProcRRGetProviderInfo(ClientPtr client)
 #endif
     memcpy(name, provider->name, rep.nameLength);
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.capabilities, n);
-        swaps(&rep.nCrtcs, n);
-        swaps(&rep.nOutputs, n);
-        swaps(&rep.nameLength, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.capabilities);
+        swaps(&rep.nCrtcs);
+        swaps(&rep.nOutputs);
+        swaps(&rep.nameLength);
     }
     WriteToClient(client, sizeof(xRRGetProviderInfoReply), (char *) &rep);
     if (extraLen)

--- a/nx-X11/programs/Xserver/randr/rrproviderproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproviderproperty.c
@@ -401,7 +401,6 @@ ProcRRListProviderProperties(ClientPtr client)
     int numProps = 0;
     RRProviderPtr provider;
     RRPropertyPtr prop;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRListProviderPropertiesReq);
 
@@ -424,9 +423,9 @@ ProcRRListProviderProperties(ClientPtr client)
         .nAtoms = numProps
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swaps(&rep.nAtoms, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.nAtoms);
     }
     temppAtoms = pAtoms;
     for (prop = provider->properties; prop; prop = prop->next)
@@ -450,7 +449,6 @@ ProcRRQueryProviderProperty(ClientPtr client)
     RRProviderPtr provider;
     RRPropertyPtr prop;
     char *extra = NULL;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRQueryProviderPropertyReq);
 
@@ -478,8 +476,8 @@ ProcRRQueryProviderProperty(ClientPtr client)
         .immutable = prop->immutable
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
     }
     WriteToClient(client, sizeof(xRRQueryProviderPropertyReply), (char *) &rep);
     if (prop->num_valid) {
@@ -637,11 +635,11 @@ ProcRRGetProviderProperty(ClientPtr client)
         reply.propertyType = None;
         reply.format = 0;
         if (client->swapped) {
-            swaps(&reply.sequenceNumber, n);
-            swapl(&reply.length, n);
-            swapl(&reply.propertyType, n);
-            swapl(&reply.bytesAfter, n);
-            swapl(&reply.nItems, n);
+            swaps(&reply.sequenceNumber);
+            swapl(&reply.length);
+            swapl(&reply.propertyType);
+            swapl(&reply.bytesAfter);
+            swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetProviderPropertyReply),
                       (char *) &reply);
@@ -666,11 +664,11 @@ ProcRRGetProviderProperty(ClientPtr client)
         reply.nItems = 0;
         reply.propertyType = prop_value->type;
         if (client->swapped) {
-            swaps(&reply.sequenceNumber, n);
-            swapl(&reply.length, n);
-            swapl(&reply.propertyType, n);
-            swapl(&reply.bytesAfter, n);
-            swapl(&reply.nItems, n);
+            swaps(&reply.sequenceNumber);
+            swapl(&reply.length);
+            swapl(&reply.propertyType);
+            swapl(&reply.bytesAfter);
+            swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetProviderPropertyReply),
                       (char *) &reply);
@@ -720,11 +718,11 @@ ProcRRGetProviderProperty(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&reply.sequenceNumber, n);
-        swapl(&reply.length, n);
-        swapl(&reply.propertyType, n);
-        swapl(&reply.bytesAfter, n);
-        swapl(&reply.nItems, n);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swapl(&reply.propertyType);
+        swapl(&reply.bytesAfter);
+        swapl(&reply.nItems);
     }
     WriteToClient(client, sizeof(xGenericReply), (char *) &reply);
     if (len) {

--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -212,7 +212,6 @@ ProcRRGetScreenSizeRange(ClientPtr client)
     ScreenPtr pScreen;
     rrScrPrivPtr pScrPriv;
     int rc;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetScreenSizeRangeReq);
 #ifndef NXAGENT_SERVER
@@ -248,12 +247,12 @@ ProcRRGetScreenSizeRange(ClientPtr client)
         rep.maxHeight = rep.minHeight = pScreen->height;
     }
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swaps(&rep.minWidth, n);
-        swaps(&rep.minHeight, n);
-        swaps(&rep.maxWidth, n);
-        swaps(&rep.maxHeight, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.minWidth);
+        swaps(&rep.minHeight);
+        swaps(&rep.maxWidth);
+        swaps(&rep.maxHeight);
     }
     WriteToClient(client, sizeof(xRRGetScreenSizeRangeReply), (char *) &rep);
     return Success;
@@ -340,21 +339,19 @@ ProcRRSetScreenSize(ClientPtr client)
 static inline void
 swap_modeinfos(xRRModeInfo * modeinfos, int i)
 {
-    int n;
-
-    swapl(&modeinfos[i].id, n);
-    swaps(&modeinfos[i].width, n);
-    swaps(&modeinfos[i].height, n);
-    swapl(&modeinfos[i].dotClock, n);
-    swaps(&modeinfos[i].hSyncStart, n);
-    swaps(&modeinfos[i].hSyncEnd, n);
-    swaps(&modeinfos[i].hTotal, n);
-    swaps(&modeinfos[i].hSkew, n);
-    swaps(&modeinfos[i].vSyncStart, n);
-    swaps(&modeinfos[i].vSyncEnd, n);
-    swaps(&modeinfos[i].vTotal, n);
-    swaps(&modeinfos[i].nameLength, n);
-    swapl(&modeinfos[i].modeFlags, n);
+    swapl(&modeinfos[i].id);
+    swaps(&modeinfos[i].width);
+    swaps(&modeinfos[i].height);
+    swapl(&modeinfos[i].dotClock);
+    swaps(&modeinfos[i].hSyncStart);
+    swaps(&modeinfos[i].hSyncEnd);
+    swaps(&modeinfos[i].hTotal);
+    swaps(&modeinfos[i].hSkew);
+    swaps(&modeinfos[i].vSyncStart);
+    swaps(&modeinfos[i].vSyncEnd);
+    swaps(&modeinfos[i].vTotal);
+    swaps(&modeinfos[i].nameLength);
+    swapl(&modeinfos[i].modeFlags);
 }
 
 #define update_arrays(gpuscreen, pScrPriv, primary_crtc, has_primary) do {            \
@@ -366,13 +363,13 @@ swap_modeinfos(xRRModeInfo * modeinfos, int i)
         }\
         crtcs[crtc_count] = pScrPriv->crtcs[j]->id;        \
         if (client->swapped)                               \
-            swapl(&crtcs[crtc_count], n);                     \
+            swapl(&crtcs[crtc_count]);                     \
         crtc_count++;                                      \
     }                                                      \
     for (j = 0; j < pScrPriv->numOutputs; j++) {           \
         outputs[output_count] = pScrPriv->outputs[j]->id;  \
         if (client->swapped)                               \
-            swapl(&outputs[output_count], n);                 \
+            swapl(&outputs[output_count]);                 \
         output_count++;                                    \
     }                                                      \
     {                                                      \
@@ -412,7 +409,6 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
     xRRModeInfo *modeinfos;
     CARD8 *names;
     int has_primary = 0;
-    int n;
 
     /* we need to iterate all the GPU masters and all their output slaves */
     total_crtcs = 0;
@@ -479,7 +475,7 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
         primary_crtc = pScrPriv->primaryOutput->crtc;
         crtcs[0] = pScrPriv->primaryOutput->crtc->id;
         if (client->swapped)
-            swapl(&crtcs[0], n);
+            swapl(&crtcs[0]);
         crtc_count = 1;
     }
     update_arrays(pScreen, pScrPriv, primary_crtc, has_primary);
@@ -492,14 +488,14 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
 
     assert(bytes_to_int32((char *) names - (char *) extra) == rep.length);
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swapl(&rep.configTimestamp, n);
-        swaps(&rep.nCrtcs, n);
-        swaps(&rep.nOutputs, n);
-        swaps(&rep.nModes, n);
-        swaps(&rep.nbytesNames, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swapl(&rep.configTimestamp);
+        swaps(&rep.nCrtcs);
+        swaps(&rep.nOutputs);
+        swaps(&rep.nModes);
+        swaps(&rep.nbytesNames);
     }
     WriteToClient(client, sizeof(xRRGetScreenResourcesReply), (char *) &rep);
     if (extraLen) {
@@ -525,7 +521,6 @@ rrGetScreenResources(ClientPtr client, Bool query)
     RROutput *outputs;
     xRRModeInfo *modeinfos;
     CARD8 *names;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesReq);
 
@@ -613,7 +608,7 @@ rrGetScreenResources(ClientPtr client, Bool query)
             has_primary = 1;
             crtcs[0] = pScrPriv->primaryOutput->crtc->id;
             if (client->swapped)
-                swapl(&crtcs[0], n);
+                swapl(&crtcs[0]);
         }
 
         for (i = 0; i < pScrPriv->numCrtcs; i++) {
@@ -624,13 +619,13 @@ rrGetScreenResources(ClientPtr client, Bool query)
             }
             crtcs[i + has_primary] = pScrPriv->crtcs[i]->id;
             if (client->swapped)
-                swapl(&crtcs[i + has_primary], n);
+                swapl(&crtcs[i + has_primary]);
         }
 
         for (i = 0; i < pScrPriv->numOutputs; i++) {
             outputs[i] = pScrPriv->outputs[i]->id;
             if (client->swapped)
-                swapl(&outputs[i], n);
+                swapl(&outputs[i]);
         }
 
         for (i = 0; i < num_modes; i++) {
@@ -638,19 +633,19 @@ rrGetScreenResources(ClientPtr client, Bool query)
 
             modeinfos[i] = mode->mode;
             if (client->swapped) {
-                swapl(&modeinfos[i].id, n);
-                swaps(&modeinfos[i].width, n);
-                swaps(&modeinfos[i].height, n);
-                swapl(&modeinfos[i].dotClock, n);
-                swaps(&modeinfos[i].hSyncStart, n);
-                swaps(&modeinfos[i].hSyncEnd, n);
-                swaps(&modeinfos[i].hTotal, n);
-                swaps(&modeinfos[i].hSkew, n);
-                swaps(&modeinfos[i].vSyncStart, n);
-                swaps(&modeinfos[i].vSyncEnd, n);
-                swaps(&modeinfos[i].vTotal, n);
-                swaps(&modeinfos[i].nameLength, n);
-                swapl(&modeinfos[i].modeFlags, n);
+                swapl(&modeinfos[i].id);
+                swaps(&modeinfos[i].width);
+                swaps(&modeinfos[i].height);
+                swapl(&modeinfos[i].dotClock);
+                swaps(&modeinfos[i].hSyncStart);
+                swaps(&modeinfos[i].hSyncEnd);
+                swaps(&modeinfos[i].hTotal);
+                swaps(&modeinfos[i].hSkew);
+                swaps(&modeinfos[i].vSyncStart);
+                swaps(&modeinfos[i].vSyncEnd);
+                swaps(&modeinfos[i].vTotal);
+                swaps(&modeinfos[i].nameLength);
+                swapl(&modeinfos[i].modeFlags);
             }
             memcpy(names, mode->name, mode->mode.nameLength);
             names += mode->mode.nameLength;
@@ -660,14 +655,14 @@ rrGetScreenResources(ClientPtr client, Bool query)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swapl(&rep.configTimestamp, n);
-        swaps(&rep.nCrtcs, n);
-        swaps(&rep.nOutputs, n);
-        swaps(&rep.nModes, n);
-        swaps(&rep.nbytesNames, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swapl(&rep.configTimestamp);
+        swaps(&rep.nCrtcs);
+        swaps(&rep.nOutputs);
+        swaps(&rep.nModes);
+        swaps(&rep.nbytesNames);
     }
     WriteToClient(client, sizeof(xRRGetScreenResourcesReply),
                   (char *) (char *) &rep);
@@ -801,7 +796,6 @@ ProcRRGetScreenInfo(ClientPtr client)
     CARD8 *extra;
     unsigned long extraLen;
     RROutputPtr output;
-    int n;
 
     REQUEST_SIZE_MATCH(xRRGetScreenInfoReq);
 #ifndef NXAGENT_SERVER
@@ -895,22 +889,22 @@ ProcRRGetScreenInfo(ClientPtr client)
             size->widthInMillimeters = pSize->mmWidth;
             size->heightInMillimeters = pSize->mmHeight;
             if (client->swapped) {
-                swaps(&size->widthInPixels, n);
-                swaps(&size->heightInPixels, n);
-                swaps(&size->widthInMillimeters, n);
-                swaps(&size->heightInMillimeters, n);
+                swaps(&size->widthInPixels);
+                swaps(&size->heightInPixels);
+                swaps(&size->widthInMillimeters);
+                swaps(&size->heightInMillimeters);
             }
             size++;
             if (has_rate) {
                 *rates = pSize->nRates;
                 if (client->swapped) {
-                    swaps(rates, n);
+                    swaps(rates);
                 }
                 rates++;
                 for (j = 0; j < pSize->nRates; j++) {
                     *rates = pSize->pRates[j].rate;
                     if (client->swapped) {
-                        swaps(rates, n);
+                        swaps(rates);
                     }
                     rates++;
                 }
@@ -926,15 +920,15 @@ ProcRRGetScreenInfo(ClientPtr client)
         rep.length = bytes_to_int32(extraLen);
     }
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.timestamp, n);
-        swapl(&rep.configTimestamp, n);
-        swaps(&rep.rotation, n);
-        swaps(&rep.nSizes, n);
-        swaps(&rep.sizeID, n);
-        swaps(&rep.rate, n);
-        swaps(&rep.nrateEnts, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.timestamp);
+        swapl(&rep.configTimestamp);
+        swaps(&rep.rotation);
+        swaps(&rep.nSizes);
+        swaps(&rep.sizeID);
+        swaps(&rep.rate);
+        swaps(&rep.nrateEnts);
     }
     WriteToClient(client, sizeof(xRRGetScreenInfoReply), (char *) &rep);
     if (extraLen) {
@@ -965,7 +959,6 @@ ProcRRSetScreenConfig(ClientPtr client)
     RR10DataPtr pData = NULL;
     RRScreenSizePtr pSize;
     int width, height;
-    int n;
 
     UpdateCurrentTime();
 
@@ -1173,11 +1166,11 @@ ProcRRSetScreenConfig(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.newTimestamp, n);
-        swapl(&rep.newConfigTimestamp, n);
-        swapl(&rep.root, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.newTimestamp);
+        swapl(&rep.newConfigTimestamp);
+        swapl(&rep.root);
     }
     WriteToClient(client, sizeof(xRRSetScreenConfigReply), (char *) &rep);
 

--- a/nx-X11/programs/Xserver/randr/rrsdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrsdispatch.c
@@ -25,162 +25,140 @@
 static int
 SProcRRQueryVersion(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRRQueryVersionReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->majorVersion, n);
-    swapl(&stuff->minorVersion, n);
+    swaps(&stuff->length);
+    swapl(&stuff->majorVersion);
+    swapl(&stuff->minorVersion);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetScreenInfo(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetScreenInfoReq);
 
     REQUEST_SIZE_MATCH(xRRGetScreenInfoReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetScreenConfig(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetScreenConfigReq);
 
     if (RRClientKnowsRates(client)) {
         REQUEST_SIZE_MATCH(xRRSetScreenConfigReq);
-        swaps(&stuff->rate, n);
+        swaps(&stuff->rate);
     }
     else {
         REQUEST_SIZE_MATCH(xRR1_0SetScreenConfigReq);
     }
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->timestamp, n);
-    swaps(&stuff->sizeID, n);
-    swaps(&stuff->rotation, n);
+    swaps(&stuff->length);
+    swapl(&stuff->drawable);
+    swapl(&stuff->timestamp);
+    swaps(&stuff->sizeID);
+    swaps(&stuff->rotation);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSelectInput(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSelectInputReq);
 
     REQUEST_SIZE_MATCH(xRRSelectInputReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swaps(&stuff->enable, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swaps(&stuff->enable);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetScreenSizeRange(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetScreenSizeRangeReq);
 
     REQUEST_SIZE_MATCH(xRRGetScreenSizeRangeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetScreenSize(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetScreenSizeReq);
 
     REQUEST_SIZE_MATCH(xRRSetScreenSizeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swapl(&stuff->widthInMillimeters, n);
-    swapl(&stuff->heightInMillimeters, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->widthInMillimeters);
+    swapl(&stuff->heightInMillimeters);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetScreenResources(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetScreenResourcesReq);
 
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetOutputInfo(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetOutputInfoReq);
 
     REQUEST_SIZE_MATCH(xRRGetOutputInfoReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->configTimestamp, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->configTimestamp);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRListOutputProperties(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRListOutputPropertiesReq);
 
     REQUEST_SIZE_MATCH(xRRListOutputPropertiesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRQueryOutputProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRQueryOutputPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRQueryOutputPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->property);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRConfigureOutputProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRConfigureOutputPropertyReq);
 
     REQUEST_AT_LEAST_SIZE(xRRConfigureOutputPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->property);
     SwapRestL(stuff);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
@@ -188,16 +166,14 @@ SProcRRConfigureOutputProperty(ClientPtr client)
 static int
 SProcRRChangeOutputProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRChangeOutputPropertyReq);
 
     REQUEST_AT_LEAST_SIZE(xRRChangeOutputPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->nUnits, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->nUnits);
     switch (stuff->format) {
     case 8:
         break;
@@ -217,134 +193,118 @@ SProcRRChangeOutputProperty(ClientPtr client)
 static int
 SProcRRDeleteOutputProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRDeleteOutputPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRDeleteOutputPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->property);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetOutputProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetOutputPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRGetOutputPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->longOffset, n);
-    swapl(&stuff->longLength, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->longOffset);
+    swapl(&stuff->longLength);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRCreateMode(ClientPtr client)
 {
-    int n;
-
     xRRModeInfo *modeinfo;
 
     REQUEST(xRRCreateModeReq);
 
     REQUEST_AT_LEAST_SIZE(xRRCreateModeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
 
     modeinfo = &stuff->modeInfo;
-    swapl(&modeinfo->id, n);
-    swaps(&modeinfo->width, n);
-    swaps(&modeinfo->height, n);
-    swapl(&modeinfo->dotClock, n);
-    swaps(&modeinfo->hSyncStart, n);
-    swaps(&modeinfo->hSyncEnd, n);
-    swaps(&modeinfo->hTotal, n);
-    swaps(&modeinfo->vSyncStart, n);
-    swaps(&modeinfo->vSyncEnd, n);
-    swaps(&modeinfo->vTotal, n);
-    swaps(&modeinfo->nameLength, n);
-    swapl(&modeinfo->modeFlags, n);
+    swapl(&modeinfo->id);
+    swaps(&modeinfo->width);
+    swaps(&modeinfo->height);
+    swapl(&modeinfo->dotClock);
+    swaps(&modeinfo->hSyncStart);
+    swaps(&modeinfo->hSyncEnd);
+    swaps(&modeinfo->hTotal);
+    swaps(&modeinfo->vSyncStart);
+    swaps(&modeinfo->vSyncEnd);
+    swaps(&modeinfo->vTotal);
+    swaps(&modeinfo->nameLength);
+    swapl(&modeinfo->modeFlags);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRDestroyMode(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRDestroyModeReq);
 
     REQUEST_SIZE_MATCH(xRRDestroyModeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->mode, n);
+    swaps(&stuff->length);
+    swapl(&stuff->mode);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRAddOutputMode(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRAddOutputModeReq);
 
     REQUEST_SIZE_MATCH(xRRAddOutputModeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->mode, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->mode);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRDeleteOutputMode(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRDeleteOutputModeReq);
 
     REQUEST_SIZE_MATCH(xRRDeleteOutputModeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->output, n);
-    swapl(&stuff->mode, n);
+    swaps(&stuff->length);
+    swapl(&stuff->output);
+    swapl(&stuff->mode);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetCrtcInfo(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetCrtcInfoReq);
 
     REQUEST_SIZE_MATCH(xRRGetCrtcInfoReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
-    swapl(&stuff->configTimestamp, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
+    swapl(&stuff->configTimestamp);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetCrtcConfig(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetCrtcConfigReq);
 
     REQUEST_AT_LEAST_SIZE(xRRSetCrtcConfigReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
-    swapl(&stuff->timestamp, n);
-    swapl(&stuff->configTimestamp, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
-    swapl(&stuff->mode, n);
-    swaps(&stuff->rotation, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
+    swapl(&stuff->timestamp);
+    swapl(&stuff->configTimestamp);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swapl(&stuff->mode);
+    swaps(&stuff->rotation);
     SwapRestL(stuff);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
@@ -352,40 +312,34 @@ SProcRRSetCrtcConfig(ClientPtr client)
 static int
 SProcRRGetCrtcGammaSize(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetCrtcGammaSizeReq);
 
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaSizeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetCrtcGamma(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetCrtcGammaReq);
 
     REQUEST_SIZE_MATCH(xRRGetCrtcGammaReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetCrtcGamma(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetCrtcGammaReq);
 
     REQUEST_AT_LEAST_SIZE(xRRSetCrtcGammaReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
-    swaps(&stuff->size, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
+    swaps(&stuff->size);
     SwapRestS(stuff);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
@@ -396,16 +350,15 @@ SProcRRSetCrtcTransform(ClientPtr client)
     int nparams;
     char *filter;
     CARD32 *params;
-    int n;
 
     REQUEST(xRRSetCrtcTransformReq);
 
     REQUEST_AT_LEAST_SIZE(xRRSetCrtcTransformReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
     SwapLongs((CARD32 *) &stuff->transform,
               bytes_to_int32(sizeof(xRenderTransform)));
-    swaps(&stuff->nbytesFilter, n);
+    swaps(&stuff->nbytesFilter);
     filter = (char *) (stuff + 1);
     params = (CARD32 *) (filter + pad_to_int32(stuff->nbytesFilter));
     nparams = ((CARD32 *) stuff + client->req_len) - params;
@@ -419,177 +372,153 @@ SProcRRSetCrtcTransform(ClientPtr client)
 static int
 SProcRRGetCrtcTransform(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetCrtcTransformReq);
 
     REQUEST_SIZE_MATCH(xRRGetCrtcTransformReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRGetPanning(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetPanningReq);
 
     REQUEST_SIZE_MATCH(xRRGetPanningReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetPanning(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetPanningReq);
 
     REQUEST_SIZE_MATCH(xRRSetPanningReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->crtc, n);
-    swapl(&stuff->timestamp, n);
-    swaps(&stuff->left, n);
-    swaps(&stuff->top, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
-    swaps(&stuff->track_left, n);
-    swaps(&stuff->track_top, n);
-    swaps(&stuff->track_width, n);
-    swaps(&stuff->track_height, n);
-    swaps(&stuff->border_left, n);
-    swaps(&stuff->border_top, n);
-    swaps(&stuff->border_right, n);
-    swaps(&stuff->border_bottom, n);
+    swaps(&stuff->length);
+    swapl(&stuff->crtc);
+    swapl(&stuff->timestamp);
+    swaps(&stuff->left);
+    swaps(&stuff->top);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swaps(&stuff->track_left);
+    swaps(&stuff->track_top);
+    swaps(&stuff->track_width);
+    swaps(&stuff->track_height);
+    swaps(&stuff->border_left);
+    swaps(&stuff->border_top);
+    swaps(&stuff->border_right);
+    swaps(&stuff->border_bottom);
     return (*ProcRandrVector[stuff->randrReqType]) (client);
 }
 
 static int
 SProcRRSetOutputPrimary(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetOutputPrimaryReq);
 
     REQUEST_SIZE_MATCH(xRRSetOutputPrimaryReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->output, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swapl(&stuff->output);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRGetOutputPrimary(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetOutputPrimaryReq);
 
     REQUEST_SIZE_MATCH(xRRGetOutputPrimaryReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRGetProviders(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetProvidersReq);
 
     REQUEST_SIZE_MATCH(xRRGetProvidersReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRGetProviderInfo(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetProviderInfoReq);
 
     REQUEST_SIZE_MATCH(xRRGetProviderInfoReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->configTimestamp, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->configTimestamp);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRSetProviderOffloadSink(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetProviderOffloadSinkReq);
 
     REQUEST_SIZE_MATCH(xRRSetProviderOffloadSinkReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->sink_provider, n);
-    swapl(&stuff->configTimestamp, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->sink_provider);
+    swapl(&stuff->configTimestamp);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRSetProviderOutputSource(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetProviderOutputSourceReq);
 
     REQUEST_SIZE_MATCH(xRRSetProviderOutputSourceReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->source_provider, n);
-    swapl(&stuff->configTimestamp, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->source_provider);
+    swapl(&stuff->configTimestamp);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRListProviderProperties(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRListProviderPropertiesReq);
 
     REQUEST_SIZE_MATCH(xRRListProviderPropertiesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRQueryProviderProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRQueryProviderPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRQueryProviderPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->property);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRConfigureProviderProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRConfigureProviderPropertyReq);
 
     REQUEST_AT_LEAST_SIZE(xRRConfigureProviderPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->property);
     /* TODO: no way to specify format? */
     SwapRestL(stuff);
     return ProcRandrVector[stuff->randrReqType] (client);
@@ -598,16 +527,14 @@ SProcRRConfigureProviderProperty(ClientPtr client)
 static int
 SProcRRChangeProviderProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRChangeProviderPropertyReq);
 
     REQUEST_AT_LEAST_SIZE(xRRChangeProviderPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->nUnits, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->nUnits);
     switch (stuff->format) {
     case 8:
         break;
@@ -624,63 +551,55 @@ SProcRRChangeProviderProperty(ClientPtr client)
 static int
 SProcRRDeleteProviderProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRDeleteProviderPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRDeleteProviderPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->property, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->property);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRGetProviderProperty(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetProviderPropertyReq);
 
     REQUEST_SIZE_MATCH(xRRGetProviderPropertyReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->provider, n);
-    swapl(&stuff->property, n);
-    swapl(&stuff->type, n);
-    swapl(&stuff->longOffset, n);
-    swapl(&stuff->longLength, n);
+    swaps(&stuff->length);
+    swapl(&stuff->provider);
+    swapl(&stuff->property);
+    swapl(&stuff->type);
+    swapl(&stuff->longOffset);
+    swapl(&stuff->longLength);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRGetMonitors(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRGetMonitorsReq);
 
     REQUEST_SIZE_MATCH(xRRGetMonitorsReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 
 static int
 SProcRRSetMonitor(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRSetMonitorReq);
 
     REQUEST_AT_LEAST_SIZE(xRRGetMonitorsReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->monitor.name, n);
-    swaps(&stuff->monitor.noutput, n);
-    swaps(&stuff->monitor.x, n);
-    swaps(&stuff->monitor.y, n);
-    swaps(&stuff->monitor.width, n);
-    swaps(&stuff->monitor.height, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swapl(&stuff->monitor.name);
+    swaps(&stuff->monitor.noutput);
+    swaps(&stuff->monitor.x);
+    swaps(&stuff->monitor.y);
+    swaps(&stuff->monitor.width);
+    swaps(&stuff->monitor.height);
     SwapRestL(stuff);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
@@ -688,14 +607,12 @@ SProcRRSetMonitor(ClientPtr client)
 static int
 SProcRRDeleteMonitor(ClientPtr client)
 {
-    int n;
-
     REQUEST(xRRDeleteMonitorReq);
 
     REQUEST_SIZE_MATCH(xRRDeleteMonitorReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->name, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swapl(&stuff->name);
     return ProcRandrVector[stuff->randrReqType] (client);
 }
 

--- a/nx-X11/programs/Xserver/randr/rrxinerama.c
+++ b/nx-X11/programs/Xserver/randr/rrxinerama.c
@@ -108,8 +108,6 @@ extern Bool noRRXineramaExtension;
 int
 ProcRRXineramaQueryVersion(ClientPtr client)
 {
-    int n;
-
     xPanoramiXQueryVersionReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
@@ -120,10 +118,10 @@ ProcRRXineramaQueryVersion(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xPanoramiXQueryVersionReq);
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swaps(&rep.majorVersion, n);
-        swaps(&rep.minorVersion, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.majorVersion);
+        swaps(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xPanoramiXQueryVersionReply), (char *) &rep);
     return Success;
@@ -139,7 +137,6 @@ ProcRRXineramaGetState(ClientPtr client)
     ScreenPtr pScreen;
     rrScrPrivPtr pScrPriv;
     Bool active = FALSE;
-    int n;
 
     REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
 #ifndef NXAGENT_SERVER
@@ -167,9 +164,9 @@ ProcRRXineramaGetState(ClientPtr client)
         .window = stuff->window
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.window, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.window);
     }
     WriteToClient(client, sizeof(xPanoramiXGetStateReply), (char *) &rep);
     return Success;
@@ -194,7 +191,6 @@ ProcRRXineramaGetScreenCount(ClientPtr client)
     WindowPtr pWin;
     xPanoramiXGetScreenCountReply rep;
     register int rc;
-    int n;
 
     REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
 
@@ -215,9 +211,9 @@ ProcRRXineramaGetScreenCount(ClientPtr client)
         .window = stuff->window
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.window, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.window);
     }
     WriteToClient(client, sizeof(xPanoramiXGetScreenCountReply), (char *) &rep);
     return Success;
@@ -231,7 +227,6 @@ ProcRRXineramaGetScreenSize(ClientPtr client)
     ScreenPtr pScreen;
     xPanoramiXGetScreenSizeReply rep;
     register int rc;
-    int n;
 
     REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
 #ifndef NXAGENT_SERVER
@@ -257,12 +252,12 @@ ProcRRXineramaGetScreenSize(ClientPtr client)
         .screen = stuff->screen
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.width, n);
-        swapl(&rep.height, n);
-        swapl(&rep.window, n);
-        swapl(&rep.screen, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.width);
+        swapl(&rep.height);
+        swapl(&rep.window);
+        swapl(&rep.screen);
     }
     WriteToClient(client, sizeof(xPanoramiXGetScreenSizeReply), (char *) &rep);
     return Success;
@@ -272,7 +267,6 @@ int
 ProcRRXineramaIsActive(ClientPtr client)
 {
     xXineramaIsActiveReply rep;
-    int n;
 
     REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
 
@@ -283,9 +277,9 @@ ProcRRXineramaIsActive(ClientPtr client)
         .state = RRXineramaScreenActive(screenInfo.screens[RR_XINERAMA_SCREEN])
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.state, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.state);
     }
     WriteToClient(client, sizeof(xXineramaIsActiveReply), (char *) &rep);
     return Success;
@@ -312,7 +306,6 @@ ProcRRXineramaQueryScreens(ClientPtr client)
     int m;
     RRMonitorPtr monitors = NULL;
     int nmonitors = 0;
-    int n;
 
     REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
 
@@ -329,9 +322,9 @@ ProcRRXineramaQueryScreens(ClientPtr client)
         .number = nmonitors
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber, n);
-        swapl(&rep.length, n);
-        swapl(&rep.number, n);
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.number);
     }
     WriteToClient(client, sizeof(xXineramaQueryScreensReply), (char *) &rep);
 
@@ -370,10 +363,8 @@ ProcRRXineramaDispatch(ClientPtr client)
 static int
 SProcRRXineramaQueryVersion(ClientPtr client)
 {
-    int n;
-
     REQUEST(xPanoramiXQueryVersionReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xPanoramiXQueryVersionReq);
     return ProcRRXineramaQueryVersion(client);
 }
@@ -381,47 +372,39 @@ SProcRRXineramaQueryVersion(ClientPtr client)
 static int
 SProcRRXineramaGetState(ClientPtr client)
 {
-    int n;
-
     REQUEST(xPanoramiXGetStateReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return ProcRRXineramaGetState(client);
 }
 
 static int
 SProcRRXineramaGetScreenCount(ClientPtr client)
 {
-    int n;
-
     REQUEST(xPanoramiXGetScreenCountReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
-    swapl(&stuff->window, n);
+    swapl(&stuff->window);
     return ProcRRXineramaGetScreenCount(client);
 }
 
 static int
 SProcRRXineramaGetScreenSize(ClientPtr client)
 {
-    int n;
-
     REQUEST(xPanoramiXGetScreenSizeReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
-    swapl(&stuff->window, n);
-    swapl(&stuff->screen, n);
+    swapl(&stuff->window);
+    swapl(&stuff->screen);
     return ProcRRXineramaGetScreenSize(client);
 }
 
 static int
 SProcRRXineramaIsActive(ClientPtr client)
 {
-    int n;
-
     REQUEST(xXineramaIsActiveReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
     return ProcRRXineramaIsActive(client);
 }
@@ -429,10 +412,8 @@ SProcRRXineramaIsActive(ClientPtr client)
 static int
 SProcRRXineramaQueryScreens(ClientPtr client)
 {
-    int n;
-
     REQUEST(xXineramaQueryScreensReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
     return ProcRRXineramaQueryScreens(client);
 }

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -283,7 +283,7 @@ ProcRenderQueryVersion (ClientPtr client)
 {
     RenderClientPtr pRenderClient = GetRenderClient (client);
     xRenderQueryVersionReply rep;
-    register int n;
+
     REQUEST(xRenderQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xRenderQueryVersionReq);
@@ -298,10 +298,10 @@ ProcRenderQueryVersion (ClientPtr client)
     rep.majorVersion = SERVER_RENDER_MAJOR_VERSION;
     rep.minorVersion = SERVER_RENDER_MINOR_VERSION;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swapl(&rep.majorVersion, n);
-	swapl(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.majorVersion);
+	swapl(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xRenderQueryVersionReply), (char *)&rep);
     return (client->noClientException);
@@ -456,16 +456,16 @@ ProcRenderQueryPictFormats (ClientPtr client)
 		    pictForm->colormap = None;
 		if (client->swapped)
 		{
-		    swapl (&pictForm->id, n);
-		    swaps (&pictForm->direct.red, n);
-		    swaps (&pictForm->direct.redMask, n);
-		    swaps (&pictForm->direct.green, n);
-		    swaps (&pictForm->direct.greenMask, n);
-		    swaps (&pictForm->direct.blue, n);
-		    swaps (&pictForm->direct.blueMask, n);
-		    swaps (&pictForm->direct.alpha, n);
-		    swaps (&pictForm->direct.alphaMask, n);
-		    swapl (&pictForm->colormap, n);
+		    swapl (&pictForm->id);
+		    swaps (&pictForm->direct.red);
+		    swaps (&pictForm->direct.redMask);
+		    swaps (&pictForm->direct.green);
+		    swaps (&pictForm->direct.greenMask);
+		    swaps (&pictForm->direct.blue);
+		    swaps (&pictForm->direct.blueMask);
+		    swaps (&pictForm->direct.alpha);
+		    swaps (&pictForm->direct.alphaMask);
+		    swapl (&pictForm->colormap);
 		}
 		pictForm++;
 	    }
@@ -495,8 +495,8 @@ ProcRenderQueryPictFormats (ClientPtr client)
 		    pictVisual->format = pFormat->id;
 		    if (client->swapped)
 		    {
-			swapl (&pictVisual->visual, n);
-			swapl (&pictVisual->format, n);
+			swapl (&pictVisual->visual);
+			swapl (&pictVisual->format);
 		    }
 		    pictVisual++;
 		    nvisual++;
@@ -506,7 +506,7 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    pictDepth->nPictVisuals = nvisual;
 	    if (client->swapped)
 	    {
-		swaps (&pictDepth->nPictVisuals, n);
+		swaps (&pictDepth->nPictVisuals);
 	    }
 	    ndepth++;
 	    pictDepth = (xPictDepth *) pictVisual;
@@ -519,8 +519,8 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    pictScreen->fallback = 0;
 	if (client->swapped)
 	{
-	    swapl (&pictScreen->nDepth, n);
-	    swapl (&pictScreen->fallback, n);
+	    swapl (&pictScreen->nDepth);
+	    swapl (&pictScreen->fallback);
 	}
 	pictScreen = (xPictScreen *) pictDepth;
     }
@@ -536,20 +536,20 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	    *pictSubpixel = SubPixelUnknown;
 	if (client->swapped)
 	{
-	    swapl (pictSubpixel, n);
+	    swapl (pictSubpixel);
 	}
 	++pictSubpixel;
     }
     
     if (client->swapped)
     {
-	swaps (&reply->sequenceNumber, n);
-	swapl (&reply->length, n);
-	swapl (&reply->numFormats, n);
-	swapl (&reply->numScreens, n);
-	swapl (&reply->numDepths, n);
-	swapl (&reply->numVisuals, n);
-	swapl (&reply->numSubpixel, n);
+	swaps (&reply->sequenceNumber);
+	swapl (&reply->length);
+	swapl (&reply->numFormats);
+	swapl (&reply->numScreens);
+	swapl (&reply->numDepths);
+	swapl (&reply->numVisuals);
+	swapl (&reply->numSubpixel);
     }
     WriteToClient(client, rlength, (char *) reply);
     free (reply);
@@ -563,7 +563,7 @@ ProcRenderQueryPictIndexValues (ClientPtr client)
     PictFormatPtr   pFormat;
     int		    num;
     int		    rlength;
-    int		    i, n;
+    int		    i;
     REQUEST(xRenderQueryPictIndexValuesReq);
     xRenderQueryPictIndexValuesReply *reply;
     xIndexValue	    *values;
@@ -605,15 +605,15 @@ ProcRenderQueryPictIndexValues (ClientPtr client)
     {
 	for (i = 0; i < num; i++)
 	{
-	    swapl (&values[i].pixel, n);
-	    swaps (&values[i].red, n);
-	    swaps (&values[i].green, n);
-	    swaps (&values[i].blue, n);
-	    swaps (&values[i].alpha, n);
+	    swapl (&values[i].pixel);
+	    swaps (&values[i].red);
+	    swaps (&values[i].green);
+	    swaps (&values[i].blue);
+	    swaps (&values[i].alpha);
 	}
-	swaps (&reply->sequenceNumber, n);
-	swapl (&reply->length, n);
-	swapl (&reply->numIndexValues, n);
+	swaps (&reply->sequenceNumber);
+	swapl (&reply->length);
+	swapl (&reply->numIndexValues);
     }
 
     WriteToClient(client, rlength, (char *) reply);
@@ -1807,16 +1807,14 @@ ProcRenderQueryFilters (ClientPtr client)
 
     if (client->swapped)
     {
-	register int n;
-
 	for (i = 0; i < reply->numAliases; i++)
 	{
-	    swaps (&aliases[i], n);
+	    swaps (&aliases[i]);
 	}
-    	swaps(&reply->sequenceNumber, n);
-    	swapl(&reply->length, n);
-	swapl(&reply->numAliases, n);
-	swapl(&reply->numFilters, n);
+	swaps(&reply->sequenceNumber);
+	swapl(&reply->length);
+	swapl(&reply->numAliases);
+	swapl(&reply->numFilters);
     }
     WriteToClient(client, total_bytes, (char *) reply);
     free (reply);
@@ -2039,34 +2037,31 @@ ProcRenderDispatch (ClientPtr client)
 static int
 SProcRenderQueryVersion (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderQueryVersionReq);
     REQUEST_SIZE_MATCH(xRenderQueryVersionReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->majorVersion, n);
-    swapl(&stuff->minorVersion, n);
+    swaps(&stuff->length);
+    swapl(&stuff->majorVersion);
+    swapl(&stuff->minorVersion);
     return (*ProcRenderVector[stuff->renderReqType])(client);
 }
 
 static int
 SProcRenderQueryPictFormats (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderQueryPictFormatsReq);
     REQUEST_SIZE_MATCH(xRenderQueryPictFormatsReq);
-    swaps(&stuff->length, n);
+    swaps(&stuff->length);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderQueryPictIndexValues (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderQueryPictIndexValuesReq);
     REQUEST_AT_LEAST_SIZE(xRenderQueryPictIndexValuesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->format, n);
+    swaps(&stuff->length);
+    swapl(&stuff->format);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
@@ -2079,14 +2074,13 @@ SProcRenderQueryDithers (ClientPtr client)
 static int
 SProcRenderCreatePicture (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderCreatePictureReq);
     REQUEST_AT_LEAST_SIZE(xRenderCreatePictureReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->drawable, n);
-    swapl(&stuff->format, n);
-    swapl(&stuff->mask, n);
+    swaps(&stuff->length);
+    swapl(&stuff->pid);
+    swapl(&stuff->drawable);
+    swapl(&stuff->format);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2094,12 +2088,11 @@ SProcRenderCreatePicture (ClientPtr client)
 static int
 SProcRenderChangePicture (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderChangePictureReq);
     REQUEST_AT_LEAST_SIZE(xRenderChangePictureReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
-    swapl(&stuff->mask, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
+    swapl(&stuff->mask);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2107,11 +2100,10 @@ SProcRenderChangePicture (ClientPtr client)
 static int
 SProcRenderSetPictureClipRectangles (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderSetPictureClipRectanglesReq);
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureClipRectanglesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
     SwapRestS(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2119,68 +2111,64 @@ SProcRenderSetPictureClipRectangles (ClientPtr client)
 static int
 SProcRenderFreePicture (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderFreePictureReq);
     REQUEST_SIZE_MATCH(xRenderFreePictureReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderComposite (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderCompositeReq);
     REQUEST_SIZE_MATCH(xRenderCompositeReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->src, n);
-    swapl(&stuff->mask, n);
-    swapl(&stuff->dst, n);
-    swaps(&stuff->xSrc, n);
-    swaps(&stuff->ySrc, n);
-    swaps(&stuff->xMask, n);
-    swaps(&stuff->yMask, n);
-    swaps(&stuff->xDst, n);
-    swaps(&stuff->yDst, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swaps(&stuff->length);
+    swapl(&stuff->src);
+    swapl(&stuff->mask);
+    swapl(&stuff->dst);
+    swaps(&stuff->xSrc);
+    swaps(&stuff->ySrc);
+    swaps(&stuff->xMask);
+    swaps(&stuff->yMask);
+    swaps(&stuff->xDst);
+    swaps(&stuff->yDst);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderScale (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderScaleReq);
     REQUEST_SIZE_MATCH(xRenderScaleReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->src, n);
-    swapl(&stuff->dst, n);
-    swapl(&stuff->colorScale, n);
-    swapl(&stuff->alphaScale, n);
-    swaps(&stuff->xSrc, n);
-    swaps(&stuff->ySrc, n);
-    swaps(&stuff->xDst, n);
-    swaps(&stuff->yDst, n);
-    swaps(&stuff->width, n);
-    swaps(&stuff->height, n);
+    swaps(&stuff->length);
+    swapl(&stuff->src);
+    swapl(&stuff->dst);
+    swapl(&stuff->colorScale);
+    swapl(&stuff->alphaScale);
+    swaps(&stuff->xSrc);
+    swaps(&stuff->ySrc);
+    swaps(&stuff->xDst);
+    swaps(&stuff->yDst);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderTrapezoids (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderTrapezoidsReq);
 
     REQUEST_AT_LEAST_SIZE(xRenderTrapezoidsReq);
-    swaps (&stuff->length, n);
-    swapl (&stuff->src, n);
-    swapl (&stuff->dst, n);
-    swapl (&stuff->maskFormat, n);
-    swaps (&stuff->xSrc, n);
-    swaps (&stuff->ySrc, n);
+    swaps (&stuff->length);
+    swapl (&stuff->src);
+    swapl (&stuff->dst);
+    swapl (&stuff->maskFormat);
+    swaps (&stuff->xSrc);
+    swaps (&stuff->ySrc);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2188,16 +2176,15 @@ SProcRenderTrapezoids (ClientPtr client)
 static int
 SProcRenderTriangles (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderTrianglesReq);
 
     REQUEST_AT_LEAST_SIZE(xRenderTrianglesReq);
-    swaps (&stuff->length, n);
-    swapl (&stuff->src, n);
-    swapl (&stuff->dst, n);
-    swapl (&stuff->maskFormat, n);
-    swaps (&stuff->xSrc, n);
-    swaps (&stuff->ySrc, n);
+    swaps (&stuff->length);
+    swapl (&stuff->src);
+    swapl (&stuff->dst);
+    swapl (&stuff->maskFormat);
+    swaps (&stuff->xSrc);
+    swaps (&stuff->ySrc);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2205,16 +2192,15 @@ SProcRenderTriangles (ClientPtr client)
 static int
 SProcRenderTriStrip (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderTriStripReq);
 
     REQUEST_AT_LEAST_SIZE(xRenderTriStripReq);
-    swaps (&stuff->length, n);
-    swapl (&stuff->src, n);
-    swapl (&stuff->dst, n);
-    swapl (&stuff->maskFormat, n);
-    swaps (&stuff->xSrc, n);
-    swaps (&stuff->ySrc, n);
+    swaps (&stuff->length);
+    swapl (&stuff->src);
+    swapl (&stuff->dst);
+    swapl (&stuff->maskFormat);
+    swaps (&stuff->xSrc);
+    swaps (&stuff->ySrc);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2222,16 +2208,15 @@ SProcRenderTriStrip (ClientPtr client)
 static int
 SProcRenderTriFan (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderTriFanReq);
 
     REQUEST_AT_LEAST_SIZE(xRenderTriFanReq);
-    swaps (&stuff->length, n);
-    swapl (&stuff->src, n);
-    swapl (&stuff->dst, n);
-    swapl (&stuff->maskFormat, n);
-    swaps (&stuff->xSrc, n);
-    swaps (&stuff->ySrc, n);
+    swaps (&stuff->length);
+    swapl (&stuff->src);
+    swapl (&stuff->dst);
+    swapl (&stuff->maskFormat);
+    swaps (&stuff->xSrc);
+    swaps (&stuff->ySrc);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2257,51 +2242,47 @@ SProcRenderTransform (ClientPtr client)
 static int
 SProcRenderCreateGlyphSet (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderCreateGlyphSetReq);
     REQUEST_SIZE_MATCH(xRenderCreateGlyphSetReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->gsid, n);
-    swapl(&stuff->format, n);
+    swaps(&stuff->length);
+    swapl(&stuff->gsid);
+    swapl(&stuff->format);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderReferenceGlyphSet (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderReferenceGlyphSetReq);
     REQUEST_SIZE_MATCH(xRenderReferenceGlyphSetReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->gsid, n);
-    swapl(&stuff->existing, n);
+    swaps(&stuff->length);
+    swapl(&stuff->gsid);
+    swapl(&stuff->existing);
     return (*ProcRenderVector[stuff->renderReqType])  (client);
 }
 
 static int
 SProcRenderFreeGlyphSet (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderFreeGlyphSetReq);
     REQUEST_SIZE_MATCH(xRenderFreeGlyphSetReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->glyphset, n);
+    swaps(&stuff->length);
+    swapl(&stuff->glyphset);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderAddGlyphs (ClientPtr client)
 {
-    register int n;
     register int i;
     CARD32  *gids;
     void    *end;
     xGlyphInfo *gi;
     REQUEST(xRenderAddGlyphsReq);
     REQUEST_AT_LEAST_SIZE(xRenderAddGlyphsReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->glyphset, n);
-    swapl(&stuff->nglyphs, n);
+    swaps(&stuff->length);
+    swapl(&stuff->glyphset);
+    swapl(&stuff->nglyphs);
     if (stuff->nglyphs & 0xe0000000)
 	return BadLength;
     end = (CARD8 *) stuff + (client->req_len << 2);
@@ -2313,13 +2294,13 @@ SProcRenderAddGlyphs (ClientPtr client)
 	return BadLength;
     for (i = 0; i < stuff->nglyphs; i++)
     {
-	swapl (&gids[i], n);
-	swaps (&gi[i].width, n);
-	swaps (&gi[i].height, n);
-	swaps (&gi[i].x, n);
-	swaps (&gi[i].y, n);
-	swaps (&gi[i].xOff, n);
-	swaps (&gi[i].yOff, n);
+	swapl (&gids[i]);
+	swaps (&gi[i].width);
+	swaps (&gi[i].height);
+	swaps (&gi[i].x);
+	swaps (&gi[i].y);
+	swaps (&gi[i].xOff);
+	swaps (&gi[i].yOff);
     }
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2333,11 +2314,10 @@ SProcRenderAddGlyphsFromPicture (ClientPtr client)
 static int
 SProcRenderFreeGlyphs (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderFreeGlyphsReq);
     REQUEST_AT_LEAST_SIZE(xRenderFreeGlyphsReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->glyphset, n);
+    swaps(&stuff->length);
+    swapl(&stuff->glyphset);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2345,7 +2325,6 @@ SProcRenderFreeGlyphs (ClientPtr client)
 static int
 SProcRenderCompositeGlyphs (ClientPtr client)
 {
-    register int n;
     xGlyphElt	*elt;
     CARD8	*buffer;
     CARD8	*end;
@@ -2362,13 +2341,13 @@ SProcRenderCompositeGlyphs (ClientPtr client)
     case X_RenderCompositeGlyphs32: size = 4; break;
     }
 	    
-    swaps(&stuff->length, n);
-    swapl(&stuff->src, n);
-    swapl(&stuff->dst, n);
-    swapl(&stuff->maskFormat, n);
-    swapl(&stuff->glyphset, n);
-    swaps(&stuff->xSrc, n);
-    swaps(&stuff->ySrc, n);
+    swaps(&stuff->length);
+    swapl(&stuff->src);
+    swapl(&stuff->dst);
+    swapl(&stuff->maskFormat);
+    swapl(&stuff->glyphset);
+    swaps(&stuff->xSrc);
+    swaps(&stuff->ySrc);
     buffer = (CARD8 *) (stuff + 1);
     end = (CARD8 *) stuff + (client->req_len << 2);
     while (buffer + sizeof (xGlyphElt) < end)
@@ -2376,13 +2355,13 @@ SProcRenderCompositeGlyphs (ClientPtr client)
 	elt = (xGlyphElt *) buffer;
 	buffer += sizeof (xGlyphElt);
 	
-	swaps (&elt->deltax, n);
-	swaps (&elt->deltay, n);
+	swaps (&elt->deltax);
+	swaps (&elt->deltay);
 	
 	i = elt->len;
 	if (i == 0xff)
 	{
-	    swapl (buffer, n);
+	    swapl ((int *) buffer);
 	    buffer += 4;
 	}
 	else
@@ -2395,14 +2374,14 @@ SProcRenderCompositeGlyphs (ClientPtr client)
 	    case 2:
 		while (i--)
 		{
-		    swaps (buffer, n);
+		    swaps ((short *) buffer);
 		    buffer += 2;
 		}
 		break;
 	    case 4:
 		while (i--)
 		{
-		    swapl (buffer, n);
+		    swapl ((int *) buffer);
 		    buffer += 4;
 		}
 		break;
@@ -2417,16 +2396,15 @@ SProcRenderCompositeGlyphs (ClientPtr client)
 static int
 SProcRenderFillRectangles (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderFillRectanglesReq);
 
     REQUEST_AT_LEAST_SIZE (xRenderFillRectanglesReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->dst, n);
-    swaps(&stuff->color.red, n);
-    swaps(&stuff->color.green, n);
-    swaps(&stuff->color.blue, n);
-    swaps(&stuff->color.alpha, n);
+    swaps(&stuff->length);
+    swapl(&stuff->dst);
+    swaps(&stuff->color.red);
+    swaps(&stuff->color.green);
+    swaps(&stuff->color.blue);
+    swaps(&stuff->color.alpha);
     SwapRestS(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2434,73 +2412,68 @@ SProcRenderFillRectangles (ClientPtr client)
 static int
 SProcRenderCreateCursor (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderCreateCursorReq);
     REQUEST_SIZE_MATCH (xRenderCreateCursorReq);
     
-    swaps(&stuff->length, n);
-    swapl(&stuff->cid, n);
-    swapl(&stuff->src, n);
-    swaps(&stuff->x, n);
-    swaps(&stuff->y, n);
+    swaps(&stuff->length);
+    swapl(&stuff->cid);
+    swapl(&stuff->src);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
     
 static int
 SProcRenderSetPictureTransform (ClientPtr client)
 {
-    register int n;
     REQUEST(xRenderSetPictureTransformReq);
     REQUEST_SIZE_MATCH(xRenderSetPictureTransformReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
-    swapl(&stuff->transform.matrix11, n);
-    swapl(&stuff->transform.matrix12, n);
-    swapl(&stuff->transform.matrix13, n);
-    swapl(&stuff->transform.matrix21, n);
-    swapl(&stuff->transform.matrix22, n);
-    swapl(&stuff->transform.matrix23, n);
-    swapl(&stuff->transform.matrix31, n);
-    swapl(&stuff->transform.matrix32, n);
-    swapl(&stuff->transform.matrix33, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
+    swapl(&stuff->transform.matrix11);
+    swapl(&stuff->transform.matrix12);
+    swapl(&stuff->transform.matrix13);
+    swapl(&stuff->transform.matrix21);
+    swapl(&stuff->transform.matrix22);
+    swapl(&stuff->transform.matrix23);
+    swapl(&stuff->transform.matrix31);
+    swapl(&stuff->transform.matrix32);
+    swapl(&stuff->transform.matrix33);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static int
 SProcRenderQueryFilters (ClientPtr client)
 {
-    register int n;
     REQUEST (xRenderQueryFiltersReq);
     REQUEST_SIZE_MATCH (xRenderQueryFiltersReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->drawable, n);
+    swaps(&stuff->length);
+    swapl(&stuff->drawable);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
     
 static int
 SProcRenderSetPictureFilter (ClientPtr client)
 {
-    register int n;
     REQUEST (xRenderSetPictureFilterReq);
     REQUEST_AT_LEAST_SIZE (xRenderSetPictureFilterReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
-    swaps(&stuff->nbytes, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
+    swaps(&stuff->nbytes);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
     
 static int
 SProcRenderCreateAnimCursor (ClientPtr client)
 {
-    register int n;
     REQUEST (xRenderCreateAnimCursorReq);
     REQUEST_AT_LEAST_SIZE (xRenderCreateAnimCursorReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->cid, n);
+    swaps(&stuff->length);
+    swapl(&stuff->cid);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2508,14 +2481,13 @@ SProcRenderCreateAnimCursor (ClientPtr client)
 static int
 SProcRenderAddTraps (ClientPtr client)
 {
-    register int n;
     REQUEST (xRenderAddTrapsReq);
     REQUEST_AT_LEAST_SIZE (xRenderAddTrapsReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->picture, n);
-    swaps(&stuff->xOff, n);
-    swaps(&stuff->yOff, n);
+    swaps(&stuff->length);
+    swapl(&stuff->picture);
+    swaps(&stuff->xOff);
+    swaps(&stuff->yOff);
     SwapRestL(stuff);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
@@ -2523,49 +2495,50 @@ SProcRenderAddTraps (ClientPtr client)
 static int
 SProcRenderCreateSolidFill(ClientPtr client)
 {
-    register int n;
     REQUEST (xRenderCreateSolidFillReq);
     REQUEST_AT_LEAST_SIZE (xRenderCreateSolidFillReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->pid, n);
-    swaps(&stuff->color.alpha, n);
-    swaps(&stuff->color.red, n);
-    swaps(&stuff->color.green, n);
-    swaps(&stuff->color.blue, n);
+    swaps(&stuff->length);
+    swapl(&stuff->pid);
+    swaps(&stuff->color.alpha);
+    swaps(&stuff->color.red);
+    swaps(&stuff->color.green);
+    swaps(&stuff->color.blue);
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 
 static void swapStops(void *stuff, int num)
 {
-    int i, n;
+    int i;
     CARD32 *stops;
+    CARD16 *colors;
+
     stops = (CARD32 *)(stuff);
     for (i = 0; i < num; ++i) {
-        swapl(stops, n);
+        swapl(stops);
         ++stops;
     }
+    colors = (CARD16 *) (stops);
     for (i = 0; i < 4*num; ++i) {
-        swaps(stops, n);
-        ++stops;
+        swaps(colors);
+        ++colors;
     }
 }
 
 static int
 SProcRenderCreateLinearGradient (ClientPtr client)
 {
-    register int n;
     int len;
     REQUEST (xRenderCreateLinearGradientReq);
     REQUEST_AT_LEAST_SIZE (xRenderCreateLinearGradientReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->p1.x, n);
-    swapl(&stuff->p1.y, n);
-    swapl(&stuff->p2.x, n);
-    swapl(&stuff->p2.y, n);
-    swapl(&stuff->nStops, n);
+    swaps(&stuff->length);
+    swapl(&stuff->pid);
+    swapl(&stuff->p1.x);
+    swapl(&stuff->p1.y);
+    swapl(&stuff->p2.x);
+    swapl(&stuff->p2.y);
+    swapl(&stuff->nStops);
 
     len = (client->req_len << 2) - sizeof(xRenderCreateLinearGradientReq);
     if (stuff->nStops > UINT32_MAX/(sizeof(xFixed) + sizeof(xRenderColor)))
@@ -2581,20 +2554,19 @@ SProcRenderCreateLinearGradient (ClientPtr client)
 static int
 SProcRenderCreateRadialGradient (ClientPtr client)
 {
-    register int n;
     int len;
     REQUEST (xRenderCreateRadialGradientReq);
     REQUEST_AT_LEAST_SIZE (xRenderCreateRadialGradientReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->inner.x, n);
-    swapl(&stuff->inner.y, n);
-    swapl(&stuff->outer.x, n);
-    swapl(&stuff->outer.y, n);
-    swapl(&stuff->inner_radius, n);
-    swapl(&stuff->outer_radius, n);
-    swapl(&stuff->nStops, n);
+    swaps(&stuff->length);
+    swapl(&stuff->pid);
+    swapl(&stuff->inner.x);
+    swapl(&stuff->inner.y);
+    swapl(&stuff->outer.x);
+    swapl(&stuff->outer.y);
+    swapl(&stuff->inner_radius);
+    swapl(&stuff->outer_radius);
+    swapl(&stuff->nStops);
 
     len = (client->req_len << 2) - sizeof(xRenderCreateRadialGradientReq);
     if (stuff->nStops > UINT32_MAX/(sizeof(xFixed) + sizeof(xRenderColor)))
@@ -2610,17 +2582,16 @@ SProcRenderCreateRadialGradient (ClientPtr client)
 static int
 SProcRenderCreateConicalGradient (ClientPtr client)
 {
-    register int n;
     int len;
     REQUEST (xRenderCreateConicalGradientReq);
     REQUEST_AT_LEAST_SIZE (xRenderCreateConicalGradientReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->pid, n);
-    swapl(&stuff->center.x, n);
-    swapl(&stuff->center.y, n);
-    swapl(&stuff->angle, n);
-    swapl(&stuff->nStops, n);
+    swaps(&stuff->length);
+    swapl(&stuff->pid);
+    swapl(&stuff->center.x);
+    swapl(&stuff->center.y);
+    swapl(&stuff->angle);
+    swapl(&stuff->nStops);
 
     len = (client->req_len << 2) - sizeof(xRenderCreateConicalGradientReq);
     if (stuff->nStops > UINT32_MAX/(sizeof(xFixed) + sizeof(xRenderColor)))

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -225,12 +225,11 @@ GetBit (unsigned char *line, int x)
 int
 SProcXFixesSelectCursorInput (ClientPtr client)
 {
-    register int n;
     REQUEST(xXFixesSelectCursorInputReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->eventMask, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swapl(&stuff->eventMask);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
     
@@ -329,20 +328,18 @@ ProcXFixesGetCursorImage (ClientPtr client)
     rep->cursorSerial = pCursor->serialNumber;
 
     image = (CARD32 *) (rep + 1);
-    CopyCursorToImage (pCursor, image);
-    if (client->swapped)
-    {
-	int n;
-	swaps (&rep->sequenceNumber, n);
-	swapl (&rep->length, n);
-	swaps (&rep->x, n);
-	swaps (&rep->y, n);
-	swaps (&rep->width, n);
-	swaps (&rep->height, n);
-	swaps (&rep->xhot, n);
-	swaps (&rep->yhot, n);
-	swapl (&rep->cursorSerial, n);
-	SwapLongs (image, npixels);
+    CopyCursorToImage(pCursor, image);
+    if (client->swapped) {
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swaps(&rep->x);
+	swaps(&rep->y);
+	swaps(&rep->width);
+	swaps(&rep->height);
+	swaps(&rep->xhot);
+	swaps(&rep->yhot);
+	swapl(&rep->cursorSerial);
+	SwapLongs(image, npixels);
     }
     (void) WriteToClient(client, sizeof (xXFixesGetCursorImageReply) +
 			 (npixels << 2), (char *) rep);
@@ -353,9 +350,8 @@ ProcXFixesGetCursorImage (ClientPtr client)
 int
 SProcXFixesGetCursorImage (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesGetCursorImageReq);
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -381,13 +377,12 @@ ProcXFixesSetCursorName (ClientPtr client)
 int
 SProcXFixesSetCursorName (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesSetCursorNameReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xXFixesSetCursorNameReq);
-    swapl (&stuff->cursor, n);
-    swaps (&stuff->nbytes, n);
+    swapl(&stuff->cursor);
+    swaps(&stuff->nbytes);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -413,13 +408,11 @@ ProcXFixesGetCursorName (ClientPtr client)
     reply.sequenceNumber = client->sequence;
     reply.atom = pCursor->name;
     reply.nbytes = len;
-    if (client->swapped)
-    {
-	int n;
-	swaps (&reply.sequenceNumber, n);
-	swapl (&reply.length, n);
-	swapl (&reply.atom, n);
-	swaps (&reply.nbytes, n);
+    if (client->swapped) {
+	swaps(&reply.sequenceNumber);
+	swapl(&reply.length);
+	swapl(&reply.atom);
+	swaps(&reply.nbytes);
     }
     WriteReplyToClient(client, sizeof(xXFixesGetCursorNameReply), &reply);
     (void)WriteToClient(client, len, str);
@@ -430,12 +423,11 @@ ProcXFixesGetCursorName (ClientPtr client)
 int
 SProcXFixesGetCursorName (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesSetCursorNameReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesGetCursorNameReq);
-    swapl (&stuff->cursor, n);
+    swapl(&stuff->cursor);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -482,23 +474,21 @@ ProcXFixesGetCursorImageAndName (ClientPtr client)
     rep->nbytes = nbytes;
 
     image = (CARD32 *) (rep + 1);
-    CopyCursorToImage (pCursor, image);
-    memcpy ((image + npixels), name, nbytes);
-    if (client->swapped)
-    {
-	int n;
-	swaps (&rep->sequenceNumber, n);
-	swapl (&rep->length, n);
-	swaps (&rep->x, n);
-	swaps (&rep->y, n);
-	swaps (&rep->width, n);
-	swaps (&rep->height, n);
-	swaps (&rep->xhot, n);
-	swaps (&rep->yhot, n);
-	swapl (&rep->cursorSerial, n);
-	swapl (&rep->cursorName, n);
-	swaps (&rep->nbytes, n);
-	SwapLongs (image, npixels);
+    CopyCursorToImage(pCursor, image);
+    memcpy((image + npixels), name, nbytes);
+    if (client->swapped) {
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swaps(&rep->x);
+	swaps(&rep->y);
+	swaps(&rep->width);
+	swaps(&rep->height);
+	swaps(&rep->xhot);
+	swaps(&rep->yhot);
+	swapl(&rep->cursorSerial);
+	swapl(&rep->cursorName);
+	swaps(&rep->nbytes);
+	SwapLongs(image, npixels);
     }
     (void) WriteToClient(client, sizeof (xXFixesGetCursorImageAndNameReply) +
 			 (npixels << 2) + nbytesRound, (char *) rep);
@@ -509,9 +499,8 @@ ProcXFixesGetCursorImageAndName (ClientPtr client)
 int
 SProcXFixesGetCursorImageAndName (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesGetCursorImageAndNameReq);
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -642,13 +631,12 @@ ProcXFixesChangeCursor (ClientPtr client)
 int
 SProcXFixesChangeCursor (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesChangeCursorReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesChangeCursorReq);
-    swapl (&stuff->source, n);
-    swapl (&stuff->destination, n);
+    swapl(&stuff->source);
+    swapl(&stuff->destination);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -678,13 +666,12 @@ ProcXFixesChangeCursorByName (ClientPtr client)
 int
 SProcXFixesChangeCursorByName (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesChangeCursorByNameReq);
 
-    swaps (&stuff->length, n);
-    REQUEST_AT_LEAST_SIZE (xXFixesChangeCursorByNameReq);
-    swapl (&stuff->source, n);
-    swaps (&stuff->nbytes, n);
+    swaps(&stuff->length);
+    REQUEST_AT_LEAST_SIZE(xXFixesChangeCursorByNameReq);
+    swapl(&stuff->source);
+    swaps(&stuff->nbytes);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 

--- a/nx-X11/programs/Xserver/xfixes/region.c
+++ b/nx-X11/programs/Xserver/xfixes/region.c
@@ -96,12 +96,11 @@ ProcXFixesCreateRegion (ClientPtr client)
 int
 SProcXFixesCreateRegion (ClientPtr client)
 {
-    register int n;
     REQUEST(xXFixesCreateRegionReq);
-    
-    swaps(&stuff->length, n);
+
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xXFixesCreateRegionReq);
-    swapl(&stuff->region, n);
+    swapl(&stuff->region);
     SwapRestS(stuff);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
@@ -141,13 +140,12 @@ ProcXFixesCreateRegionFromBitmap (ClientPtr client)
 int
 SProcXFixesCreateRegionFromBitmap (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCreateRegionFromBitmapReq);
+    REQUEST(xXFixesCreateRegionFromBitmapReq);
 
-    swaps(&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesCreateRegionFromBitmapReq);
-    swapl(&stuff->region, n);
-    swapl(&stuff->bitmap, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromBitmapReq);
+    swapl(&stuff->region);
+    swapl(&stuff->bitmap);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -205,13 +203,12 @@ ProcXFixesCreateRegionFromWindow (ClientPtr client)
 int
 SProcXFixesCreateRegionFromWindow (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCreateRegionFromWindowReq);
+    REQUEST(xXFixesCreateRegionFromWindowReq);
 
-    swaps(&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesCreateRegionFromWindowReq);
-    swapl(&stuff->region, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromWindowReq);
+    swapl(&stuff->region);
+    swapl(&stuff->window);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -252,13 +249,12 @@ ProcXFixesCreateRegionFromGC (ClientPtr client)
 int
 SProcXFixesCreateRegionFromGC (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCreateRegionFromGCReq);
+    REQUEST(xXFixesCreateRegionFromGCReq);
 
-    swaps(&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesCreateRegionFromGCReq);
-    swapl(&stuff->region, n);
-    swapl(&stuff->gc, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromGCReq);
+    swapl(&stuff->region);
+    swapl(&stuff->gc);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -304,13 +300,12 @@ ProcXFixesCreateRegionFromPicture (ClientPtr client)
 int
 SProcXFixesCreateRegionFromPicture (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCreateRegionFromPictureReq);
+    REQUEST(xXFixesCreateRegionFromPictureReq);
 
-    swaps(&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesCreateRegionFromPictureReq);
-    swapl(&stuff->region, n);
-    swapl(&stuff->picture, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromPictureReq);
+    swapl(&stuff->region);
+    swapl(&stuff->picture);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -329,12 +324,11 @@ ProcXFixesDestroyRegion (ClientPtr client)
 int
 SProcXFixesDestroyRegion (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesDestroyRegionReq);
+    REQUEST(xXFixesDestroyRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesDestroyRegionReq);
-    swapl (&stuff->region, n);
+    swapl(&stuff->region);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -368,12 +362,11 @@ ProcXFixesSetRegion (ClientPtr client)
 int
 SProcXFixesSetRegion (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesSetRegionReq);
+    REQUEST(xXFixesSetRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xXFixesSetRegionReq);
-    swapl (&stuff->region, n);
+    swapl(&stuff->region);
     SwapRestS(stuff);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
@@ -396,13 +389,12 @@ ProcXFixesCopyRegion (ClientPtr client)
 int
 SProcXFixesCopyRegion (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCopyRegionReq);
+    REQUEST(xXFixesCopyRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xXFixesCopyRegionReq);
-    swapl (&stuff->source, n);
-    swapl (&stuff->destination, n);
+    swapl(&stuff->source);
+    swapl(&stuff->destination);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -441,14 +433,13 @@ ProcXFixesCombineRegion (ClientPtr client)
 int
 SProcXFixesCombineRegion (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesCombineRegionReq);
+    REQUEST(xXFixesCombineRegionReq);
 
-    swaps (&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesCombineRegionReq);
-    swapl (&stuff->source1, n);
-    swapl (&stuff->source2, n);
-    swapl (&stuff->destination, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesCombineRegionReq);
+    swapl(&stuff->source1);
+    swapl(&stuff->source2);
+    swapl(&stuff->destination);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -488,17 +479,16 @@ ProcXFixesInvertRegion (ClientPtr client)
 int
 SProcXFixesInvertRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesInvertRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesInvertRegionReq);
-    swapl (&stuff->source, n);
-    swaps (&stuff->x, n);
-    swaps (&stuff->y, n);
-    swaps (&stuff->width, n);
-    swaps (&stuff->height, n);
-    swapl (&stuff->destination, n);
+    swapl(&stuff->source);
+    swaps(&stuff->x);
+    swaps(&stuff->y);
+    swaps(&stuff->width);
+    swaps(&stuff->height);
+    swapl(&stuff->destination);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -518,14 +508,13 @@ ProcXFixesTranslateRegion (ClientPtr client)
 int
 SProcXFixesTranslateRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesTranslateRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesTranslateRegionReq);
-    swapl (&stuff->region, n);
-    swaps (&stuff->dx, n);
-    swaps (&stuff->dy, n);
+    swapl(&stuff->region);
+    swaps(&stuff->dx);
+    swaps(&stuff->dy);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -547,13 +536,12 @@ ProcXFixesRegionExtents (ClientPtr client)
 int
 SProcXFixesRegionExtents (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesRegionExtentsReq);
-    
-    swaps (&stuff->length, n);
+
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesRegionExtentsReq);
-    swapl (&stuff->source, n);
-    swapl (&stuff->destination, n);
+    swapl(&stuff->source);
+    swapl(&stuff->destination);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -595,16 +583,14 @@ ProcXFixesFetchRegion (ClientPtr client)
 	pRect[i].width = pBox[i].x2 - pBox[i].x1;
 	pRect[i].height = pBox[i].y2 - pBox[i].y1;
     }
-    if (client->swapped)
-    {
-	int n;
-	swaps (&reply->sequenceNumber, n);
-	swapl (&reply->length, n);
-	swaps (&reply->x, n);
-	swaps (&reply->y, n);
-	swaps (&reply->width, n);
-	swaps (&reply->height, n);
-	SwapShorts ((INT16 *) pRect, nBox * 4);
+    if (client->swapped) {
+	swaps(&reply->sequenceNumber);
+	swapl(&reply->length);
+	swaps(&reply->x);
+	swaps(&reply->y);
+	swaps(&reply->width);
+	swaps(&reply->height);
+	SwapShorts((INT16 *) pRect, nBox * 4);
     }
     (void) WriteToClient(client, sizeof (xXFixesFetchRegionReply) +
 			 nBox * sizeof (xRectangle), (char *) reply);
@@ -615,12 +601,11 @@ ProcXFixesFetchRegion (ClientPtr client)
 int
 SProcXFixesFetchRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesFetchRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesFetchRegionReq);
-    swapl (&stuff->region, n);
+    swapl(&stuff->region);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -654,15 +639,14 @@ ProcXFixesSetGCClipRegion (ClientPtr client)
 int
 SProcXFixesSetGCClipRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesSetGCClipRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesSetGCClipRegionReq);
-    swapl (&stuff->gc, n);
-    swapl (&stuff->region, n);
-    swaps (&stuff->xOrigin, n);
-    swaps (&stuff->yOrigin, n);
+    swapl(&stuff->gc);
+    swapl(&stuff->region);
+    swaps(&stuff->xOrigin);
+    swaps(&stuff->yOrigin);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -752,15 +736,14 @@ ProcXFixesSetWindowShapeRegion (ClientPtr client)
 int
 SProcXFixesSetWindowShapeRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesSetWindowShapeRegionReq);
 
-    swaps (&stuff->length, n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xXFixesSetWindowShapeRegionReq);
-    swapl (&stuff->dest, n);
-    swaps (&stuff->xOff, n);
-    swaps (&stuff->yOff, n);
-    swapl (&stuff->region, n);
+    swapl(&stuff->dest);
+    swaps(&stuff->xOff);
+    swaps(&stuff->yOff);
+    swapl(&stuff->region);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -791,15 +774,14 @@ ProcXFixesSetPictureClipRegion (ClientPtr client)
 int
 SProcXFixesSetPictureClipRegion (ClientPtr client)
 {
-    int n;
     REQUEST(xXFixesSetPictureClipRegionReq);
-    
-    swaps (&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesSetPictureClipRegionReq);
-    swapl (&stuff->picture, n);
-    swapl (&stuff->region, n);
-    swaps (&stuff->xOrigin, n);
-    swaps (&stuff->yOrigin, n);
+
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesSetPictureClipRegionReq);
+    swapl(&stuff->picture);
+    swapl(&stuff->region);
+    swaps(&stuff->xOrigin);
+    swaps(&stuff->yOrigin);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 
@@ -848,17 +830,15 @@ ProcXFixesExpandRegion (ClientPtr client)
 int
 SProcXFixesExpandRegion (ClientPtr client)
 {
-    int n;
-    REQUEST (xXFixesExpandRegionReq);
+    REQUEST(xXFixesExpandRegionReq);
 
-    swaps (&stuff->length, n);
-    REQUEST_SIZE_MATCH (xXFixesExpandRegionReq);
-    swapl (&stuff->source, n);
-    swapl (&stuff->destination, n);
-    swaps (&stuff->left, n);
-    swaps (&stuff->right, n);
-    swaps (&stuff->top, n);
-    swaps (&stuff->bottom, n);
+    swaps(&stuff->length);
+    REQUEST_SIZE_MATCH(xXFixesExpandRegionReq);
+    swapl(&stuff->source);
+    swapl(&stuff->destination);
+    swaps(&stuff->left);
+    swaps(&stuff->right);
+    swaps(&stuff->top);
+    swaps(&stuff->bottom);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
-

--- a/nx-X11/programs/Xserver/xfixes/saveset.c
+++ b/nx-X11/programs/Xserver/xfixes/saveset.c
@@ -70,10 +70,9 @@ ProcXFixesChangeSaveSet(ClientPtr client)
 int
 SProcXFixesChangeSaveSet(ClientPtr client)
 {
-    register int n;
     REQUEST(xXFixesChangeSaveSetReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
     return ProcXFixesChangeSaveSet(client);
 }

--- a/nx-X11/programs/Xserver/xfixes/select.c
+++ b/nx-X11/programs/Xserver/xfixes/select.c
@@ -215,14 +215,13 @@ ProcXFixesSelectSelectionInput (ClientPtr client)
 int
 SProcXFixesSelectSelectionInput (ClientPtr client)
 {
-    register int n;
     REQUEST(xXFixesSelectSelectionInputReq);
 
     REQUEST_SIZE_MATCH(xXFixesSelectSelectionInputReq);
-    swaps(&stuff->length, n);
-    swapl(&stuff->window, n);
-    swapl(&stuff->selection, n);
-    swapl(&stuff->eventMask, n);
+    swaps(&stuff->length);
+    swapl(&stuff->window);
+    swapl(&stuff->selection);
+    swapl(&stuff->eventMask);
     return ProcXFixesSelectSelectionInput(client);
 }
     

--- a/nx-X11/programs/Xserver/xfixes/xfixes.c
+++ b/nx-X11/programs/Xserver/xfixes/xfixes.c
@@ -39,7 +39,6 @@ ProcXFixesQueryVersion(ClientPtr client)
 {
     XFixesClientPtr pXFixesClient = GetXFixesClient (client);
     xXFixesQueryVersionReply rep;
-    register int n;
     REQUEST(xXFixesQueryVersionReq);
 
     REQUEST_SIZE_MATCH(xXFixesQueryVersionReq);
@@ -61,10 +60,10 @@ ProcXFixesQueryVersion(ClientPtr client)
     pXFixesClient->major_version = rep.majorVersion;
     pXFixesClient->minor_version = rep.minorVersion;
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-    	swapl(&rep.length, n);
-	swapl(&rep.majorVersion, n);
-	swapl(&rep.minorVersion, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swapl(&rep.majorVersion);
+	swapl(&rep.minorVersion);
     }
     WriteToClient(client, sizeof(xXFixesQueryVersionReply), (char *)&rep);
     return(client->noClientException);
@@ -131,12 +130,11 @@ ProcXFixesDispatch (ClientPtr client)
 static int
 SProcXFixesQueryVersion(ClientPtr client)
 {
-    register int n;
     REQUEST(xXFixesQueryVersionReq);
 
-    swaps(&stuff->length, n);
-    swapl(&stuff->majorVersion, n);
-    swapl(&stuff->minorVersion, n);
+    swaps(&stuff->length);
+    swapl(&stuff->majorVersion);
+    swapl(&stuff->minorVersion);
     return (*ProcXFixesVector[stuff->xfixesReqType]) (client);
 }
 

--- a/nx-X11/programs/Xserver/xkb/ddxList.c
+++ b/nx-X11/programs/Xserver/xkb/ddxList.c
@@ -118,9 +118,8 @@ char *		tmp;
     wire16[1]= slen;
     memcpy(wire8,str,slen);
     if (client->swapped) {
-	register int n;
-	swaps(&wire16[0],n);
-	swaps(&wire16[1],n);
+	swaps(&wire16[0]);
+	swaps(&wire16[1]);
     }
     list->nPool+= wlen;
     list->nFound[what]++;

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -165,7 +165,6 @@ ProcXkbUseExtension(ClientPtr client)
 {
     REQUEST(xkbUseExtensionReq);
     xkbUseExtensionReply	rep;
-    register int n;
     int	supported;
 
     REQUEST_SIZE_MATCH(xkbUseExtensionReq);
@@ -201,9 +200,9 @@ ProcXkbUseExtension(ClientPtr client)
     rep.serverMajor = SERVER_XKB_MAJOR_VERSION;
     rep.serverMinor = SERVER_XKB_MINOR_VERSION;
     if ( client->swapped ) {
-	swaps(&rep.sequenceNumber, n);
-	swaps(&rep.serverMajor, n);
-	swaps(&rep.serverMinor, n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.serverMajor);
+	swaps(&rep.serverMinor);
     }
     WriteToClient(client,SIZEOF(xkbUseExtensionReply), (char *)&rep);
     return client->noClientException;
@@ -535,9 +534,8 @@ ProcXkbGetState(ClientPtr client)
     rep.compatState = xkb->compat_state;
     rep.ptrBtnState = xkb->ptr_buttons;
     if (client->swapped) {
-	register int n;
-	swaps(&rep.sequenceNumber,n);
-	swaps(&rep.ptrBtnState,n);
+	swaps(&rep.sequenceNumber);
+	swaps(&rep.ptrBtnState);
     }
     WriteToClient(client, SIZEOF(xkbGetStateReply), (char *)&rep);
     return client->noClientException;
@@ -610,7 +608,6 @@ ProcXkbGetControls(ClientPtr client)
     xkbGetControlsReply rep;
     XkbControlsPtr	xkb;
     DeviceIntPtr 	dev;
-    register int 	n;
 
     REQUEST(xkbGetControlsReq);
     REQUEST_SIZE_MATCH(xkbGetControlsReq);
@@ -653,26 +650,26 @@ ProcXkbGetControls(ClientPtr client)
     rep.axOptions = xkb->ax_options;
     memcpy(rep.perKeyRepeat,xkb->per_key_repeat,XkbPerKeyBitArraySize);
     if (client->swapped) {
-    	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.length,n);
-	swaps(&rep.internalVMods, n);
-	swaps(&rep.ignoreLockVMods, n);
-	swapl(&rep.enabledCtrls, n);
-	swaps(&rep.repeatDelay, n);
-	swaps(&rep.repeatInterval, n);
-	swaps(&rep.slowKeysDelay, n);
-	swaps(&rep.debounceDelay, n);
-	swaps(&rep.mkDelay, n);
-	swaps(&rep.mkInterval, n);
-	swaps(&rep.mkTimeToMax, n);
-	swaps(&rep.mkMaxSpeed, n);
-	swaps(&rep.mkCurve, n);
-	swaps(&rep.axTimeout, n);
-	swapl(&rep.axtCtrlsMask, n);
-	swapl(&rep.axtCtrlsValues, n);
-	swaps(&rep.axtOptsMask, n);
-	swaps(&rep.axtOptsValues, n);
-	swaps(&rep.axOptions, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.internalVMods);
+	swaps(&rep.ignoreLockVMods);
+	swapl(&rep.enabledCtrls);
+	swaps(&rep.repeatDelay);
+	swaps(&rep.repeatInterval);
+	swaps(&rep.slowKeysDelay);
+	swaps(&rep.debounceDelay);
+	swaps(&rep.mkDelay);
+	swaps(&rep.mkInterval);
+	swaps(&rep.mkTimeToMax);
+	swaps(&rep.mkMaxSpeed);
+	swaps(&rep.mkCurve);
+	swaps(&rep.axTimeout);
+	swapl(&rep.axtCtrlsMask);
+	swapl(&rep.axtCtrlsValues);
+	swaps(&rep.axtOptsMask);
+	swaps(&rep.axtOptsValues);
+	swaps(&rep.axOptions);
     }
     WriteToClient(client, SIZEOF(xkbGetControlsReply), (char *)&rep);
     return(client->noClientException);
@@ -940,8 +937,7 @@ XkbWriteKeyTypes(	XkbDescPtr		xkb,
 	wire->nMapEntries = type->map_count;
 	wire->preserve = (type->preserve!=NULL);
 	if (client->swapped) {
-	    register int n;
-	    swaps(&wire->virtualMods,n);
+	    swaps(&wire->virtualMods);
 	}	
 
 	buf= (char *)&wire[1];
@@ -957,8 +953,7 @@ XkbWriteKeyTypes(	XkbDescPtr		xkb,
 		wire->realMods= entry->mods.real_mods;
 		wire->virtualMods= entry->mods.vmods;
 		if (client->swapped) {
-		    register int n;
-		    swaps(&wire->virtualMods,n);
+		    swaps(&wire->virtualMods);
 		}
 	    }
 	    buf= (char *)wire;
@@ -972,8 +967,7 @@ XkbWriteKeyTypes(	XkbDescPtr		xkb,
 		    pwire->realMods= preserve->real_mods;
 		    pwire->virtualMods= preserve->vmods;
 		    if (client->swapped) {
-			register int n;
-			swaps(&pwire->virtualMods,n);
+			swaps(&pwire->virtualMods);
 		    }
 		}
 		buf= (char *)pwire;
@@ -1053,10 +1047,10 @@ register unsigned	i;
 	pSym = &xkb->map->syms[symMap->offset];
 	memcpy((char *)buf,(char *)pSym,outMap->nSyms*4);
 	if (client->swapped) {
-	    register int n,nSyms= outMap->nSyms;
-	    swaps(&outMap->nSyms,n);
+	    register int nSyms= outMap->nSyms;
+	    swaps(&outMap->nSyms);
 	    while (nSyms-->0) {
-		swapl(buf,n);
+		swapl((int *)buf);
 		buf+= 4;
 	    }
 	}
@@ -1345,12 +1339,11 @@ char		*desc,*start;
 					len, (unsigned long)(desc-start));
     }
     if (client->swapped) {
-	register int n;
-	swaps(&rep->sequenceNumber,n);
-	swapl(&rep->length,n);
-	swaps(&rep->present,n);
-	swaps(&rep->totalSyms,n);
-	swaps(&rep->totalActs,n);
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swaps(&rep->present);
+	swaps(&rep->totalSyms);
+	swaps(&rep->totalActs);
     }
     WriteToClient(client, (i=SIZEOF(xkbGetMapReply)), (char *)rep);
     WriteToClient(client, len, start);
@@ -1532,8 +1525,7 @@ register xkbKeyTypeWireDesc	*wire = *wireRtrn;
     for (i=0;i<req->nTypes;i++) {
 	unsigned	width;
 	if (client->swapped) {
-	    register int s;
-	    swaps(&wire->virtualMods,s);
+	    swaps(&wire->virtualMods);
 	}
 	n= i+req->firstType;
 	width= wire->numLevels;
@@ -1559,8 +1551,7 @@ register xkbKeyTypeWireDesc	*wire = *wireRtrn;
 	    preWire= (xkbModsWireDesc *)&mapWire[wire->nMapEntries];
 	    for (n=0;n<wire->nMapEntries;n++) {
 		if (client->swapped) {
-		    register int s;
-		    swaps(&mapWire[n].virtualMods,s);
+		    swaps(&mapWire[n].virtualMods);
 		}
 		if (mapWire[n].realMods&(~wire->realMods)) {
 		    *nMapsRtrn= _XkbErrCode4(0x06,n,mapWire[n].realMods,
@@ -1578,8 +1569,7 @@ register xkbKeyTypeWireDesc	*wire = *wireRtrn;
 		}
 		if (wire->preserve) {
 		    if (client->swapped) {
-			register int s;
-			swaps(&preWire[n].virtualMods,s);
+			swaps(&preWire[n].virtualMods);
 		    }
 		    if (preWire[n].realMods&(~mapWire[n].realMods)) {
 			*nMapsRtrn= _XkbErrCode4(0x09,n,preWire[n].realMods,
@@ -1643,7 +1633,7 @@ xkbSymMapWireDesc*	wire = *wireRtrn;
 	KeySym *pSyms;
 	register unsigned nG;
 	if (client->swapped) {
-	    swaps(&wire->nSyms,nG);
+	    swaps(&wire->nSyms);
 	}
 	nG = XkbNumGroups(wire->groupInfo);
 	if (nG>XkbNumKbdGroups) {
@@ -2023,9 +2013,8 @@ unsigned		first,last;
 		newSyms[s]= pSyms[s];
 	    }
 	    if (client->swapped) {
-		int n;
 		for (s=0;s<wire->nSyms;s++) {
-		    swapl(&newSyms[s],n);
+		    swapl(&newSyms[s]);
 		}
 	    }
 	}
@@ -2516,8 +2505,7 @@ int		size;
 		wire->flags= sym->flags;
 		memcpy((char*)&wire->act,(char*)&sym->act,sz_xkbActionWireDesc);
 		if (client->swapped) {
-		    register int n;
-		    swapl(&wire->sym,n);
+		    swapl(&wire->sym);
 		}
 	    }
 	    if (rep->groups) {
@@ -2528,8 +2516,7 @@ int		size;
 			grp->realMods= compat->groups[i].real_mods;
 			grp->virtualMods= compat->groups[i].vmods;
 			if (client->swapped) {
-			    register int n;
-			    swaps(&grp->virtualMods,n);
+			    swaps(&grp->virtualMods);
 			}
 			grp++;
 		    }
@@ -2542,12 +2529,11 @@ int		size;
     else data= NULL;
 
     if (client->swapped) {
-	register int n;
-	swaps(&rep->sequenceNumber,n);
-	swapl(&rep->length,n);
-	swaps(&rep->firstSI,n);
-	swaps(&rep->nSI,n);
-	swaps(&rep->nTotalSI,n);
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swaps(&rep->firstSI);
+	swaps(&rep->nSI);
+	swaps(&rep->nTotalSI);
     }
 
     WriteToClient(client, SIZEOF(xkbGetCompatMapReply), (char *)rep);
@@ -2662,8 +2648,7 @@ ProcXkbSetCompatMap(ClientPtr client)
 	sym = &compat->sym_interpret[stuff->firstSI];
 	for (i=0;i<stuff->nSI;i++,wire++,sym++) {
 	    if (client->swapped) {
-		register int n;
-		swapl(&wire->sym,n);
+		swapl(&wire->sym);
 	    }
 	    sym->sym= wire->sym;
 	    sym->mods= wire->mods;
@@ -2685,8 +2670,7 @@ ProcXkbSetCompatMap(ClientPtr client)
 	for (i=0,bit=1;i<XkbNumKbdGroups;i++,bit<<=1) {
 	    if (stuff->groups&bit) {
 		if (client->swapped) {
-		    register int n;
-		    swaps(&wire->virtualMods,n);
+		    swaps(&wire->virtualMods);
 		}
 		compat->groups[i].mask= wire->realMods;
 		compat->groups[i].real_mods= wire->realMods;
@@ -2742,7 +2726,6 @@ ProcXkbGetIndicatorState(ClientPtr client)
     xkbGetIndicatorStateReply 	rep;
     XkbSrvLedInfoPtr		sli;
     DeviceIntPtr 		dev;
-    register int 		i;
 
     REQUEST(xkbGetIndicatorStateReq);
     REQUEST_SIZE_MATCH(xkbGetIndicatorStateReq);
@@ -2764,8 +2747,8 @@ ProcXkbGetIndicatorState(ClientPtr client)
     rep.state = sli->effectiveState;
 
     if (client->swapped) {
-	swaps(&rep.sequenceNumber,i);
-	swapl(&rep.state,i);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.state);
     }
     WriteToClient(client, SIZEOF(xkbGetIndicatorStateReply), (char *)&rep);
     return client->noClientException;
@@ -2817,9 +2800,8 @@ register unsigned	bit;
 		    wire->virtualMods= indicators->maps[i].mods.vmods;
 		    wire->ctrls= indicators->maps[i].ctrls;
 		    if (client->swapped) {
-			register int n;
-			swaps(&wire->virtualMods,n);
-			swapl(&wire->ctrls,n);
+			swaps(&wire->virtualMods);
+			swapl(&wire->ctrls);
 		    }
 		    wire++;
 		}
@@ -2834,10 +2816,10 @@ register unsigned	bit;
     }
     else map = NULL;
     if (client->swapped) {
-	swaps(&rep->sequenceNumber,i);
-	swapl(&rep->length,i);
-	swapl(&rep->which,i);
-	swapl(&rep->realIndicators,i);
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swapl(&rep->which);
+	swapl(&rep->realIndicators);
     }
     WriteToClient(client, SIZEOF(xkbGetIndicatorMapReply), (char *)rep);
     if (map) {
@@ -2920,9 +2902,8 @@ ProcXkbSetIndicatorMap(ClientPtr client)
     for (i=0,bit=1;i<XkbNumIndicators;i++,bit<<=1) {
 	if (stuff->which&bit) {
 	    if (client->swapped) {
-		register int n;
-		swaps(&from->virtualMods,n);
-		swapl(&from->ctrls,n);
+		swaps(&from->virtualMods);
+		swapl(&from->ctrls);
 	    }
 	    CHK_MASK_LEGAL(i,from->whichGroups,XkbIM_UseAnyGroup);
 	    CHK_MASK_LEGAL(i,from->whichMods,XkbIM_UseAnyMods);
@@ -3037,12 +3018,11 @@ ProcXkbGetNamedIndicator(ClientPtr client)
 	rep.supported= 		supported;
     }
     if ( client->swapped ) {
-	register int n;
-	swapl(&rep.length,n);
-	swaps(&rep.sequenceNumber,n);
-	swapl(&rep.indicator,n);
-	swaps(&rep.virtualMods,n);
-	swapl(&rep.ctrls,n);
+	swapl(&rep.length);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.indicator);
+	swaps(&rep.virtualMods);
+	swapl(&rep.ctrls);
     }
 
     WriteToClient(client,SIZEOF(xkbGetNamedIndicatorReply), (char *)&rep);
@@ -3203,8 +3183,7 @@ Atom *atm;
 	if (atoms[i]!=None) {
 	    *atm= atoms[i];
 	    if (swap) {
-		register int n;
-		swapl(atm,n);
+		swapl(atm);
 	    }
 	    atm++;
 	}
@@ -3327,12 +3306,11 @@ char *			desc;
     length= rep->length*4;
     which= rep->which;
     if (client->swapped) {
-	register int n;
-	swaps(&rep->sequenceNumber,n);
-	swapl(&rep->length,n);
-	swapl(&rep->which,n);
-	swaps(&rep->virtualMods,n);
-	swapl(&rep->indicators,n);
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swapl(&rep->which);
+	swaps(&rep->virtualMods);
+	swapl(&rep->indicators);
     }
 
     start = desc = (char *)ALLOCATE_LOCAL(length);
@@ -3341,24 +3319,21 @@ char *			desc;
     if (which&XkbKeycodesNameMask) {
 	*((CARD32 *)desc)= xkb->names->keycodes;
 	if (client->swapped) {
-	    register int n;
-	    swapl(desc,n);
+	    swapl((int *)desc);
 	}
 	desc+= 4;
     }
     if (which&XkbGeometryNameMask)  {
 	*((CARD32 *)desc)= xkb->names->geometry;
 	if (client->swapped) {
-	    register int n;
-	    swapl(desc,n);
+	    swapl((int *)desc);
 	}
 	desc+= 4;
     }
     if (which&XkbSymbolsNameMask) {
 	*((CARD32 *)desc)= xkb->names->symbols;
 	if (client->swapped) {
-	    register int n;
-	    swapl(desc,n);
+	    swapl((int *)desc);
 	}
 	desc+= 4;
     }
@@ -3366,24 +3341,21 @@ char *			desc;
 	register CARD32 *atm= (CARD32 *)desc;
 	atm[0]= (CARD32)xkb->names->phys_symbols;
 	if (client->swapped) {
-	    register int n;
-	    swapl(&atm[0],n);
+	    swapl(&atm[0]);
 	}
 	desc+= 4;
     }
     if (which&XkbTypesNameMask) {
 	*((CARD32 *)desc)= (CARD32)xkb->names->types;
 	if (client->swapped) {
-	    register int n;
-	    swapl(desc,n);
+	    swapl((int *)desc);
 	}
 	desc+= 4;
     }
     if (which&XkbCompatNameMask) {
 	*((CARD32 *)desc)= (CARD32)xkb->names->compat;
 	if (client->swapped) {
-	    register int n;
-	    swapl(desc,n);
+	    swapl((int *)desc);
 	}
 	desc+= 4;
     }
@@ -3394,8 +3366,7 @@ char *			desc;
 	for (i=0;i<xkb->map->num_types;i++,atm++,type++) {
 	    *atm= (CARD32)type->name;
 	    if (client->swapped) {
-		register int n;
-		swapl(atm,n);
+		swapl(atm);
 	    }
 	}
 	desc= (char *)atm;
@@ -3416,8 +3387,7 @@ char *			desc;
 		for (l=0;l<type->num_levels;l++,atm++) {
 		    *atm= type->level_names[l];
 		    if (client->swapped) {
-			register unsigned n;
-			swapl(atm,n);
+			swapl(atm);
 		    }
 		}
 		desc+= type->num_levels*4;
@@ -3453,8 +3423,7 @@ char *			desc;
 	for (i=0;i<rep->nRadioGroups;i++,atm++) {
 	    *atm= (CARD32)xkb->names->radio_groups[i];
 	    if (client->swapped) {
-		register unsigned n;
-		swapl(atm,n);
+		swapl(atm);
 	    }
 	}
 	desc+= rep->nRadioGroups*4;
@@ -3515,8 +3484,7 @@ register int i;
 
     for (i=0;i<nAtoms;i++,wire++) {
 	if (swapped) {
-	    register int n;
-	    swapl(wire,n);
+	    swapl(wire);
 	}
 	if ((((Atom)*wire)!=None)&&(!ValidAtom((Atom)*wire))) {
 	    *pError= ((Atom)*wire);
@@ -3536,8 +3504,7 @@ register unsigned i,bit;
 	if ((present&bit)==0)
 	    continue;
 	if (swapped) {
-	    register int n;
-	    swapl(wire,n);
+	    swapl(wire);
 	}
 	if ((((Atom)*wire)!=None)&&(!ValidAtom(((Atom)*wire)))) {
 	    *pError= (Atom)*wire;
@@ -3930,8 +3897,7 @@ CARD16	len,*pLen;
     pLen= (CARD16 *)wire;
     *pLen= len;
     if (swap) {
-	register int n;
-	swaps(pLen,n);
+	swaps(pLen);
     }
     memcpy(&wire[2],str,len);
     wire+= ((2+len+3)/4)*4;
@@ -4046,8 +4012,7 @@ xkbShapeWireDesc *	shapeWire;
 	     shapeWire->approxNdx= XkbOutlineIndex(shape,shape->approx);
 	else shapeWire->approxNdx= XkbNoShape;
 	if (swap) {
-	    register int n;
-	    swapl(&shapeWire->name,n);
+	    swapl(&shapeWire->name);
 	}
 	wire= (char *)&shapeWire[1];
 	for (o=0,ol=shape->outlines;o<shape->num_outlines;o++,ol++) {
@@ -4063,9 +4028,8 @@ xkbShapeWireDesc *	shapeWire;
 		ptWire[p].x= pt->x;
 		ptWire[p].y= pt->y;
 		if (swap) {
-		    register int n;
-		    swaps(&ptWire[p].x,n);
-		    swaps(&ptWire[p].y,n);
+		    swaps(&ptWire[p].x);
+		    swaps(&ptWire[p].y);
 		}
 	    }
 	    wire= (char *)&ptWire[ol->num_points];
@@ -4108,10 +4072,9 @@ xkbDoodadWireDesc *	doodadWire;
 	doodadWire->any.top= doodad->any.top;
 	doodadWire->any.left= doodad->any.left;
 	if (swap) {
-	    register int n;
-	    swapl(&doodadWire->any.name,n);
-	    swaps(&doodadWire->any.top,n);
-	    swaps(&doodadWire->any.left,n);
+	    swapl(&doodadWire->any.name);
+	    swaps(&doodadWire->any.top);
+	    swaps(&doodadWire->any.left);
 	}
 	switch (doodad->any.type) {
 	    case XkbOutlineDoodad:
@@ -4120,8 +4083,7 @@ xkbDoodadWireDesc *	doodadWire;
 		doodadWire->shape.colorNdx= doodad->shape.color_ndx;
 		doodadWire->shape.shapeNdx= doodad->shape.shape_ndx;
 		if (swap) {
-		    register int n;
-		    swaps(&doodadWire->shape.angle,n);
+		    swaps(&doodadWire->shape.angle);
 		}
 		break;
 	    case XkbTextDoodad:
@@ -4130,10 +4092,9 @@ xkbDoodadWireDesc *	doodadWire;
 		doodadWire->text.height= doodad->text.height;
 		doodadWire->text.colorNdx= doodad->text.color_ndx;
 		if (swap) {
-		    register int n;
-		    swaps(&doodadWire->text.angle,n);
-		    swaps(&doodadWire->text.width,n);
-		    swaps(&doodadWire->text.height,n);
+		    swaps(&doodadWire->text.angle);
+		    swaps(&doodadWire->text.width);
+		    swaps(&doodadWire->text.height);
 		}
 		wire= XkbWriteCountedString(wire,doodad->text.text,swap);
 		wire= XkbWriteCountedString(wire,doodad->text.font,swap);
@@ -4171,8 +4132,7 @@ xkbOverlayWireDesc *	olWire;
    olWire->name= ol->name;
    olWire->nRows= ol->num_rows;
    if (swap) {
-	register int n;
-	swapl(&olWire->name,n);
+	swapl(&olWire->name);
    }
    wire= (char *)&olWire[1];
    for (r=0,row=ol->rows;r<ol->num_rows;r++,row++) {
@@ -4250,13 +4210,12 @@ xkbSectionWireDesc *	sectionWire;
 	sectionWire->nOverlays= section->num_overlays;
 	sectionWire->pad= 0;
 	if (swap) {
-	    register int n;
-	    swapl(&sectionWire->name,n);
-	    swaps(&sectionWire->top,n);
-	    swaps(&sectionWire->left,n);
-	    swaps(&sectionWire->width,n);
-	    swaps(&sectionWire->height,n);
-	    swaps(&sectionWire->angle,n);
+	    swapl(&sectionWire->name);
+	    swaps(&sectionWire->top);
+	    swaps(&sectionWire->left);
+	    swaps(&sectionWire->width);
+	    swaps(&sectionWire->height);
+	    swaps(&sectionWire->angle);
 	}
 	wire= (char *)&sectionWire[1];
 	if (section->rows) {
@@ -4271,9 +4230,8 @@ xkbSectionWireDesc *	sectionWire;
 		rowWire->vertical= row->vertical;
 		rowWire->pad= 0;
 		if (swap) {
-		    register int n;
-		    swaps(&rowWire->top,n);
-		    swaps(&rowWire->left,n);
+		    swaps(&rowWire->top);
+		    swaps(&rowWire->left);
 		}
 		wire= (char *)&rowWire[1];
 		if (row->keys) {
@@ -4287,8 +4245,7 @@ xkbSectionWireDesc *	sectionWire;
 			keyWire[k].shapeNdx= key->shape_ndx;
 			keyWire[k].colorNdx= key->color_ndx;
 			if (swap) {
-			    register int n;
-			    swaps(&keyWire[k].gap,n);
+			    swaps(&keyWire[k].gap);
 			}
 		    }
 		    wire= (char *)&keyWire[row->num_keys];
@@ -4390,18 +4347,17 @@ XkbSendGeometry(	ClientPtr		client,
 	start= NULL;
     }
     if (client->swapped) {
-	register int n;
-	swaps(&rep->sequenceNumber,n);
-	swapl(&rep->length,n);
-	swapl(&rep->name,n);
-	swaps(&rep->widthMM,n);
-	swaps(&rep->heightMM,n);
-	swaps(&rep->nProperties,n);
-	swaps(&rep->nColors,n);
-	swaps(&rep->nShapes,n);
-	swaps(&rep->nSections,n);
-	swaps(&rep->nDoodads,n);
-	swaps(&rep->nKeyAliases,n);
+	swaps(&rep->sequenceNumber);
+	swapl(&rep->length);
+	swapl(&rep->name);
+	swaps(&rep->widthMM);
+	swaps(&rep->heightMM);
+	swaps(&rep->nProperties);
+	swaps(&rep->nColors);
+	swaps(&rep->nShapes);
+	swaps(&rep->nSections);
+	swaps(&rep->nDoodads);
+	swaps(&rep->nKeyAliases);
     }
     WriteToClient(client, SIZEOF(xkbGetGeometryReply), (char *)rep);
     if (len>0)
@@ -4453,8 +4409,7 @@ CARD16	len;
     wire= *wire_inout;
     len= (CARD16 *)wire;
     if (client->swapped) {
-	register int n;
-	swaps(&len, n);
+	swaps(&len);
     }
     next = wire + XkbPaddedSize(len + 2);
     /* Check we're still within the size of the request */
@@ -4487,11 +4442,10 @@ Status			status;
     any = dWire->any;
     wire= (char *)&dWire[1];
     if (client->swapped) {
-	register int n;
-	swapl(&any.name, n);
-	swaps(&any.top, n);
-	swaps(&any.left, n);
-	swaps(&any.angle, n);
+	swapl(&any.name);
+	swaps(&any.top);
+	swaps(&any.left);
+	swaps(&any.angle);
     }
     CHK_ATOM_ONLY(dWire->any.name);
     doodad = XkbAddGeomDoodad(geom, section, any.name);
@@ -4526,9 +4480,8 @@ Status			status;
 	    }
 	    text = dWire->text;
 	    if (client->swapped) {
-		register int n;
-		swaps(&text.width, n);
-		swaps(&text.height, n);
+		swaps(&text.width);
+		swaps(&text.height);
 	    }
 	    doodad->text.width= text.width;
 	    doodad->text.height= text.height;
@@ -4602,8 +4555,7 @@ xkbOverlayRowWireDesc *	rWire;
     wire= *wire_inout;
     olWire= (xkbOverlayWireDesc *)wire;
     if (client->swapped) {
-	register int n;
-	swapl(&olWire->name,n);
+	swapl(&olWire->name);
     }
     CHK_ATOM_ONLY(olWire->name);
     ol= XkbAddGeomOverlay(section,olWire->name,olWire->nRows);
@@ -4655,13 +4607,12 @@ XkbSectionPtr		section;
 	register int		r;
 	xkbRowWireDesc *	rWire;
 	if (client->swapped) {
-	    register int n;
-	    swapl(&sWire->name,n);
-	    swaps(&sWire->top,n);
-	    swaps(&sWire->left,n);
-	    swaps(&sWire->width,n);
-	    swaps(&sWire->height,n);
-	    swaps(&sWire->angle,n);
+	    swapl(&sWire->name);
+	    swaps(&sWire->top);
+	    swaps(&sWire->left);
+	    swaps(&sWire->width);
+	    swaps(&sWire->height);
+	    swaps(&sWire->angle);
 	}
 	CHK_ATOM_ONLY(sWire->name);
 	section= XkbAddGeomSection(geom,sWire->name,sWire->nRows,
@@ -4680,9 +4631,8 @@ XkbSectionPtr		section;
 	    XkbRowPtr		row;
 	    xkbKeyWireDesc *	kWire;
 	    if (client->swapped) {
-		register int n;
-		swaps(&rWire->top,n);
-		swaps(&rWire->left,n);
+		swaps(&rWire->top);
+		swaps(&rWire->left);
 	    }
 	    row= XkbAddGeomRow(section,rWire->nKeys);
 	    if (!row)
@@ -4777,9 +4727,8 @@ char *		wire;
 		    pt->x= ptWire[p].x;
 		    pt->y= ptWire[p].y;
 		    if (client->swapped) {
-			register int n;
-			swaps(&pt->x,n);
-			swaps(&pt->y,n);
+			swaps(&pt->x);
+			swaps(&pt->y);
 		    }
 		}
 		ol->num_points= olWire->nPoints;
@@ -5022,12 +4971,11 @@ ProcXkbPerClientFlags(ClientPtr client)
 	rep.autoCtrls= rep.autoCtrlValues= 0;
     }
     if ( client->swapped ) {
-	register int n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.supported,n);
-	swapl(&rep.value,n);
-	swapl(&rep.autoCtrls,n);
-	swapl(&rep.autoCtrlValues,n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.supported);
+	swapl(&rep.value);
+	swapl(&rep.autoCtrls);
+	swapl(&rep.autoCtrlValues);
     }
     WriteToClient(client,SIZEOF(xkbPerClientFlagsReply), (char *)&rep);
     return client->noClientException;
@@ -5148,16 +5096,15 @@ ProcXkbListComponents(ClientPtr client)
     if (list.nTotal>list.maxRtrn)
 	rep.extra = (list.nTotal-list.maxRtrn);
     if (client->swapped) {
-	register int n;
-	swaps(&rep.sequenceNumber,n);
-	swapl(&rep.length,n);
-	swaps(&rep.nKeymaps,n);
-	swaps(&rep.nKeycodes,n);
-	swaps(&rep.nTypes,n);
-	swaps(&rep.nCompatMaps,n);
-	swaps(&rep.nSymbols,n);
-	swaps(&rep.nGeometries,n);
-	swaps(&rep.extra,n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.nKeymaps);
+	swaps(&rep.nKeycodes);
+	swaps(&rep.nTypes);
+	swaps(&rep.nCompatMaps);
+	swaps(&rep.nSymbols);
+	swaps(&rep.nGeometries);
+	swaps(&rep.extra);
     }
     WriteToClient(client,SIZEOF(xkbListComponentsReply),(char *)&rep);
     if (list.nPool && list.pool) {
@@ -5416,11 +5363,10 @@ ProcXkbGetKbdByName(ClientPtr client)
 
     reported= rep.reported;
     if ( client->swapped ) {
-	register int n;
-	swaps(&rep.sequenceNumber,n);
-	swapl(&rep.length,n);
-	swaps(&rep.found,n);
-	swaps(&rep.reported,n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.found);
+	swaps(&rep.reported);
     }
     WriteToClient(client,SIZEOF(xkbGetKbdByNameReply), (char *)&rep);
     if (reported&(XkbGBN_SymbolsMask|XkbGBN_TypesMask))
@@ -5606,13 +5552,12 @@ int			length;
     wire.physIndicators= 	sli->physIndicators;
     wire.state=			sli->effectiveState;
     if (client->swapped) {
-	register int n;
-	swaps(&wire.ledClass,n);
-	swaps(&wire.ledID,n);
-	swapl(&wire.namesPresent,n);
-	swapl(&wire.mapsPresent,n);
-	swapl(&wire.physIndicators,n);
-	swapl(&wire.state,n);
+	swaps(&wire.ledClass);
+	swaps(&wire.ledID);
+	swapl(&wire.namesPresent);
+	swapl(&wire.mapsPresent);
+	swapl(&wire.physIndicators);
+	swapl(&wire.state);
     }
     WriteToClient(client,SIZEOF(xkbDeviceLedsWireDesc),(char *)&wire);
     length+= SIZEOF(xkbDeviceLedsWireDesc);
@@ -5624,8 +5569,7 @@ int			length;
 		if (sli->namesPresent&bit) {
 		    awire= (CARD32)sli->names[i];
 		    if (client->swapped) {
-			register int n;
-			swapl(&awire,n);
+			swapl(&awire);
 		    }
 		    WriteToClient(client,4,(char *)&awire);
 		    length+= 4;
@@ -5645,9 +5589,8 @@ int			length;
 		    iwire.virtualMods=	sli->maps[i].mods.vmods;
 		    iwire.ctrls= 	sli->maps[i].ctrls;
 		    if (client->swapped) {
-			register int n;
-			swaps(&iwire.virtualMods,n);
-			swapl(&iwire.ctrls,n);
+			swaps(&iwire.virtualMods);
+			swapl(&iwire.ctrls);
 		    }
 		    WriteToClient(client,SIZEOF(xkbIndicatorMapWireDesc),
 								(char *)&iwire);
@@ -5802,14 +5745,16 @@ char *			str;
     supported= rep.supported;
     nDeviceLedFBs = rep.nDeviceLedFBs;
     if (client->swapped) {
-	register int n;
-	swaps(&rep.sequenceNumber,n);
-	swapl(&rep.length,n);
-	swaps(&rep.present,n);
-	swaps(&rep.supported,n);
-	swaps(&rep.unsupported,n);
-	swaps(&rep.nDeviceLedFBs,n);
-	swapl(&rep.type,n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.length);
+	swaps(&rep.present);
+	swaps(&rep.supported);
+	swaps(&rep.unsupported);
+	swaps(&rep.nDeviceLedFBs);
+
+	// FIXME: rep.type here is an Atom... this might go terribly wrong...
+
+	swapl((int *)&rep.type);
     }
     WriteToClient(client,SIZEOF(xkbGetDeviceInfoReply), (char *)&rep);
 
@@ -5871,12 +5816,11 @@ XkbSrvLedInfoPtr 	sli;
     ledWire= (xkbDeviceLedsWireDesc *)wire;
     for (i=0;i<num;i++) {
 	if (client->swapped) {
-	   register int n;
-	   swaps(&ledWire->ledClass,n);
-	   swaps(&ledWire->ledID,n);
-	   swapl(&ledWire->namesPresent,n);
-	   swapl(&ledWire->mapsPresent,n);
-	   swapl(&ledWire->physIndicators,n);
+	   swaps(&ledWire->ledClass);
+	   swaps(&ledWire->ledID);
+	   swapl(&ledWire->namesPresent);
+	   swapl(&ledWire->mapsPresent);
+	   swapl(&ledWire->physIndicators);
 	}
 
         sli= XkbFindSrvLedInfo(dev,ledWire->ledClass,ledWire->ledID,
@@ -5899,8 +5843,7 @@ XkbSrvLedInfoPtr 	sli;
 	    if (nNames>0) {
 		for (n=0;n<nNames;n++) {
 		    if (client->swapped) {
-			register int t;
-			swapl(atomWire,t);
+			swapl(atomWire);
 		    }
 		    CHK_ATOM_OR_NONE3(((Atom)(*atomWire)),client->errorValue,
 							*status_rtrn,NULL);
@@ -5911,9 +5854,8 @@ XkbSrvLedInfoPtr 	sli;
 	    if (nMaps>0) {
 		for (n=0;n<nMaps;n++) {
 		    if (client->swapped) {
-			register int t;
-			swaps(&mapWire->virtualMods,t);
-			swapl(&mapWire->ctrls,t);
+			swaps(&mapWire->virtualMods);
+			swapl(&mapWire->ctrls);
 		    }
 		    CHK_MASK_LEGAL3(0x21,mapWire->whichGroups,
 						XkbIM_UseAnyGroup,
@@ -6165,12 +6107,11 @@ xkbSetDebuggingFlagsReply 	rep;
     rep.supportedFlags = ~0;
     rep.supportedCtrls = ~0;
     if ( client->swapped ) {
-	register int n;
-	swaps(&rep.sequenceNumber, n);
-	swapl(&rep.currentFlags, n);
-	swapl(&rep.currentCtrls, n);
-	swapl(&rep.supportedFlags, n);
-	swapl(&rep.supportedCtrls, n);
+	swaps(&rep.sequenceNumber);
+	swapl(&rep.currentFlags);
+	swapl(&rep.currentCtrls);
+	swapl(&rep.supportedFlags);
+	swapl(&rep.supportedCtrls);
     }
     WriteToClient(client,SIZEOF(xkbSetDebuggingFlagsReply), (char *)&rep);
     return client->noClientException;

--- a/nx-X11/programs/Xserver/xkb/xkbEvents.c
+++ b/nx-X11/programs/Xserver/xkb/xkbEvents.c
@@ -67,10 +67,9 @@ CARD16		changed;
 		pNKN->time = time;
 		pNKN->changed = changed;
 		if ( clients[i]->swapped ) {
-		    register int n;
-		    swaps(&pNKN->sequenceNumber,n);
-		    swapl(&pNKN->time,n);
-		    swaps(&pNKN->changed,n);
+		    swaps(&pNKN->sequenceNumber);
+		    swapl(&pNKN->time);
+		    swaps(&pNKN->changed);
 		}
 		WriteToClient(clients[i],sizeof(xEvent),(char *)pNKN);
 		if (changed&XkbNKN_KeycodesMask) {
@@ -87,8 +86,7 @@ CARD16		changed;
 	    event.u.mappingNotify.count= clients[i]->maxKC-clients[i]->minKC+1;
 	    event.u.u.sequenceNumber= clients[i]->sequence;
 	    if (clients[i]->swapped) {
-		int n;
-		swaps(&event.u.u.sequenceNumber,n);
+		swaps(&event.u.u.sequenceNumber);
 	    }
 	    WriteToClient(clients[i],SIZEOF(xEvent), (char *)&event);
 	    event.u.mappingNotify.request= MappingModifier;
@@ -146,11 +144,10 @@ register CARD16	changed,bState;
 	    pSN->changed = changed;
 	    pSN->ptrBtnState = bState;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pSN->sequenceNumber,n);
-		swapl(&pSN->time,n);
-		swaps(&pSN->changed,n);
-		swaps(&pSN->ptrBtnState,n);
+		swaps(&pSN->sequenceNumber);
+		swapl(&pSN->time);
+		swaps(&pSN->changed);
+		swaps(&pSN->ptrBtnState);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pSN);
 	}
@@ -192,10 +189,9 @@ CARD16		changed;
 	    pMN->sequenceNumber = clients[i]->sequence;
 	    pMN->changed = changed;
 	    if ( clients[i]->swapped ) {
-		register int n;
-		swaps(&pMN->sequenceNumber,n);
-		swapl(&pMN->time,n);
-		swaps(&pMN->changed,n);
+		swaps(&pMN->sequenceNumber);
+		swapl(&pMN->time);
+		swaps(&pMN->changed);
 	    }
 	    WriteToClient(clients[i],sizeof(xEvent),(char *)pMN);
 	}
@@ -315,12 +311,11 @@ Time 		 	time = 0;
 	    pCN->sequenceNumber = interest->client->sequence;
 	    pCN->time = time;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pCN->sequenceNumber,n);
-		swapl(&pCN->changedControls,n);
-		swapl(&pCN->enabledControls,n);
-		swapl(&pCN->enabledControlChanges,n);
-		swapl(&pCN->time,n);
+		swaps(&pCN->sequenceNumber);
+		swapl(&pCN->changedControls);
+		swapl(&pCN->enabledControls);
+		swapl(&pCN->enabledControlChanges);
+		swapl(&pCN->time);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pCN);
 	}
@@ -364,11 +359,10 @@ CARD32		state,changed;
 	    pEv->changed = changed;
 	    pEv->state = state;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
-		swapl(&pEv->changed,n);
-		swapl(&pEv->state,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
+		swapl(&pEv->changed);
+		swapl(&pEv->state);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}
@@ -447,13 +441,12 @@ XID		winID = 0;
 	    bn.name = name;
 	    bn.window=  winID;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&bn.sequenceNumber,n);
-		swapl(&bn.time,n);
-		swaps(&bn.pitch,n);
-		swaps(&bn.duration,n);
-		swapl(&bn.name,n);
-		swapl(&bn.window,n);
+		swaps(&bn.sequenceNumber);
+		swapl(&bn.time);
+		swaps(&bn.pitch);
+		swaps(&bn.duration);
+		swapl(&bn.name);
+		swapl(&bn.window);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)&bn);
 	}
@@ -494,11 +487,10 @@ CARD16		sk_delay,db_delay;
 	    pEv->slowKeysDelay = sk_delay;
 	    pEv->debounceDelay = db_delay;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
-		swaps(&pEv->slowKeysDelay,n);
-		swaps(&pEv->debounceDelay,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
+		swaps(&pEv->slowKeysDelay);
+		swaps(&pEv->debounceDelay);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}
@@ -542,12 +534,11 @@ CARD32		changedIndicators;
 	    pEv->changedIndicators = changedIndicators;
 	    pEv->changedVirtualMods= changedVirtualMods;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
-		swaps(&pEv->changed,n);
-		swapl(&pEv->changedIndicators,n);
-		swaps(&pEv->changedVirtualMods,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
+		swaps(&pEv->changed);
+		swapl(&pEv->changedIndicators);
+		swaps(&pEv->changedVirtualMods);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}
@@ -590,12 +581,11 @@ CARD16		firstSI = 0, nSI = 0, nTotalSI = 0;
 	    pEv->nSI = nSI;
 	    pEv->nTotalSI = nTotalSI;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
-		swaps(&pEv->firstSI,n);
-		swaps(&pEv->nSI,n);
-		swaps(&pEv->nTotalSI,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
+		swaps(&pEv->firstSI);
+		swaps(&pEv->nSI);
+		swaps(&pEv->nTotalSI);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}
@@ -636,9 +626,8 @@ Time 		 time = 0;
 	    pEv->sequenceNumber = interest->client->sequence;
 	    pEv->time = time;
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}
@@ -696,13 +685,12 @@ CARD16		 reason, supported = 0;
 		    continue;
 	    }
 	    if ( interest->client->swapped ) {
-		register int n;
-		swaps(&pEv->sequenceNumber,n);
-		swapl(&pEv->time,n);
-		swapl(&pEv->ledsDefined,n);
-		swapl(&pEv->ledState,n);
-		swaps(&pEv->reason,n);
-		swaps(&pEv->supported,n);
+		swaps(&pEv->sequenceNumber);
+		swapl(&pEv->time);
+		swapl(&pEv->ledsDefined);
+		swapl(&pEv->ledState);
+		swaps(&pEv->reason);
+		swaps(&pEv->supported);
 	    }
 	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
 	}

--- a/nx-X11/programs/Xserver/xkb/xkbSwap.c
+++ b/nx-X11/programs/Xserver/xkb/xkbSwap.c
@@ -48,32 +48,30 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 static int
 SProcXkbUseExtension(ClientPtr client)
 {
-register int n;
 
     REQUEST(xkbUseExtensionReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbUseExtensionReq);
-    swaps(&stuff->wantedMajor,n);
-    swaps(&stuff->wantedMinor,n);
+    swaps(&stuff->wantedMajor);
+    swaps(&stuff->wantedMinor);
     return ProcXkbUseExtension(client);
 }
 
 static int
 SProcXkbSelectEvents(ClientPtr client)
 {
-register int n;
 
     REQUEST(xkbSelectEventsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSelectEventsReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->affectWhich,n);
-    swaps(&stuff->clear,n);
-    swaps(&stuff->selectAll,n);
-    swaps(&stuff->affectMap,n);
-    swaps(&stuff->map,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->affectWhich);
+    swaps(&stuff->clear);
+    swaps(&stuff->selectAll);
+    swaps(&stuff->affectMap);
+    swaps(&stuff->map);
     if ((stuff->affectWhich&(~XkbMapNotifyMask))!=0)  {
 	union {
 	    BOOL	*b;
@@ -117,12 +115,12 @@ register int n;
 	    if (dataLeft<(size*2))
 		return BadLength;
 	    if (size==2) {
-		swaps(&from.c16[0],n);
-		swaps(&from.c16[1],n);
+		swaps(&from.c16[0]);
+		swaps(&from.c16[1]);
 	    }
 	    else if (size==4) {
-		swapl(&from.c32[0],n);
-		swapl(&from.c32[1],n);
+		swapl(&from.c32[0]);
+		swapl(&from.c32[1]);
 	    }
 	    else {
 		size= 2;
@@ -141,128 +139,114 @@ register int n;
 static int
 SProcXkbBell(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbBellReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbBellReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->bellClass,n);
-    swaps(&stuff->bellID,n);
-    swapl(&stuff->name,n);
-    swapl(&stuff->window,n);
-    swaps(&stuff->pitch,n);
-    swaps(&stuff->duration,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->bellClass);
+    swaps(&stuff->bellID);
+    swapl(&stuff->name);
+    swapl(&stuff->window);
+    swaps(&stuff->pitch);
+    swaps(&stuff->duration);
     return ProcXkbBell(client);
 }
 
 static int
 SProcXkbGetState(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetStateReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetStateReq);
-    swaps(&stuff->deviceSpec,n);
+    swaps(&stuff->deviceSpec);
     return ProcXkbGetState(client);
 }
 
 static int
 SProcXkbLatchLockState(ClientPtr client)
 {
-register int 	n;
-
     REQUEST(xkbLatchLockStateReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbLatchLockStateReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->groupLatch,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->groupLatch);
     return ProcXkbLatchLockState(client);
 }
 
 static int
 SProcXkbGetControls(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetControlsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetControlsReq);
-    swaps(&stuff->deviceSpec,n);
+    swaps(&stuff->deviceSpec);
     return ProcXkbGetControls(client);
 }
 
 static int
 SProcXkbSetControls(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetControlsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbSetControlsReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->affectInternalVMods,n);
-    swaps(&stuff->internalVMods,n);
-    swaps(&stuff->affectIgnoreLockVMods,n);
-    swaps(&stuff->ignoreLockVMods,n);
-    swaps(&stuff->axOptions,n);
-    swapl(&stuff->affectEnabledCtrls,n);
-    swapl(&stuff->enabledCtrls,n);
-    swapl(&stuff->changeCtrls,n);
-    swaps(&stuff->repeatDelay,n);
-    swaps(&stuff->repeatInterval,n);
-    swaps(&stuff->slowKeysDelay,n);
-    swaps(&stuff->debounceDelay,n);
-    swaps(&stuff->mkDelay,n);
-    swaps(&stuff->mkInterval,n);
-    swaps(&stuff->mkTimeToMax,n);
-    swaps(&stuff->mkMaxSpeed,n);
-    swaps(&stuff->mkCurve,n);
-    swaps(&stuff->axTimeout,n);
-    swapl(&stuff->axtCtrlsMask,n);
-    swapl(&stuff->axtCtrlsValues,n);
-    swaps(&stuff->axtOptsMask,n);
-    swaps(&stuff->axtOptsValues,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->affectInternalVMods);
+    swaps(&stuff->internalVMods);
+    swaps(&stuff->affectIgnoreLockVMods);
+    swaps(&stuff->ignoreLockVMods);
+    swaps(&stuff->axOptions);
+    swapl(&stuff->affectEnabledCtrls);
+    swapl(&stuff->enabledCtrls);
+    swapl(&stuff->changeCtrls);
+    swaps(&stuff->repeatDelay);
+    swaps(&stuff->repeatInterval);
+    swaps(&stuff->slowKeysDelay);
+    swaps(&stuff->debounceDelay);
+    swaps(&stuff->mkDelay);
+    swaps(&stuff->mkInterval);
+    swaps(&stuff->mkTimeToMax);
+    swaps(&stuff->mkMaxSpeed);
+    swaps(&stuff->mkCurve);
+    swaps(&stuff->axTimeout);
+    swapl(&stuff->axtCtrlsMask);
+    swapl(&stuff->axtCtrlsValues);
+    swaps(&stuff->axtOptsMask);
+    swaps(&stuff->axtOptsValues);
     return ProcXkbSetControls(client);
 }
 
 static int
 SProcXkbGetMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->full,n);
-    swaps(&stuff->partial,n);
-    swaps(&stuff->virtualMods,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->full);
+    swaps(&stuff->partial);
+    swaps(&stuff->virtualMods);
     return ProcXkbGetMap(client);
 }
 
 static int
 SProcXkbSetMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->present,n);
-    swaps(&stuff->flags,n);
-    swaps(&stuff->totalSyms,n);
-    swaps(&stuff->totalActs,n);
-    swaps(&stuff->virtualMods,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->present);
+    swaps(&stuff->flags);
+    swaps(&stuff->totalSyms);
+    swaps(&stuff->totalActs);
+    swaps(&stuff->virtualMods);
     return ProcXkbSetMap(client);
 }
 
@@ -270,105 +254,91 @@ register int	n;
 static int
 SProcXkbGetCompatMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetCompatMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetCompatMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->firstSI,n);
-    swaps(&stuff->nSI,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->firstSI);
+    swaps(&stuff->nSI);
     return ProcXkbGetCompatMap(client);
 }
 
 static int
 SProcXkbSetCompatMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetCompatMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetCompatMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->firstSI,n);
-    swaps(&stuff->nSI,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->firstSI);
+    swaps(&stuff->nSI);
     return ProcXkbSetCompatMap(client);
 }
 
 static int
 SProcXkbGetIndicatorState(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetIndicatorStateReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetIndicatorStateReq);
-    swaps(&stuff->deviceSpec,n);
+    swaps(&stuff->deviceSpec);
     return ProcXkbGetIndicatorState(client);
 }
 
 static int
 SProcXkbGetIndicatorMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetIndicatorMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetIndicatorMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->which,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->which);
     return ProcXkbGetIndicatorMap(client);
 }
 
 static int
 SProcXkbSetIndicatorMap(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetIndicatorMapReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetIndicatorMapReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->which,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->which);
     return ProcXkbSetIndicatorMap(client);
 }
 
 static int
 SProcXkbGetNamedIndicator(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetNamedIndicatorReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetNamedIndicatorReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->ledClass,n);
-    swaps(&stuff->ledID,n);
-    swapl(&stuff->indicator,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->ledClass);
+    swaps(&stuff->ledID);
+    swapl(&stuff->indicator);
     return ProcXkbGetNamedIndicator(client);
 }
 
 static int
 SProcXkbSetNamedIndicator(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetNamedIndicatorReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbSetNamedIndicatorReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->ledClass,n);
-    swaps(&stuff->ledID,n);
-    swapl(&stuff->indicator,n);
-    swaps(&stuff->virtualMods,n);
-    swapl(&stuff->ctrls,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->ledClass);
+    swaps(&stuff->ledID);
+    swapl(&stuff->indicator);
+    swaps(&stuff->virtualMods);
+    swapl(&stuff->ctrls);
     return ProcXkbSetNamedIndicator(client);
 }
 
@@ -376,160 +346,140 @@ register int	n;
 static int
 SProcXkbGetNames(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetNamesReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetNamesReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->which,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->which);
     return ProcXkbGetNames(client);
 }
 
 static int
 SProcXkbSetNames(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetNamesReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetNamesReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->virtualMods,n);
-    swapl(&stuff->which,n);
-    swapl(&stuff->indicators,n);
-    swaps(&stuff->totalKTLevelNames,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->virtualMods);
+    swapl(&stuff->which);
+    swapl(&stuff->indicators);
+    swaps(&stuff->totalKTLevelNames);
     return ProcXkbSetNames(client);
 }
 
 static int
 SProcXkbGetGeometry(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetGeometryReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetGeometryReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->name,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->name);
     return ProcXkbGetGeometry(client);
 }
 
 static int
 SProcXkbSetGeometry(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetGeometryReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetGeometryReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->name,n);
-    swaps(&stuff->widthMM,n);
-    swaps(&stuff->heightMM,n);
-    swaps(&stuff->nProperties,n);
-    swaps(&stuff->nColors,n);
-    swaps(&stuff->nDoodads,n);
-    swaps(&stuff->nKeyAliases,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->name);
+    swaps(&stuff->widthMM);
+    swaps(&stuff->heightMM);
+    swaps(&stuff->nProperties);
+    swaps(&stuff->nColors);
+    swaps(&stuff->nDoodads);
+    swaps(&stuff->nKeyAliases);
     return ProcXkbSetGeometry(client);
 }
 
 static int
 SProcXkbPerClientFlags(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbPerClientFlagsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbPerClientFlagsReq);
-    swaps(&stuff->deviceSpec,n);
-    swapl(&stuff->change,n);
-    swapl(&stuff->value,n);
-    swapl(&stuff->ctrlsToChange,n);
-    swapl(&stuff->autoCtrls,n);
-    swapl(&stuff->autoCtrlValues,n);
+    swaps(&stuff->deviceSpec);
+    swapl(&stuff->change);
+    swapl(&stuff->value);
+    swapl(&stuff->ctrlsToChange);
+    swapl(&stuff->autoCtrls);
+    swapl(&stuff->autoCtrlValues);
     return ProcXkbPerClientFlags(client);
 }
 
 static int
 SProcXkbListComponents(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbListComponentsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbListComponentsReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->maxNames,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->maxNames);
     return ProcXkbListComponents(client);
 }
 
 static int
 SProcXkbGetKbdByName(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetKbdByNameReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbGetKbdByNameReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->want,n);
-    swaps(&stuff->need,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->want);
+    swaps(&stuff->need);
     return ProcXkbGetKbdByName(client);
 }
 
 static int
 SProcXkbGetDeviceInfo(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbGetDeviceInfoReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_SIZE_MATCH(xkbGetDeviceInfoReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->wanted,n);
-    swaps(&stuff->ledClass,n);
-    swaps(&stuff->ledID,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->wanted);
+    swaps(&stuff->ledClass);
+    swaps(&stuff->ledID);
     return ProcXkbGetDeviceInfo(client);
 }
 
 static int
 SProcXkbSetDeviceInfo(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetDeviceInfoReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetDeviceInfoReq);
-    swaps(&stuff->deviceSpec,n);
-    swaps(&stuff->change,n);
-    swaps(&stuff->nDeviceLedFBs,n);
+    swaps(&stuff->deviceSpec);
+    swaps(&stuff->change);
+    swaps(&stuff->nDeviceLedFBs);
     return ProcXkbSetDeviceInfo(client);
 }
 
 static int
 SProcXkbSetDebuggingFlags(ClientPtr client)
 {
-register int	n;
-
     REQUEST(xkbSetDebuggingFlagsReq);
 
-    swaps(&stuff->length,n);
+    swaps(&stuff->length);
     REQUEST_AT_LEAST_SIZE(xkbSetDebuggingFlagsReq);
-    swapl(&stuff->affectFlags,n);
-    swapl(&stuff->flags,n);
-    swapl(&stuff->affectCtrls,n);
-    swapl(&stuff->ctrls,n);
-    swaps(&stuff->msgLength,n);
+    swapl(&stuff->affectFlags);
+    swapl(&stuff->flags);
+    swapl(&stuff->affectCtrls);
+    swapl(&stuff->ctrls);
+    swaps(&stuff->msgLength);
     return ProcXkbSetDebuggingFlags(client);
 }
 


### PR DESCRIPTION
 While working on this changeset, various spots got discovered where
 swapl or swaps was used on a wrong type, where byte swapping calls had
 been forgotten or done on the wrong variable.

 This backport at least includes changes from the following X.org
 commits, listed in non-chronological order:

 commit 2c7c520cfe0df30f4bc3adba59d9c62582823bf8
 Author: Matt Turner mattst88@gmail.com
 Date:   Thu Aug 4 15:35:41 2011 -0400

```
Use internal temp variable for swap macros

Also, fix whitespace, mainly around
    swaps(&rep.sequenceNumber)

Reviewed-by: Peter Harris <pharris@opentext.com>
Signed-off-by: Matt Turner <mattst88@gmail.com>
```

 commit 9edcae78c46286baff42e74bfe26f6ae4d00fe01
 Author: Matt Turner mattst88@gmail.com
 Date:   Wed Sep 21 17:14:16 2011 -0400

```
Use correct swap{l,s} (or none at all for CARD8)

Swapping the wrong size was never caught because swap{l,s} are macros.

It's clear in the case of Xext/xres.c, that the author believed
client_major/minor to be CARD16 from looking at the code in the first
hunk.

v2: dmx.c fixes from Keith.

Reviewed-by: Peter Harris <pharris@opentext.com>
Signed-off-by: Matt Turner <mattst88@gmail.com>
```

 commit dab064fa5e0b1f5c67222562ad5367005832cba1
 Author: Andrea Canciani ranma42@gmail.com
 Date:   Tue Nov 2 20:10:32 2010 +0100

```
render: Fix byteswapping of gradient stops

The function swapStops repeatedly swaps the color components as
CARD16, but incorrectly steps over them as if they were CARD32.

This causes half of the stops not to be swapped at all and some
unrelated data be swapped instead.

Signed-off-by: Andrea Canciani <ranma42@gmail.com>
Reviewed-by: Soren Sandmann <sandmann@daimi.au.dk>
Reviewed-by: Julien Cristau <jcristau@debian.org>
Signed-off-by: Keith Packard <keithp@keithp.com>
```

 commit 54770c980cd2b91a8377f975a58ed69def5cfa42
 Author: Matt Turner mattst88@gmail.com
 Date:   Tue Aug 16 16:59:07 2011 -0400

```
Cast char* buffers to swap functions

Reviewed-by: Peter Harris <pharris@opentext.com>
Signed-off-by: Matt Turner <mattst88@gmail.com>
```

 commit 6844bd2e63490870bab3c469eec6030354ef2865
 Author: Alan Coopersmith alan.coopersmith@sun.com
 Date:   Wed Jan 9 19:52:00 2008 -0800

```
More Xv extension byte swapping fixes
```

 commit e46f6ddeccd082b2d507a1e8b57ea30e6b0a2c83
 Author: Michel Dänzer michel@tungstengraphics.com
 Date:   Wed Jan 16 14:24:22 2008 +0100

```
Yet another Xv extension byte swapping fix.
```
