### PR TITLE
Backport _XGetRequest and XEatDataWords from X.org's libX11

### DIFF
--- a/nx-X11/lib/X11/XlibInt.c
+++ b/nx-X11/lib/X11/XlibInt.c
@@ -2751,6 +2751,30 @@ void _XEatData(
 #undef SCRATCHSIZE
 }
 
+/*
+   Port from libXfixes commit
+   b031e3b60fa1af9e49449f23d4a84395868be3ab We need this here to
+   enable linking of current libXrender against libNX_X11 instead of
+   the system's libX11
+
+   The original implementation of this function (libX11 commit
+   9f5d83706543696fc944c1835a403938c06f2cc5) uses xcb stuff which we
+   do not have in libNX_X11. So we take a workaround from another
+   lib. This workaround had been implemented temporarily in a couple
+   of X libs, see e.g. https://lists.x.org/archives/xorg-devel/2013-July/036763.html.
+*/
+#include <X11/Xmd.h>  /* for LONG64 on 64-bit platforms */
+#include <limits.h>
+
+void _XEatDataWords(Display *dpy, unsigned long n)
+{
+#ifndef LONG64
+    if (n >= (ULONG_MAX >> 2))
+        _XIOError(dpy);
+#endif
+    _XEatData (dpy, n << 2);
+}
+
 
 /*
  * _XEnq - Place event packets on the display's queue.

--- a/nx-X11/lib/X11/XlibInt.c
+++ b/nx-X11/lib/X11/XlibInt.c
@@ -3732,6 +3732,36 @@ Screen *_XScreenOfWindow (dpy, w)
     return NULL;
 }
 
+/*
+ * WARNING: This implementation's pre-conditions and post-conditions
+ * must remain compatible with the old macro-based implementations of
+ * GetReq, GetReqExtra, GetResReq, and GetEmptyReq. The portions of the
+ * Display structure affected by those macros are part of libX11's
+ * ABI.
+ */
+void *_XGetRequest(Display *dpy, CARD8 type, size_t len)
+{
+    xReq *req;
+
+    WORD64ALIGN
+
+    if (dpy->bufptr + len > dpy->bufmax)
+       _XFlush(dpy);
+
+    if (len % 4)
+       fprintf(stderr,
+               "Xlib: request %d length %zd not a multiple of 4.\n",
+               type, len);
+
+    dpy->last_req = dpy->bufptr;
+
+    req = (xReq*)dpy->bufptr;
+    req->reqType = type;
+    req->length = len / 4;
+    dpy->bufptr += len;
+    dpy->request++;
+    return req;
+}
 
 #if defined(WIN32)
 

--- a/nx-X11/lib/X11/Xlibint.h
+++ b/nx-X11/lib/X11/Xlibint.h
@@ -422,6 +422,19 @@ extern LockInfoPtr _Xglobal_lock;
 /* Leftover from CRAY support - was defined empty on all non-Cray systems */
 #define WORD64ALIGN
 
+/**
+ * Return a len-sized request buffer for the request type. This function may
+ * flush the output queue.
+ *
+ * @param dpy The display connection
+ * @param type The request type
+ * @param len Length of the request in bytes
+ *
+ * @returns A pointer to the request buffer with a few default values
+ * initialized.
+ */
+extern void *_XGetRequest(Display *dpy, CARD8 type, size_t len);
+
 /*
  * GetReq - Get the next available X request packet in the buffer and
  * return it. 
@@ -433,23 +446,10 @@ extern LockInfoPtr _Xglobal_lock;
 
 #if !defined(UNIXCPP) || defined(ANSICPP)
 #define GetReq(name, req) \
-	if ((dpy->bufptr + SIZEOF(x##name##Req)) > dpy->bufmax)\
-		_XFlush(dpy);\
-	req = (x##name##Req *)(dpy->last_req = dpy->bufptr);\
-	req->reqType = X_##name;\
-	req->length = (SIZEOF(x##name##Req))>>2;\
-	dpy->bufptr += SIZEOF(x##name##Req);\
-	dpy->request++
-
+        req = (x##name##Req *) _XGetRequest(dpy, X_##name, SIZEOF(x##name##Req))
 #else  /* non-ANSI C uses empty comment instead of "##" for token concatenation */
 #define GetReq(name, req) \
-	if ((dpy->bufptr + SIZEOF(x/**/name/**/Req)) > dpy->bufmax)\
-		_XFlush(dpy);\
-	req = (x/**/name/**/Req *)(dpy->last_req = dpy->bufptr);\
-	req->reqType = X_/**/name;\
-	req->length = (SIZEOF(x/**/name/**/Req))>>2;\
-	dpy->bufptr += SIZEOF(x/**/name/**/Req);\
-	dpy->request++
+        req = (x/**/name/**/Req *) _XGetRequest(dpy, X_/**/name, SIZEOF(x/**/name/**/Req))
 #endif
 
 /* GetReqExtra is the same as GetReq, but allocates "n" additional
@@ -457,22 +457,10 @@ extern LockInfoPtr _Xglobal_lock;
 
 #if !defined(UNIXCPP) || defined(ANSICPP)
 #define GetReqExtra(name, n, req) \
-	if ((dpy->bufptr + SIZEOF(x##name##Req) + n) > dpy->bufmax)\
-		_XFlush(dpy);\
-	req = (x##name##Req *)(dpy->last_req = dpy->bufptr);\
-	req->reqType = X_##name;\
-	req->length = (SIZEOF(x##name##Req) + n)>>2;\
-	dpy->bufptr += SIZEOF(x##name##Req) + n;\
-	dpy->request++
+        req = (x##name##Req *) _XGetRequest(dpy, X_##name, SIZEOF(x##name##Req) + n)
 #else
 #define GetReqExtra(name, n, req) \
-	if ((dpy->bufptr + SIZEOF(x/**/name/**/Req) + n) > dpy->bufmax)\
-		_XFlush(dpy);\
-	req = (x/**/name/**/Req *)(dpy->last_req = dpy->bufptr);\
-	req->reqType = X_/**/name;\
-	req->length = (SIZEOF(x/**/name/**/Req) + n)>>2;\
-	dpy->bufptr += SIZEOF(x/**/name/**/Req) + n;\
-	dpy->request++
+        req = (x/**/name/**/Req *) _XGetRequest(dpy, X_/**/name, SIZEOF(x/**/name/**/Req) + n)
 #endif
 
 

--- a/nx-X11/lib/X11/Xlibint.h
+++ b/nx-X11/lib/X11/Xlibint.h
@@ -879,6 +879,10 @@ extern void _XEatData(
     Display*		/* dpy */,
     unsigned long	/* n */
 );
+extern void _XEatDataWords(
+    Display*            /* dpy */,
+    unsigned long       /* n */
+);
 extern char *_XAllocScratch(
     Display*		/* dpy */,
     unsigned long	/* nbytes */


### PR DESCRIPTION
nx-libs's nxagent links against libXrender. libXrender is originally designed to link against libX11. In nxagent we (have to) shadow libX11 and replace it by libNX_X11. For this to be possible, libNX_X11 has to be API(/ABI) compatible with libX11.

For linking libXrender against libNX_X11, two functions had to be backported to libNX_X11: _XGetRequest() and XEatDataWords().

Fixes ArcticaProject/nx-libs#169 (i.e. this PR obsoletes former PR).
