### PR TITLE
ABI backport, no sequence number set by callers of WriteEventsToClient

### DIFF
--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -447,7 +447,6 @@ SendScreenSaverNotify (pScreen, state, forced)
     ScreenSaverEventPtr		pEv;
     unsigned long		mask;
     xScreenSaverNotifyEvent	ev;
-    ClientPtr			client;
     int				kind;
 
     UpdateCurrentTimeIf ();
@@ -466,18 +465,16 @@ SendScreenSaverNotify (pScreen, state, forced)
 	kind = ScreenSaverInternal;
     for (pEv = pPriv->events; pEv; pEv = pEv->next)
     {
-	client = pEv->client;
 	if (!(pEv->mask & mask))
 	    continue;
 	ev.type = ScreenSaverNotify + ScreenSaverEventBase;
 	ev.state = state;
-	ev.sequenceNumber = client->sequence;
 	ev.timestamp = currentTime.milliseconds;
 	ev.root = pScreen->root->drawable.id;
 	ev.window = savedScreenInfo[pScreen->myNum].wid;
 	ev.kind = kind;
 	ev.forced = forced;
-	WriteEventsToClient (client, 1, (xEvent *) &ev);
+	WriteEventsToClient (pEv->client, 1, (xEvent *) &ev);
     }
 }
 

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -467,8 +467,6 @@ SendScreenSaverNotify (pScreen, state, forced)
     for (pEv = pPriv->events; pEv; pEv = pEv->next)
     {
 	client = pEv->client;
-	if (client->clientGone)
-	    continue;
 	if (!(pEv->mask & mask))
 	    continue;
 	ev.type = ScreenSaverNotify + ScreenSaverEventBase;

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -310,15 +310,11 @@ SecurityDeleteAuthorization(
     {
 	/* send revocation event event */
 	ClientPtr client = rClient(pEventClient);
-
-	if (!client->clientGone)
-	{
-	    xSecurityAuthorizationRevokedEvent are;
-	    are.type = SecurityEventBase + XSecurityAuthorizationRevoked;
-	    are.sequenceNumber = client->sequence;
-	    are.authId = pAuth->id;
-	    WriteEventsToClient(client, 1, (xEvent *)&are);
-	}
+	xSecurityAuthorizationRevokedEvent are;
+	are.type = SecurityEventBase + XSecurityAuthorizationRevoked;
+	are.sequenceNumber = client->sequence;
+	are.authId = pAuth->id;
+	WriteEventsToClient(client, 1, (xEvent *)&are);
 	FreeResource(pEventClient->resource, RT_NONE);
     }
 

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -309,12 +309,10 @@ SecurityDeleteAuthorization(
     while ((pEventClient = pAuth->eventClients))
     {
 	/* send revocation event event */
-	ClientPtr client = rClient(pEventClient);
 	xSecurityAuthorizationRevokedEvent are;
 	are.type = SecurityEventBase + XSecurityAuthorizationRevoked;
-	are.sequenceNumber = client->sequence;
 	are.authId = pAuth->id;
-	WriteEventsToClient(client, 1, (xEvent *)&are);
+	WriteEventsToClient(rClient(pEventClient), 1, (xEvent *)&are);
 	FreeResource(pEventClient->resource, RT_NONE);
     }
 

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -969,8 +969,6 @@ SendShapeNotify (pWin, which)
     }
     for (pShapeEvent = *pHead; pShapeEvent; pShapeEvent = pShapeEvent->next) {
 	client = pShapeEvent->client;
-	if (client == serverClient || client->clientGone)
-	    continue;
 	se.type = ShapeNotify + ShapeEventBase;
 	se.kind = which;
 	se.window = pWin->drawable.id;

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -915,7 +915,6 @@ SendShapeNotify (pWin, which)
     int		which;
 {
     ShapeEventPtr	*pHead, pShapeEvent;
-    ClientPtr		client;
     xShapeNotifyEvent	se;
     BoxRec		extents;
     RegionPtr		region;
@@ -968,18 +967,16 @@ SendShapeNotify (pWin, which)
 	return;
     }
     for (pShapeEvent = *pHead; pShapeEvent; pShapeEvent = pShapeEvent->next) {
-	client = pShapeEvent->client;
 	se.type = ShapeNotify + ShapeEventBase;
 	se.kind = which;
 	se.window = pWin->drawable.id;
-	se.sequenceNumber = client->sequence;
 	se.x = extents.x1;
 	se.y = extents.y1;
 	se.width = extents.x2 - extents.x1;
 	se.height = extents.y2 - extents.y1;
 	se.time = currentTime.milliseconds;
 	se.shaped = shaped;
-	WriteEventsToClient (client, 1, (xEvent *) &se);
+	WriteEventsToClient (pShapeEvent->client, 1, (xEvent *) &se);
     }
 }
 

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -928,7 +928,6 @@ ProcShmPutImage(client)
 
 	ev.type = ShmCompletionCode;
 	ev.drawable = stuff->drawable;
-	ev.sequenceNumber = client->sequence;
 	ev.minorEvent = X_ShmPutImage;
 	ev.majorEvent = ShmReqCode;
 	ev.shmseg = stuff->shmseg;

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -545,7 +545,6 @@ SyncSendAlarmNotifyEvents(pAlarm)
 
     ane.type = SyncEventBase + XSyncAlarmNotify;
     ane.kind = XSyncAlarmNotify;
-    ane.sequenceNumber = pAlarm->client->sequence;
     ane.alarm = pAlarm->alarm_id;
     if (pTrigger->pCounter)
     {
@@ -568,10 +567,7 @@ SyncSendAlarmNotifyEvents(pAlarm)
 
     /* send to other interested clients */
     for (pcl = pAlarm->pEventClients; pcl; pcl = pcl->next)
-    {
-	ane.sequenceNumber = pcl->client->sequence;
 	WriteEventsToClient(pcl->client, 1, (xEvent *) &ane);
-    }
 }
 
 
@@ -599,7 +595,6 @@ SyncSendCounterNotifyEvents(client, ppAwait, num_events)
 	SyncTrigger *pTrigger = &(*ppAwait)->trigger;
 	pev->type = SyncEventBase + XSyncCounterNotify;
 	pev->kind = XSyncCounterNotify;
-	pev->sequenceNumber = client->sequence;
 	pev->counter = pTrigger->pCounter->id;
 	pev->wait_value_lo = XSyncValueLow32(pTrigger->test_value);
 	pev->wait_value_hi = XSyncValueHigh32(pTrigger->test_value);

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -563,17 +563,14 @@ SyncSendAlarmNotifyEvents(pAlarm)
     ane.state = pAlarm->state;
 
     /* send to owner */
-    if (pAlarm->events && !pAlarm->client->clientGone) 
+    if (pAlarm->events)
 	WriteEventsToClient(pAlarm->client, 1, (xEvent *) &ane);
 
     /* send to other interested clients */
     for (pcl = pAlarm->pEventClients; pcl; pcl = pcl->next)
     {
-	if (!pAlarm->client->clientGone)
-	{
-	    ane.sequenceNumber = pcl->client->sequence;
-	    WriteEventsToClient(pcl->client, 1, (xEvent *) &ane);
-	}
+	ane.sequenceNumber = pcl->client->sequence;
+	WriteEventsToClient(pcl->client, 1, (xEvent *) &ane);
     }
 }
 

--- a/nx-X11/programs/Xserver/Xext/xvdisp.c
+++ b/nx-X11/programs/Xserver/Xext/xvdisp.c
@@ -1205,7 +1205,6 @@ ProcXvShmPutImage(ClientPtr client)
 
         ev.type = ShmCompletionCode;
         ev.drawable = stuff->drawable;
-        ev.sequenceNumber = client->sequence;
         ev.minorEvent = xv_ShmPutImage;
         ev.majorEvent = XvReqCode;
         ev.shmseg = stuff->shmseg;

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -69,8 +69,7 @@ DamageExtNotify (DamageExtPtr pDamageExt, BoxPtr pBoxes, int nBoxes)
 	    ev.area.y = pBoxes[i].y1;
 	    ev.area.width = pBoxes[i].x2 - pBoxes[i].x1;
 	    ev.area.height = pBoxes[i].y2 - pBoxes[i].y1;
-	    if (!pClient->clientGone)
-		WriteEventsToClient (pClient, 1, (xEvent *) &ev);
+	    WriteEventsToClient (pClient, 1, (xEvent *) &ev);
 	}
     }
     else
@@ -79,8 +78,7 @@ DamageExtNotify (DamageExtPtr pDamageExt, BoxPtr pBoxes, int nBoxes)
 	ev.area.y = 0;
 	ev.area.width = pDrawable->width;
 	ev.area.height = pDrawable->height;
-	if (!pClient->clientGone)
-	    WriteEventsToClient (pClient, 1, (xEvent *) &ev);
+	WriteEventsToClient (pClient, 1, (xEvent *) &ev);
     }
     /* Composite extension marks clients with manual Subwindows as critical */
     if (pDamageClient->critical > 0)

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -3953,7 +3953,6 @@ SendErrorToClient(ClientPtr client, unsigned majorCode, unsigned minorCode,
 
     memset(&rep, 0, sizeof(xError));
     rep.type = X_Error;
-    rep.sequenceNumber = client->sequence;
     rep.errorCode = errorCode;
     rep.majorCode = majorCode;
     rep.minorCode = minorCode;

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -1546,14 +1546,6 @@ TryClientEvents (ClientPtr client, xEvent *pEvents, int count, Mask mask,
 		return 1;
 	}
 #endif
-	type &= 0177;
-	if (type != KeymapNotify)
-	{
-	    /* all extension events must have a sequence number */
-	    for (i = 0; i < count; i++)
-		pEvents[i].u.u.sequenceNumber = client->sequence;
-	}
-
 	if (BitIsOn(criticalEvents, type))
 	{
 #ifdef SMART_SCHEDULE
@@ -4441,6 +4433,10 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 
     if (!pClient || pClient == serverClient || pClient->clientGone)
 	return;
+
+    for (i = 0; i < count; i++)
+	if ((events[i].u.u.type & 0x7f) != KeymapNotify)
+	    events[i].u.u.sequenceNumber = pClient->sequence;
 
 #ifdef XKB
     if ((!noXkbExtension)&&(!XkbFilterEvents(pClient, count, events)))

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -4439,6 +4439,9 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
     xEvent    eventTo, *eventFrom;
     int       i;
 
+    if (!pClient || pClient == serverClient || pClient->clientGone)
+	return;
+
 #ifdef XKB
     if ((!noXkbExtension)&&(!XkbFilterEvents(pClient, count, events)))
 	return;

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -859,14 +859,16 @@ SetCriticalOutputPending(void)
 int
 WriteToClient (ClientPtr who, int count, char *buf)
 {
-    OsCommPtr oc = (OsCommPtr)who->osPrivate;
-    ConnectionOutputPtr oco = oc->output;
+    OsCommPtr oc;
+    ConnectionOutputPtr oco;
     int padBytes;
 #ifdef DEBUG_COMMUNICATION
     Bool multicount = FALSE;
 #endif
-    if (!count)
+    if (!count || !who || who == serverClient || who->clientGone)
 	return(0);
+    oc = who->osPrivate;
+    oco = oc->output;
 #ifdef DEBUG_COMMUNICATION
     {
 	char info[128];

--- a/nx-X11/programs/Xserver/randr/rrcrtc.c
+++ b/nx-X11/programs/Xserver/randr/rrcrtc.c
@@ -274,9 +274,6 @@ RRDeliverCrtcEvent(ClientPtr client, WindowPtr pWin, RRCrtcPtr crtc)
     xRRCrtcChangeNotifyEvent ce = {
         .type = RRNotify + RREventBase,
         .subCode = RRNotify_CrtcChange,
-#ifdef NXAGENT_SERVER
-        .sequenceNumber = client->sequence,
-#endif
         .timestamp = pScrPriv->lastSetTime.milliseconds,
         .window = pWin->drawable.id,
         .crtc = crtc->id,

--- a/nx-X11/programs/Xserver/randr/rroutput.c
+++ b/nx-X11/programs/Xserver/randr/rroutput.c
@@ -351,9 +351,6 @@ RRDeliverOutputEvent(ClientPtr client, WindowPtr pWin, RROutputPtr output)
     xRROutputChangeNotifyEvent oe = {
         .type = RRNotify + RREventBase,
         .subCode = RRNotify_OutputChange,
-#ifdef NXAGENT_SERVER
-        .sequenceNumber = client->sequence,
-#endif
         .timestamp = pScrPriv->lastSetTime.milliseconds,
         .configTimestamp = pScrPriv->lastConfigTime.milliseconds,
         .window = pWin->drawable.id,

--- a/nx-X11/programs/Xserver/randr/rrproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproperty.c
@@ -43,9 +43,6 @@ DeliverPropertyEvent(WindowPtr pWin, void *value)
         if (!(pRREvent->mask & RROutputPropertyNotifyMask))
             continue;
 
-#ifdef NXAGENT_SERVER
-        event->sequenceNumber = pRREvent->client->sequence;
-#endif
         event->window = pRREvent->window->drawable.id;
         WriteEventsToClient(pRREvent->client, 1, (xEvent *) event);
     }

--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -111,9 +111,6 @@ RRDeliverScreenEvent(ClientPtr client, WindowPtr pWin, ScreenPtr pScreen)
 
     xRRScreenChangeNotifyEvent se = {
         .type = RRScreenChangeNotify + RREventBase,
-#ifdef NXAGENT_SERVER
-        .sequenceNumber = client->sequence,
-#endif
         .rotation = (CARD8) (crtc ? crtc->rotation : RR_Rotate_0),
         .timestamp = pScrPriv->lastSetTime.milliseconds,
         .configTimestamp = pScrPriv->lastConfigTime.milliseconds,

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -101,7 +101,6 @@ CursorDisplayCursor (ScreenPtr pScreen,
 		xXFixesCursorNotifyEvent	ev;
 		ev.type = XFixesEventBase + XFixesCursorNotify;
 		ev.subtype = XFixesDisplayCursorNotify;
-		ev.sequenceNumber = e->pClient->sequence;
 		ev.window = e->pWindow->drawable.id;
 		ev.cursorSerial = pCursor->serialNumber;
 		ev.timestamp = currentTime.milliseconds;

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -96,8 +96,7 @@ CursorDisplayCursor (ScreenPtr pScreen,
 	CursorCurrent = pCursor;
 	for (e = cursorEvents; e; e = e->next)
 	{
-	    if ((e->eventMask & XFixesDisplayCursorNotifyMask) &&
-		!e->pClient->clientGone)
+	    if ((e->eventMask & XFixesDisplayCursorNotifyMask))
 	    {
 		xXFixesCursorNotifyEvent	ev;
 		ev.type = XFixesEventBase + XFixesCursorNotify;

--- a/nx-X11/programs/Xserver/xfixes/select.c
+++ b/nx-X11/programs/Xserver/xfixes/select.c
@@ -87,7 +87,6 @@ XFixesSelectionCallback (CallbackListPtr *callbacks, void * data, void * args)
 
 	    ev.type = XFixesEventBase + XFixesSelectionNotify;
 	    ev.subtype = subtype;
-	    ev.sequenceNumber = e->pClient->sequence;
 	    ev.window = e->pWindow->drawable.id;
 	    if (subtype == XFixesSetSelectionOwnerNotify)
 		ev.owner = selection->window;

--- a/nx-X11/programs/Xserver/xfixes/select.c
+++ b/nx-X11/programs/Xserver/xfixes/select.c
@@ -79,8 +79,7 @@ XFixesSelectionCallback (CallbackListPtr *callbacks, void * data, void * args)
     for (e = selectionEvents; e; e = e->next)
     {
 	if (e->selection == selection->selection && 
-	    (e->eventMask & eventMask) &&
-	    !e->pClient->clientGone)
+	    (e->eventMask & eventMask))
 	{
 	    xXFixesSelectionNotifyEvent	ev;
 


### PR DESCRIPTION
ABI backport from X.org:

Callers of WriteEventsToClient should not bother about client->sequenceNumber. Handle that in WriteEventsToClient internally.
