### PR TITLE
Rework nxagent and nxproxy wrapper scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BINDIR      ?= $(PREFIX)/bin
 LIBDIR      ?= $(PREFIX)/lib
 USRLIBDIR   ?= $(LIBDIR)
 INCLUDEDIR  ?= $(PREFIX)/include
-NXLIBDIR    ?= $(PREFIX)/lib/nx
+NXLIBDIR    ?= $(LIBDIR)/nx
 CONFIGURE   ?= ./configure
 
 NX_VERSION_MAJOR=$(shell ./version.sh 1)
@@ -36,6 +36,8 @@ SHELL:=/bin/bash
 	# clean auto-generated nxversion.def file \
 	if [ "x$@" == "xclean" ] || [ "x$@" = "xdistclean" ]; then \
 	    rm -f nx-X11/config/cf/nxversion.def; \
+	    rm -f bin/nxagent; \
+	    rm -f bin/nxproxy; \
 	fi
 
 all: build
@@ -91,6 +93,7 @@ install-lite:
 
 	# install nxproxy wrapper script
 	$(INSTALL_DIR) $(DESTDIR)$(BINDIR)
+	sed -e 's|@@NXLIBDIR@@|$(NXLIBDIR)|g' bin/nxproxy.in > bin/nxproxy
 	$(INSTALL_PROGRAM) bin/nxproxy $(DESTDIR)$(BINDIR)
 
 	# FIXME: the below install logic should work via nxproxy/Makefile.in
@@ -103,8 +106,11 @@ install-lite:
 	gzip $(DESTDIR)$(PREFIX)/share/man/man1/*.1
 
 install-full:
-	for f in nxagent; do \
-	   $(INSTALL_PROGRAM) bin/$$f $(DESTDIR)$(BINDIR); done
+	# install nxagent wrapper script
+	$(INSTALL_DIR) $(DESTDIR)$(BINDIR)
+	sed -e 's|@@NXLIBDIR@@|$(NXLIBDIR)|g' bin/nxagent.in > bin/nxagent
+	$(INSTALL_PROGRAM) bin/nxagent $(DESTDIR)$(BINDIR)
+
 	for d in nxcompext nxcompshad; do \
 	   $(MAKE) -C $$d install; done
 
@@ -141,6 +147,9 @@ install-full:
 
 	$(INSTALL_DIR) $(DESTDIR)$(USRLIBDIR)
 	$(COPY_SYMLINK) nx-X11/.build-exports/lib/*.so* $(DESTDIR)$(USRLIBDIR)/
+	$(INSTALL_DIR) $(DESTDIR)$(USRLIBDIR)/nx-X11
+	$(INSTALL_SYMLINK) ../libNX_X11.so $(DESTDIR)$(USRLIBDIR)/nx-X11/libX11.so
+	$(INSTALL_SYMLINK) ../libNX_X11.so.6.2 $(DESTDIR)$(USRLIBDIR)/nx-X11/libX11.so.6.2
 
 	. replace.sh; set -x; find nx-X11/.build-exports/include/ -type d | \
 	    while read dirname; do \

--- a/bin/nxagent.in
+++ b/bin/nxagent.in
@@ -15,15 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
-NXAPP=nxproxy
-NX_LIBS=/usr/lib/nx
-NX_LOCAL_LIBS=/usr/local/lib/nx
+NX_LIBS=@@NXLIBDIR@@
 
 # make sure nxagent starts properly with pam_tmpdir.so being in use
 NX_TEMP=${NX_TEMP:-/tmp}
 export NX_TEMP
+export LD_LIBRARY_PATH=@@NXLIBDIR@@-X11/
 
-test -x $NX_LOCAL_LIBS/bin/$NXAPP && export NX_LIBS=$NX_LOCAL_LIBS
-test -x $NX_LIBS/bin/$NXAPP && export NX_LIBS=$NX_LIBS
-
-exec $NX_LIBS/bin/$NXAPP "$@"
+exec $NX_LIBS/bin/${NXAPP:-"nxagent"} "$@"

--- a/bin/nxproxy.in
+++ b/bin/nxproxy.in
@@ -15,15 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
-NXAPP=nxagent
-NX_LIBS=/usr/lib/nx
-NX_LOCAL_LIBS=/usr/local/lib/nx
+NX_LIBS=@@NXLIBDIR@@
 
 # make sure nxagent starts properly with pam_tmpdir.so being in use
 NX_TEMP=${NX_TEMP:-/tmp}
 export NX_TEMP
 
-test -x $NX_LOCAL_LIBS/bin/$NXAPP && export NX_LIBS=$NX_LOCAL_LIBS
-test -x $NX_LIBS/bin/$NXAPP && export NX_LIBS=$NX_LIBS
-
-exec $NX_LIBS/bin/$NXAPP "$@"
+exec $NX_LIBS/bin/${NXAPP:="nxproxy"} "$@"

--- a/debian/nxagent.install
+++ b/debian/nxagent.install
@@ -3,7 +3,8 @@ etc/nxagent/rgb
 usr/share/nx/rgb
 usr/share/nx/VERSION.nxagent
 usr/share/man/man1/nxagent.1*
-usr/lib/nx/bin/nxagent
+usr/lib/*/nx/bin/nxagent
+usr/lib/*/nx-X11/
 usr/bin/nxagent
 usr/share/pixmaps/nxagent.xpm
 etc/nxagent/nxagent.keyboard

--- a/debian/nxproxy.install
+++ b/debian/nxproxy.install
@@ -1,4 +1,4 @@
-usr/lib/nx/bin/nxproxy
+usr/lib/*/nx/bin/nxproxy
 usr/bin/nxproxy
 usr/share/man/man1/nxproxy.1*
 usr/share/nx/VERSION.nxproxy

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -329,8 +329,7 @@ sed -i -e 's#-O3#%{optflags}#' nx-X11/config/cf/host.def
 # Use multilib dirs
 # We're installing binaries into %%{_libdir}/nx/bin rather than %%{_libexedir}/nx
 # because upstream expects libraries and binaries in the same directory
-sed -i -e 's,/lib/nx,/%{_lib}/nx,' Makefile nx-X11/config/cf/X11.tmpl
-sed -i -e 's,/usr/lib/,/usr/%{_lib}/,' bin/*
+sed -i -e 's,/lib/nx,/%{_lib}/nx,' nx-X11/config/cf/X11.tmpl
 # Fix FSF address
 find -name LICENSE | xargs sed -i \
   -e 's/59 Temple Place/51 Franklin Street/' -e 's/Suite 330/Fifth Floor/' \


### PR DESCRIPTION
  o Install nxagent/nxproxy executables into multi-arch path.
  o Fake libNX_X11.so\* as $LIBDIR/nx-X11/libX11.so*.
  o Allow injecting different $NXAPP containing the executable name.

  o For e.g. x2goagent this requires the following changes:

``````
- Move x2goagent symlink from /usr/lib/x2go/bin/x2goagent to
  $LIBDIR/nx/bin/x2goagent
- Replace /usr/bin/x2goagent by a two-liner...

```
#!/bin/sh

export NXAPP=x2goagent
nxagent
```
``````
