### PR TITLE
Drop superfluous type casting from WriteToClient calls

### DIFF
--- a/nx-X11/programs/Xserver/GL/glx/glxcmds.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxcmds.c
@@ -736,7 +736,7 @@ int DoMakeCurrent( __GLXclientState *cl,
     if (client->swapped) {
 	__glXSwapMakeCurrentReply(client, &reply);
     } else {
-	WriteToClient(client, sz_xGLXMakeCurrentReply, (char *)&reply);
+	WriteToClient(client, sz_xGLXMakeCurrentReply, &reply);
     }
     return Success;
 }
@@ -765,7 +765,7 @@ int __glXIsDirect(__GLXclientState *cl, GLbyte *pc)
     if (client->swapped) {
 	__glXSwapIsDirectReply(client, &reply);
     } else {
-	WriteToClient(client, sz_xGLXIsDirectReply, (char *)&reply);
+	WriteToClient(client, sz_xGLXIsDirectReply, &reply);
     }
 
     return Success;
@@ -797,7 +797,7 @@ int __glXQueryVersion(__GLXclientState *cl, GLbyte *pc)
     if (client->swapped) {
 	__glXSwapQueryVersionReply(client, &reply);
     } else {
-	WriteToClient(client, sz_xGLXQueryVersionReply, (char *)&reply);
+	WriteToClient(client, sz_xGLXQueryVersionReply, &reply);
     }
     return Success;
 }
@@ -948,7 +948,7 @@ int DoGetVisualConfigs(__GLXclientState *cl, unsigned screen,
 	__GLX_SWAP_INT(&reply.numProps);
     }
 
-    WriteToClient(client, sz_xGLXGetVisualConfigsReply, (char *)&reply);
+    WriteToClient(client, sz_xGLXGetVisualConfigsReply, &reply);
 
     for ( modes = pGlxScreen->modes ; modes != NULL ; modes = modes->next ) {
 	if (modes->visualID == 0) {
@@ -999,7 +999,7 @@ int DoGetVisualConfigs(__GLXclientState *cl, unsigned screen,
 	    __GLX_SWAP_INT_ARRAY(buf, __GLX_TOTAL_CONFIG);
 	}
 	WriteToClient(client, __GLX_SIZE_CARD32 * __GLX_TOTAL_CONFIG, 
-		(char *)buf);
+		buf);
     }
     return Success;
 }
@@ -1056,7 +1056,7 @@ int DoGetFBConfigs(__GLXclientState *cl, unsigned screen, GLboolean do_swap)
 	__GLX_SWAP_INT(&reply.numAttribs);
     }
 
-    WriteToClient(client, sz_xGLXGetFBConfigsReply, (char *)&reply);
+    WriteToClient(client, sz_xGLXGetFBConfigsReply, &reply);
 
     for ( modes = pGlxScreen->modes ; modes != NULL ; modes = modes->next ) {
 	if (modes->visualID == 0) {
@@ -1108,7 +1108,7 @@ int DoGetFBConfigs(__GLXclientState *cl, unsigned screen, GLboolean do_swap)
 	    __GLX_SWAP_INT_ARRAY(buf, __GLX_FBCONFIG_ATTRIBS_LENGTH);
 	}
 	WriteToClient(client, __GLX_SIZE_CARD32 * __GLX_FBCONFIG_ATTRIBS_LENGTH,
-		      (char *)buf);
+		      buf);
     }
     return Success;
 }
@@ -1397,8 +1397,8 @@ int __glXQueryContextInfoEXT(__GLXclientState *cl, GLbyte *pc)
     if (client->swapped) {
 	__glXSwapQueryContextInfoEXTReply(client, &reply, sendBuf);
     } else {
-	WriteToClient(client, sz_xGLXQueryContextInfoEXTReply, (char *)&reply);
-	WriteToClient(client, nReplyBytes, (char *)sendBuf);
+	WriteToClient(client, sz_xGLXQueryContextInfoEXTReply, &reply);
+	WriteToClient(client, nReplyBytes, sendBuf);
     }
     __glXFree((char *)sendBuf);
 
@@ -1798,7 +1798,7 @@ static int __glXQueryMaxSwapBarriersSGIX(__GLXclientState *cl, GLbyte *pc)
     }
 
     WriteToClient(client, sz_xGLXQueryMaxSwapBarriersSGIXReply,
-                        (char *) &reply);
+                        &reply);
     return Success;
 }
 
@@ -1837,9 +1837,9 @@ static int __glxQueryHyperpipeNetworkSGIX(__GLXclientState *cl, GLbyte *pc)
         __GLX_SWAP_INT(&reply.npipes);
     }
     WriteToClient(client, sz_xGLXQueryHyperpipeNetworkSGIXReply,
-                  (char *) &reply);
+                  &reply);
 
-    WriteToClient(client, length << 2, (char *)rdata);
+    WriteToClient(client, length << 2, rdata);
 
     return Success;
 }
@@ -1875,7 +1875,7 @@ static int __glxDestroyHyperpipeConfigSGIX (__GLXclientState *cl, GLbyte *pc)
     }
     WriteToClient(client,
                   sz_xGLXDestroyHyperpipeConfigSGIXReply,
-                  (char *) &reply);
+                  &reply);
     return Success;
 }
 
@@ -1916,9 +1916,9 @@ static int __glxQueryHyperpipeConfigSGIX(__GLXclientState *cl, GLbyte *pc)
     }
 
     WriteToClient(client, sz_xGLXQueryHyperpipeConfigSGIXReply,
-                  (char *) &reply);
+                  &reply);
 
-    WriteToClient(client, length << 2, (char *)rdata);
+    WriteToClient(client, length << 2, rdata);
 
     return Success;
 }
@@ -1961,7 +1961,7 @@ static int __glxHyperpipeConfigSGIX(__GLXclientState *cl, GLbyte *pc)
     }
 
     WriteToClient(client, sz_xGLXHyperpipeConfigSGIXReply,
-                  (char *) &reply);
+                  &reply);
 
     return Success;
 }
@@ -2089,8 +2089,8 @@ int __glXQueryExtensionsString(__GLXclientState *cl, GLbyte *pc)
     if (client->swapped) {
         glxSwapQueryExtensionsStringReply(client, &reply, buf);
     } else {
-        WriteToClient(client, sz_xGLXQueryExtensionsStringReply,(char *)&reply);
-        WriteToClient(client, (int)(length << 2), (char *)buf);
+        WriteToClient(client, sz_xGLXQueryExtensionsStringReply,&reply);
+        WriteToClient(client, (int)(length << 2), buf);
     }
 
     __glXFree(buf);
@@ -2146,7 +2146,7 @@ int __glXQueryServerString(__GLXclientState *cl, GLbyte *pc)
     if (client->swapped) {
         glxSwapQueryServerStringReply(client, &reply, buf);
     } else {
-        WriteToClient(client, sz_xGLXQueryServerStringReply, (char *)&reply);
+        WriteToClient(client, sz_xGLXQueryServerStringReply, &reply);
         WriteToClient(client, (int)(length << 2), buf);
     }
 

--- a/nx-X11/programs/Xserver/GL/glx/glxcmdsswap.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxcmdsswap.c
@@ -397,7 +397,7 @@ void __glXSwapMakeCurrentReply(ClientPtr client, xGLXMakeCurrentReply *reply)
     __GLX_SWAP_SHORT(&reply->sequenceNumber);
     __GLX_SWAP_INT(&reply->length);
     __GLX_SWAP_INT(&reply->contextTag);
-    WriteToClient(client, sz_xGLXMakeCurrentReply, (char *)reply);
+    WriteToClient(client, sz_xGLXMakeCurrentReply, reply);
 }
 
 void __glXSwapIsDirectReply(ClientPtr client, xGLXIsDirectReply *reply)
@@ -405,7 +405,7 @@ void __glXSwapIsDirectReply(ClientPtr client, xGLXIsDirectReply *reply)
     __GLX_DECLARE_SWAP_VARIABLES;
     __GLX_SWAP_SHORT(&reply->sequenceNumber);
     __GLX_SWAP_INT(&reply->length);
-    WriteToClient(client, sz_xGLXIsDirectReply, (char *)reply);
+    WriteToClient(client, sz_xGLXIsDirectReply, reply);
 }
 
 void __glXSwapQueryVersionReply(ClientPtr client, xGLXQueryVersionReply *reply)
@@ -415,7 +415,7 @@ void __glXSwapQueryVersionReply(ClientPtr client, xGLXQueryVersionReply *reply)
     __GLX_SWAP_INT(&reply->length);
     __GLX_SWAP_INT(&reply->majorVersion);
     __GLX_SWAP_INT(&reply->minorVersion);
-    WriteToClient(client, sz_xGLXQueryVersionReply, (char *)reply);
+    WriteToClient(client, sz_xGLXQueryVersionReply, reply);
 }
 
 void glxSwapQueryExtensionsStringReply(ClientPtr client,
@@ -427,7 +427,7 @@ void glxSwapQueryExtensionsStringReply(ClientPtr client,
     __GLX_SWAP_SHORT(&reply->sequenceNumber);
     __GLX_SWAP_INT(&reply->length);
     __GLX_SWAP_INT(&reply->n);
-    WriteToClient(client, sz_xGLXQueryExtensionsStringReply, (char *)reply);
+    WriteToClient(client, sz_xGLXQueryExtensionsStringReply, reply);
     __GLX_SWAP_INT_ARRAY((int *)buf, length);
     WriteToClient(client, length << 2, buf);
 }
@@ -440,7 +440,7 @@ void glxSwapQueryServerStringReply(ClientPtr client,
     __GLX_SWAP_SHORT(&reply->sequenceNumber);
     __GLX_SWAP_INT(&reply->length);
     __GLX_SWAP_INT(&reply->n);
-    WriteToClient(client, sz_xGLXQueryServerStringReply, (char *)reply);
+    WriteToClient(client, sz_xGLXQueryServerStringReply, reply);
     /** no swap is needed for an array of chars **/
     /* __GLX_SWAP_INT_ARRAY((int *)buf, length); */
     WriteToClient(client, length << 2, buf);
@@ -454,9 +454,9 @@ void __glXSwapQueryContextInfoEXTReply(ClientPtr client, xGLXQueryContextInfoEXT
     __GLX_SWAP_SHORT(&reply->sequenceNumber);
     __GLX_SWAP_INT(&reply->length);
     __GLX_SWAP_INT(&reply->n);
-    WriteToClient(client, sz_xGLXQueryContextInfoEXTReply, (char *)reply);
+    WriteToClient(client, sz_xGLXQueryContextInfoEXTReply, reply);
     __GLX_SWAP_INT_ARRAY((int *)buf, length);
-    WriteToClient(client, length << 2, (char *)buf);
+    WriteToClient(client, length << 2, buf);
 }
 
 

--- a/nx-X11/programs/Xserver/GL/glx/glxfb.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxfb.c
@@ -114,7 +114,7 @@ __glXFBMemSwapBuffers(__GLXdrawablePrivate *glxPriv)
 			 depth,
 			 0, 0, width, height,
 			 pad, ZPixmap,
-			 (char *)buf);
+			 buf);
 
     return GL_TRUE;
 }

--- a/nx-X11/programs/Xserver/GL/glx/single2.c
+++ b/nx-X11/programs/Xserver/GL/glx/single2.c
@@ -201,9 +201,9 @@ int __glXDisp_RenderMode(__GLXclientState *cl, GLbyte *pc)
     reply.retval = retval;
     reply.size = nitems;
     reply.newMode = newMode;
-    WriteToClient(client, sz_xGLXRenderModeReply, (char *)&reply);
+    WriteToClient(client, sz_xGLXRenderModeReply, &reply);
     if (retBytes) {
-	WriteToClient(client, retBytes, (char *)retBuffer);
+	WriteToClient(client, retBytes, retBuffer);
     }
     return Success;
 }
@@ -380,7 +380,7 @@ int DoGetString(__GLXclientState *cl, GLbyte *pc, GLboolean need_swap)
     }
 
     __GLX_SEND_HEADER();
-    WriteToClient(client, length, (char *) string); 
+    WriteToClient(client, length, string);
     if (buf != NULL) {
 	__glXFree(buf);
     }

--- a/nx-X11/programs/Xserver/GL/glx/single2swap.c
+++ b/nx-X11/programs/Xserver/GL/glx/single2swap.c
@@ -218,9 +218,9 @@ int __glXDispSwap_RenderMode(__GLXclientState *cl, GLbyte *pc)
     __GLX_SWAP_INT(&reply.retval);
     __GLX_SWAP_INT(&reply.size);
     __GLX_SWAP_INT(&reply.newMode);
-    WriteToClient(client, sz_xGLXRenderModeReply, (char *)&reply);
+    WriteToClient(client, sz_xGLXRenderModeReply, &reply);
     if (retBytes) {
-	WriteToClient(client, retBytes, (char *)retBuffer);
+	WriteToClient(client, retBytes, retBuffer);
     }
     return Success;
 }

--- a/nx-X11/programs/Xserver/GL/glx/unpack.h
+++ b/nx-X11/programs/Xserver/GL/glx/unpack.h
@@ -69,7 +69,7 @@ extern xGLXSingleReply __glXReply;
   	__glXReply.sequenceNumber = client->sequence;
 
 #define __GLX_SEND_HEADER() \
-	WriteToClient( client, sz_xGLXSingleReply, (char *)&__glXReply);
+	WriteToClient( client, sz_xGLXSingleReply, &__glXReply);
 
 #define __GLX_PUT_RETVAL(a) \
   	__glXReply.retval = (a);
@@ -123,19 +123,19 @@ extern xGLXSingleReply __glXReply;
   	*(GLdouble *)&__glXReply.pad3 = *(GLdouble *)answer
 	  
 #define __GLX_SEND_BYTE_ARRAY(len) \
-	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT8), (char *)answer)
+	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT8), answer)
 
 #define __GLX_SEND_SHORT_ARRAY(len) \
-	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT16), (char *)answer)
+	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT16), answer)
   
 #define __GLX_SEND_INT_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_INT32, (char *)answer)
+	WriteToClient(client, (len)*__GLX_SIZE_INT32, answer)
   
 #define __GLX_SEND_FLOAT_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_FLOAT32, (char *)answer)
+	WriteToClient(client, (len)*__GLX_SIZE_FLOAT32, answer)
   
 #define __GLX_SEND_DOUBLE_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_FLOAT64, (char *)answer)
+	WriteToClient(client, (len)*__GLX_SIZE_FLOAT64, answer)
 
 
 #define __GLX_SEND_VOID_ARRAY(len)  __GLX_SEND_BYTE_ARRAY(len)

--- a/nx-X11/programs/Xserver/Xext/bigreq.c
+++ b/nx-X11/programs/Xserver/Xext/bigreq.c
@@ -102,6 +102,6 @@ ProcBigReqDispatch (client)
 	swaps(&rep.sequenceNumber);
 	swapl(&rep.max_request_size);
     }
-    WriteToClient(client, sizeof(xBigReqEnableReply), (char *)&rep);
+    WriteToClient(client, sizeof(xBigReqEnableReply), &rep);
     return(client->noClientException);
 }

--- a/nx-X11/programs/Xserver/Xext/dpms.c
+++ b/nx-X11/programs/Xserver/Xext/dpms.c
@@ -118,7 +118,7 @@ ProcDPMSGetVersion(client)
 	swaps(&rep.majorVersion);
 	swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xDPMSGetVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDPMSGetVersionReply), &rep);
     return(client->noClientException);
 }
 
@@ -138,7 +138,7 @@ ProcDPMSCapable(register ClientPtr client)
     if (client->swapped) {
 	swaps(&rep.sequenceNumber);
     }
-    WriteToClient(client, sizeof(xDPMSCapableReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDPMSCapableReply), &rep);
     return(client->noClientException);
 }
 
@@ -164,7 +164,7 @@ ProcDPMSGetTimeouts(client)
 	swaps(&rep.suspend);
 	swaps(&rep.off);
     }
-    WriteToClient(client, sizeof(xDPMSGetTimeoutsReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDPMSGetTimeoutsReply), &rep);
     return(client->noClientException);
 }
 
@@ -275,7 +275,7 @@ ProcDPMSInfo(register ClientPtr client)
 	swaps(&rep.sequenceNumber);
 	swaps(&rep.power_level);
     }
-    WriteToClient(client, sizeof(xDPMSInfoReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDPMSInfoReply), &rep);
     return(client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/Xext/panoramiX.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiX.c
@@ -949,7 +949,7 @@ ProcPanoramiXQueryVersion (ClientPtr client)
         swaps(&rep.majorVersion);
         swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof (xPanoramiXQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof (xPanoramiXQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -973,7 +973,7 @@ ProcPanoramiXGetState(ClientPtr client)
 	    swapl (&rep.length);
 	    swapl ((int* )&rep.state);
 	}	
-	WriteToClient (client, sizeof (xPanoramiXGetStateReply), (char *) &rep);
+	WriteToClient (client, sizeof (xPanoramiXGetStateReply), &rep);
 	return client->noClientException;
 
 }
@@ -998,7 +998,7 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
 	    swapl (&rep.length);
 	    swapl ((int* )&rep.ScreenCount);
 	}	
-	WriteToClient (client, sizeof (xPanoramiXGetScreenCountReply), (char *) &rep);
+	WriteToClient (client, sizeof (xPanoramiXGetScreenCountReply), &rep);
 	return client->noClientException;
 }
 
@@ -1025,7 +1025,7 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
 	    swapl (&rep.width);
 	    swapl (&rep.height);
 	}	
-	WriteToClient (client, sizeof (xPanoramiXGetScreenSizeReply), (char *) &rep);
+	WriteToClient (client, sizeof (xPanoramiXGetScreenSizeReply), &rep);
 	return client->noClientException;
 }
 
@@ -1047,7 +1047,7 @@ ProcXineramaIsActive(ClientPtr client)
 	swapl (&rep.length);
 	swapl (&rep.state);
     }	
-    WriteToClient (client, sizeof (xXineramaIsActiveReply), (char *) &rep);
+    WriteToClient (client, sizeof (xXineramaIsActiveReply), &rep);
     return client->noClientException;
 }
 
@@ -1069,7 +1069,7 @@ ProcXineramaQueryScreens(ClientPtr client)
 	swapl (&rep.length);
 	swapl (&rep.number);
     }	
-    WriteToClient (client, sizeof (xXineramaQueryScreensReply), (char *) &rep);
+    WriteToClient (client, sizeof (xXineramaQueryScreensReply), &rep);
 
     if(!noPanoramiXExtension) {
 	xXineramaScreenInfo scratch;
@@ -1087,7 +1087,7 @@ ProcXineramaQueryScreens(ClientPtr client)
 		swaps (&scratch.width);
 		swaps (&scratch.height);
 	    }
-	    WriteToClient (client, sz_XineramaScreenInfo, (char *) &scratch);
+	    WriteToClient (client, sz_XineramaScreenInfo, &scratch);
 	}
     }
 

--- a/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
@@ -1863,7 +1863,7 @@ int PanoramiXGetImage(ClientPtr client)
 	    XineramaGetImageData(drawables, x, y + linesDone, w, nlines,
 			format, planemask, pBuf, widthBytesLine, isRoot);
 
-		(void)WriteToClient(client,
+		WriteToClient(client,
 				    (int)(nlines * widthBytesLine),
 				    pBuf);
 	    linesDone += nlines;
@@ -1881,7 +1881,7 @@ int PanoramiXGetImage(ClientPtr client)
 					nlines, format, plane, pBuf,
 					widthBytesLine, isRoot);
 
-		    (void)WriteToClient(client,
+		    WriteToClient(client,
 				    (int)(nlines * widthBytesLine),
 				    pBuf);
 

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -702,7 +702,7 @@ ProcScreenSaverQueryVersion (client)
 	swaps(&rep.sequenceNumber);
 	swapl(&rep.length);
     }
-    WriteToClient(client, sizeof (xScreenSaverQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof (xScreenSaverQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -774,7 +774,7 @@ ProcScreenSaverQueryInfo (client)
 	swapl (&rep.idle);
 	swapl (&rep.eventMask);
     }
-    WriteToClient(client, sizeof (xScreenSaverQueryInfoReply), (char *)&rep);
+    WriteToClient(client, sizeof (xScreenSaverQueryInfoReply), &rep);
     return (client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -489,8 +489,8 @@ ProcSecurityQueryVersion(
 	swaps(&rep.majorVersion);
 	swaps(&rep.minorVersion);
     }
-    (void)WriteToClient(client, SIZEOF(xSecurityQueryVersionReply),
-			(char *)&rep);
+    WriteToClient(client, SIZEOF(xSecurityQueryVersionReply),
+			&rep);
     return (client->noClientException);
 } /* ProcSecurityQueryVersion */
 
@@ -709,7 +709,7 @@ ProcSecurityGenerateAuthorization(
     }
 
     WriteToClient(client, SIZEOF(xSecurityGenerateAuthorizationReply),
-		  (char *)&rep);
+		  &rep);
     WriteToClient(client, authdata_len, pAuthdata);
 
     SecurityAudit("client %d generated authorization %d trust %d timeout %d group %d events %d\n",

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -303,7 +303,7 @@ ProcShapeQueryVersion (client)
 	swaps(&rep.majorVersion);
 	swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof (xShapeQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof (xShapeQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -763,7 +763,7 @@ ProcShapeQueryExtents (client)
 	swaps(&rep.widthClipShape);
 	swaps(&rep.heightClipShape);
     }
-    WriteToClient(client, sizeof (xShapeQueryExtentsReply), (char *)&rep);
+    WriteToClient(client, sizeof (xShapeQueryExtentsReply), &rep);
     return (client->noClientException);
 }
 
@@ -1016,7 +1016,7 @@ ProcShapeInputSelected (client)
 	swaps (&rep.sequenceNumber);
 	swapl (&rep.length);
     }
-    WriteToClient (client, sizeof (xShapeInputSelectedReply), (char *) &rep);
+    WriteToClient (client, sizeof (xShapeInputSelectedReply), &rep);
     return (client->noClientException);
 }
 
@@ -1099,8 +1099,8 @@ ProcShapeGetRectangles (client)
 	swapl (&rep.nrects);
 	SwapShorts ((short *)rects, (unsigned long)nrects * 4);
     }
-    WriteToClient (client, sizeof (rep), (char *) &rep);
-    WriteToClient (client, nrects * sizeof (xRectangle), (char *) rects);
+    WriteToClient (client, sizeof (rep), &rep);
+    WriteToClient (client, nrects * sizeof (xRectangle), rects);
     DEALLOCATE_LOCAL (rects);
     return client->noClientException;
 }

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -366,7 +366,7 @@ ProcShmQueryVersion(client)
 	swaps(&rep.uid);
 	swaps(&rep.gid);
     }
-    WriteToClient(client, sizeof(xShmQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xShmQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -716,7 +716,7 @@ ProcPanoramiXShmGetImage(ClientPtr client)
 	swapl(&xgi.visual);
 	swapl(&xgi.size);
     }
-    WriteToClient(client, sizeof(xShmGetImageReply), (char *)&xgi);
+    WriteToClient(client, sizeof(xShmGetImageReply), &xgi);
 
     return(client->noClientException);
 }
@@ -1044,7 +1044,7 @@ ProcShmGetImage(client)
 	swapl(&xgi.visual);
 	swapl(&xgi.size);
     }
-    WriteToClient(client, sizeof(xShmGetImageReply), (char *)&xgi);
+    WriteToClient(client, sizeof(xShmGetImageReply), &xgi);
 
     return(client->noClientException);
 }

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -1349,7 +1349,7 @@ ProcSyncInitialize(client)
     {
 	swaps(&rep.sequenceNumber);
     }
-    WriteToClient(client, sizeof(rep), (char *) &rep);
+    WriteToClient(client, sizeof(rep), &rep);
     return (client->noClientException);
 }
 
@@ -1419,10 +1419,10 @@ ProcSyncListSystemCounters(client)
 				((sz_xSyncSystemCounter + namelen + 3) & ~3));
     }
 
-    WriteToClient(client, sizeof(rep), (char *) &rep);
+    WriteToClient(client, sizeof(rep), &rep);
     if (len) 
     {
-	WriteToClient(client, len, (char *) list);
+	WriteToClient(client, len, list);
 	DEALLOCATE_LOCAL(list);
     }
 
@@ -1495,7 +1495,7 @@ ProcSyncGetPriority(client)
 	swapl(&rep.priority);
     }
 
-    WriteToClient(client, sizeof(xSyncGetPriorityReply), (char *) &rep);
+    WriteToClient(client, sizeof(xSyncGetPriorityReply), &rep);
 
     return (client->noClientException);
 }
@@ -1780,7 +1780,7 @@ ProcSyncQueryCounter(client)
 	swapl(&rep.value_hi);
 	swapl(&rep.value_lo);
     }
-    WriteToClient(client, sizeof(xSyncQueryCounterReply), (char *) &rep);
+    WriteToClient(client, sizeof(xSyncQueryCounterReply), &rep);
     return (client->noClientException);
 }
 
@@ -1966,7 +1966,7 @@ ProcSyncQueryAlarm(client)
 	swapl(&rep.delta_lo);
     }
 
-    WriteToClient(client, sizeof(xSyncQueryAlarmReply), (char *) &rep);
+    WriteToClient(client, sizeof(xSyncQueryAlarmReply), &rep);
     return (client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/Xext/xcmisc.c
+++ b/nx-X11/programs/Xserver/Xext/xcmisc.c
@@ -110,7 +110,7 @@ ProcXCMiscGetVersion(client)
 	swaps(&rep.majorVersion);
 	swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xXCMiscGetVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXCMiscGetVersionReply), &rep);
     return(client->noClientException);
 }
 
@@ -133,7 +133,7 @@ ProcXCMiscGetXIDRange(client)
 	swapl(&rep.start_id);
 	swapl(&rep.count);
     }
-    WriteToClient(client, sizeof(xXCMiscGetXIDRangeReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXCMiscGetXIDRangeReply), &rep);
     return(client->noClientException);
 }
 
@@ -166,7 +166,7 @@ ProcXCMiscGetXIDList(client)
 	swapl(&rep.length);
 	swapl(&rep.count);
     }
-    WriteToClient(client, sizeof(xXCMiscGetXIDListReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXCMiscGetXIDListReply), &rep);
     if (count)
     {
     	client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;

--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
@@ -384,7 +384,7 @@ ProcXF86BigfontQueryVersion(
 	swapl(&reply.signature);
     }
     WriteToClient(client,
-		  sizeof(xXF86BigfontQueryVersionReply), (char *)&reply);
+		  sizeof(xXF86BigfontQueryVersionReply), &reply);
     return client->noClientException;
 }
 
@@ -718,7 +718,7 @@ ProcXF86BigfontQueryFont(
 		}
 	    }
 	}
-	WriteToClient(client, rlength, (char *)reply);
+	WriteToClient(client, rlength, reply);
 	DEALLOCATE_LOCAL(reply);
 	if (nCharInfos > 0) {
 	    if (shmid == -1) DEALLOCATE_LOCAL(pIndex2UniqIndex);

--- a/nx-X11/programs/Xserver/Xext/xres.c
+++ b/nx-X11/programs/Xserver/Xext/xres.c
@@ -40,7 +40,7 @@ ProcXResQueryVersion (ClientPtr client)
         swaps(&rep.server_major);
         swaps(&rep.server_minor);
     }
-    WriteToClient(client, sizeof (xXResQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof (xXResQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -73,7 +73,7 @@ ProcXResQueryClients (ClientPtr client)
         swapl (&rep.length);
         swapl (&rep.num_clients);
     }   
-    WriteToClient (client, sizeof (xXResQueryClientsReply), (char *) &rep);
+    WriteToClient (client, sizeof (xXResQueryClientsReply), &rep);
 
     if(num_clients) {
         xXResClient scratch;
@@ -86,7 +86,7 @@ ProcXResQueryClients (ClientPtr client)
                 swapl (&scratch.resource_base);
                 swapl (&scratch.resource_mask);
             }
-            WriteToClient (client, sz_xXResClient, (char *) &scratch);
+            WriteToClient (client, sz_xXResClient, &scratch);
         }
     }
 
@@ -144,7 +144,7 @@ ProcXResQueryClientResources (ClientPtr client)
         swapl (&rep.length);
         swapl (&rep.num_types);
     }   
-    WriteToClient (client,sizeof(xXResQueryClientResourcesReply),(char*)&rep);
+    WriteToClient (client,sizeof(xXResQueryClientResourcesReply),&rep);
 
     if(num_types) {
         xXResType scratch;
@@ -165,7 +165,7 @@ ProcXResQueryClientResources (ClientPtr client)
                 swapl (&scratch.resource_type);
                 swapl (&scratch.count);
             }
-            WriteToClient (client, sz_xXResType, (char *) &scratch);
+            WriteToClient (client, sz_xXResType, &scratch);
         }
     }
 
@@ -222,7 +222,7 @@ ProcXResQueryClientPixmapBytes (ClientPtr client)
         swapl (&rep.bytes);
         swapl (&rep.bytes_overflow);
     }
-    WriteToClient (client,sizeof(xXResQueryClientPixmapBytesReply),(char*)&rep);
+    WriteToClient (client,sizeof(xXResQueryClientPixmapBytesReply),&rep);
 
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/Xext/xtest.c
+++ b/nx-X11/programs/Xserver/Xext/xtest.c
@@ -132,7 +132,7 @@ ProcXTestGetVersion(client)
 	swaps(&rep.sequenceNumber);
 	swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xXTestGetVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXTestGetVersionReply), &rep);
     return(client->noClientException);
 }
 
@@ -168,7 +168,7 @@ ProcXTestCompareCursor(client)
     if (client->swapped) {
 	swaps(&rep.sequenceNumber);
     }
-    WriteToClient(client, sizeof(xXTestCompareCursorReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXTestCompareCursorReply), &rep);
     return(client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/Xext/xvdisp.c
+++ b/nx-X11/programs/Xserver/Xext/xvdisp.c
@@ -160,59 +160,59 @@ static int SWriteImageFormatInfo(ClientPtr, xvImageFormatInfo*);
 
 #define _WriteQueryAdaptorsReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryAdaptorsReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryAdaptorsReply, (char*)_d)
+  else WriteToClient(_c, sz_xvQueryAdaptorsReply, _d)
 
 #define _WriteQueryExtensionReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryExtensionReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryExtensionReply, (char*)_d)
+  else WriteToClient(_c, sz_xvQueryExtensionReply, _d)
 
 #define _WriteQueryEncodingsReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryEncodingsReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryEncodingsReply, (char*)_d)
+  else WriteToClient(_c, sz_xvQueryEncodingsReply, _d)
 
 #define _WriteAdaptorInfo(_c,_d) \
   if ((_c)->swapped) SWriteAdaptorInfo(_c, _d); \
-  else WriteToClient(_c, sz_xvAdaptorInfo, (char*)_d)
+  else WriteToClient(_c, sz_xvAdaptorInfo, _d)
 
 #define _WriteAttributeInfo(_c,_d) \
   if ((_c)->swapped) SWriteAttributeInfo(_c, _d); \
-  else WriteToClient(_c, sz_xvAttributeInfo, (char*)_d)
+  else WriteToClient(_c, sz_xvAttributeInfo, _d)
 
 #define _WriteEncodingInfo(_c,_d) \
   if ((_c)->swapped) SWriteEncodingInfo(_c, _d); \
-  else WriteToClient(_c, sz_xvEncodingInfo, (char*)_d)
+  else WriteToClient(_c, sz_xvEncodingInfo, _d)
 
 #define _WriteFormat(_c,_d) \
   if ((_c)->swapped) SWriteFormat(_c, _d); \
-  else WriteToClient(_c, sz_xvFormat, (char*)_d)
+  else WriteToClient(_c, sz_xvFormat, _d)
 
 #define _WriteGrabPortReply(_c,_d) \
   if ((_c)->swapped) SWriteGrabPortReply(_c, _d); \
-  else WriteToClient(_c, sz_xvGrabPortReply, (char*)_d)
+  else WriteToClient(_c, sz_xvGrabPortReply, _d)
 
 #define _WriteGetPortAttributeReply(_c,_d) \
   if ((_c)->swapped) SWriteGetPortAttributeReply(_c, _d); \
-  else WriteToClient(_c, sz_xvGetPortAttributeReply, (char*)_d)
+  else WriteToClient(_c, sz_xvGetPortAttributeReply, _d)
 
 #define _WriteQueryBestSizeReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryBestSizeReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryBestSizeReply,(char*) _d)
+  else WriteToClient(_c, sz_xvQueryBestSizeReply, _d)
 
 #define _WriteQueryPortAttributesReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryPortAttributesReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryPortAttributesReply,(char*) _d)
+  else WriteToClient(_c, sz_xvQueryPortAttributesReply, _d)
 
 #define _WriteQueryImageAttributesReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryImageAttributesReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryImageAttributesReply,(char*) _d)
+  else WriteToClient(_c, sz_xvQueryImageAttributesReply, _d)
 
 #define _WriteListImageFormatsReply(_c,_d) \
   if ((_c)->swapped) SWriteListImageFormatsReply(_c, _d); \
-  else WriteToClient(_c, sz_xvListImageFormatsReply,(char*) _d)
+  else WriteToClient(_c, sz_xvListImageFormatsReply, _d)
 
 #define _WriteImageFormatInfo(_c,_d) \
   if ((_c)->swapped) SWriteImageFormatInfo(_c, _d); \
-  else WriteToClient(_c, sz_xvImageFormatInfo, (char*)_d)
+  else WriteToClient(_c, sz_xvImageFormatInfo, _d)
 
 #define _AllocatePort(_i,_p) \
   ((_p)->id != _i) ? (* (_p)->pAdaptor->ddAllocatePort)(_i,_p,&_p) : Success
@@ -1278,7 +1278,7 @@ ProcXvQueryImageAttributes(ClientPtr client)
   _WriteQueryImageAttributesReply(client, &rep);
   if(client->swapped)
     SwapLongs((CARD32*)offsets, rep.length);
-  WriteToClient(client, rep.length << 2, (char*)offsets);
+  WriteToClient(client, rep.length << 2, offsets);
 
   free(offsets);
 
@@ -1639,7 +1639,7 @@ SWriteQueryExtensionReply(
   swaps(&rep->version);
   swaps(&rep->revision);
   
-  (void)WriteToClient(client, sz_xvQueryExtensionReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryExtensionReply, &rep);
 
   return Success;
 }
@@ -1653,7 +1653,7 @@ SWriteQueryAdaptorsReply(
   swapl(&rep->length);
   swaps(&rep->num_adaptors);
   
-  (void)WriteToClient(client, sz_xvQueryAdaptorsReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryAdaptorsReply, &rep);
 
   return Success;
 }
@@ -1667,7 +1667,7 @@ SWriteQueryEncodingsReply(
   swapl(&rep->length);
   swaps(&rep->num_encodings);
   
-  (void)WriteToClient(client, sz_xvQueryEncodingsReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryEncodingsReply, &rep);
 
   return Success;
 }
@@ -1682,7 +1682,7 @@ SWriteAdaptorInfo(
   swaps(&pAdaptor->num_ports);
   swaps(&pAdaptor->num_formats);
 
-  (void)WriteToClient(client, sz_xvAdaptorInfo, (char *)pAdaptor);
+  WriteToClient(client, sz_xvAdaptorInfo, pAdaptor);
 
   return Success;
 }
@@ -1698,7 +1698,7 @@ SWriteEncodingInfo(
   swaps(&pEncoding->height);
   swapl(&pEncoding->rate.numerator);
   swapl(&pEncoding->rate.denominator);
-  (void)WriteToClient(client, sz_xvEncodingInfo, (char *)pEncoding);
+  WriteToClient(client, sz_xvEncodingInfo, pEncoding);
 
   return Success;
 }
@@ -1709,7 +1709,7 @@ SWriteFormat(
    xvFormat *pFormat
 ){
   swapl(&pFormat->visual);
-  (void)WriteToClient(client, sz_xvFormat, (char *)pFormat);
+  WriteToClient(client, sz_xvFormat, pFormat);
 
   return Success;
 }
@@ -1723,7 +1723,7 @@ SWriteAttributeInfo(
   swapl(&pAtt->size);
   swapl(&pAtt->min);
   swapl(&pAtt->max);
-  (void)WriteToClient(client, sz_xvAttributeInfo, (char *)pAtt);
+  WriteToClient(client, sz_xvAttributeInfo, pAtt);
 
   return Success;
 }
@@ -1747,7 +1747,7 @@ SWriteImageFormatInfo(
   swapl(&pImage->vert_u_period);
   swapl(&pImage->vert_v_period);
 
-  (void)WriteToClient(client, sz_xvImageFormatInfo, (char *)pImage);
+  WriteToClient(client, sz_xvImageFormatInfo, pImage);
 
   return Success;
 }
@@ -1762,7 +1762,7 @@ SWriteGrabPortReply(
   swaps(&rep->sequenceNumber);
   swapl(&rep->length);
 
-  (void)WriteToClient(client, sz_xvGrabPortReply, (char *)&rep);
+  WriteToClient(client, sz_xvGrabPortReply, &rep);
 
   return Success;
 }
@@ -1776,7 +1776,7 @@ SWriteGetPortAttributeReply(
   swapl(&rep->length);
   swapl(&rep->value);
 
-  (void)WriteToClient(client, sz_xvGetPortAttributeReply, (char *)&rep);
+  WriteToClient(client, sz_xvGetPortAttributeReply, &rep);
 
   return Success;
 }
@@ -1791,7 +1791,7 @@ SWriteQueryBestSizeReply(
   swaps(&rep->actual_width);
   swaps(&rep->actual_height);
 
-  (void)WriteToClient(client, sz_xvQueryBestSizeReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryBestSizeReply, &rep);
 
   return Success;
 }
@@ -1806,7 +1806,7 @@ SWriteQueryPortAttributesReply(
   swapl(&rep->num_attributes);
   swapl(&rep->text_size);
 
-  (void)WriteToClient(client, sz_xvQueryPortAttributesReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryPortAttributesReply, &rep);
 
   return Success;
 }
@@ -1823,7 +1823,7 @@ SWriteQueryImageAttributesReply(
   swaps(&rep->width);
   swaps(&rep->height);
 
-  (void)WriteToClient(client, sz_xvQueryImageAttributesReply, (char *)&rep);
+  WriteToClient(client, sz_xvQueryImageAttributesReply, &rep);
 
   return Success;
 }
@@ -1838,7 +1838,7 @@ SWriteListImageFormatsReply(
   swapl(&rep->length);
   swapl(&rep->num_formats);
 
-  (void)WriteToClient(client, sz_xvListImageFormatsReply, (char *)&rep);
+  WriteToClient(client, sz_xvListImageFormatsReply, &rep);
 
   return Success;
 }

--- a/nx-X11/programs/Xserver/Xext/xvmc.c
+++ b/nx-X11/programs/Xserver/Xext/xvmc.c
@@ -129,7 +129,7 @@ ProcXvMCQueryVersion(ClientPtr client)
     rep.length = 0;
     rep.major = XvMCVersion;
     rep.minor = XvMCRevision;
-    WriteToClient(client, sizeof(xvmcQueryVersionReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcQueryVersionReply), &rep);
     return Success;
 }
 
@@ -169,7 +169,7 @@ ProcXvMCListSurfaceTypes(ClientPtr client)
     rep.num = (adaptor) ? adaptor->num_surfaces : 0;
     rep.length = rep.num * sizeof(xvmcSurfaceInfo) >> 2;
  
-    WriteToClient(client, sizeof(xvmcListSurfaceTypesReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcListSurfaceTypesReply), &rep);
 
     for(i = 0; i < rep.num; i++) {
 	surface = adaptor->surfaces[i];
@@ -181,7 +181,7 @@ ProcXvMCListSurfaceTypes(ClientPtr client)
 	info.subpicture_max_height = surface->subpicture_max_height;
 	info.mc_type = surface->mc_type;
 	info.flags = surface->flags;
-	WriteToClient(client, sizeof(xvmcSurfaceInfo), (char*)&info);
+	WriteToClient(client, sizeof(xvmcSurfaceInfo), &info);
     }
 
     return Success;
@@ -270,9 +270,9 @@ ProcXvMCCreateContext(ClientPtr client)
     rep.flags_return = pContext->flags; 
     rep.length = dwords;
 
-    WriteToClient(client, sizeof(xvmcCreateContextReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcCreateContextReply), &rep);
     if(dwords)
-      WriteToClient(client, dwords << 2, (char*)data); 
+      WriteToClient(client, dwords << 2, data);
     AddResource(pContext->context_id, XvMCRTContext, pContext);
 
     if(data)
@@ -332,9 +332,9 @@ ProcXvMCCreateSurface(ClientPtr client)
     rep.sequenceNumber = client->sequence;
     rep.length = dwords;
 
-    WriteToClient(client, sizeof(xvmcCreateSurfaceReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcCreateSurfaceReply), &rep);
     if(dwords)
-      WriteToClient(client, dwords << 2, (char*)data);
+      WriteToClient(client, dwords << 2, data);
     AddResource(pSurface->surface_id, XvMCRTSurface, pSurface);
 
     if(data)
@@ -443,9 +443,9 @@ ProcXvMCCreateSubpicture(ClientPtr client)
     rep.component_order[3] = pSubpicture->component_order[3];
     rep.length = dwords;
 
-    WriteToClient(client, sizeof(xvmcCreateSubpictureReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcCreateSubpictureReply), &rep);
     if(dwords)
-      WriteToClient(client, dwords << 2, (char*)data);
+      WriteToClient(client, dwords << 2, data);
     AddResource(pSubpicture->subpicture_id, XvMCRTSubpicture, pSubpicture);
 
     if(data)
@@ -525,7 +525,7 @@ ProcXvMCListSubpictureTypes(ClientPtr client)
 
     rep.length = rep.num * sizeof(xvImageFormatInfo) >> 2;
 
-    WriteToClient(client, sizeof(xvmcListSubpictureTypesReply), (char*)&rep);
+    WriteToClient(client, sizeof(xvmcListSubpictureTypesReply), &rep);
 
     for(i = 0; i < rep.num; i++) {
 	pImage = NULL;
@@ -561,7 +561,7 @@ ProcXvMCListSubpictureTypes(ClientPtr client)
         info.vert_v_period = pImage->vert_v_period;        
         memcpy(&info.comp_order, pImage->component_order, 32);     
         info.scanline_order = pImage->scanline_order;
-	WriteToClient(client, sizeof(xvImageFormatInfo), (char*)&info);
+	WriteToClient(client, sizeof(xvImageFormatInfo), &info);
     }
 
     return Success;
@@ -631,7 +631,7 @@ ProcXvMCGetDRInfo(ClientPtr client)
 #endif /* HAS_XVMCSHM */
     
     WriteToClient(client, sizeof(xvmcGetDRInfoReply), 
-		  (char*)&rep);
+		  &rep);
     if (rep.length) {      
 	WriteToClient(client, rep.nameLen, 
 		      pScreenPriv->clientDriverName);

--- a/nx-X11/programs/Xserver/Xi/chgdctl.c
+++ b/nx-X11/programs/Xserver/Xi/chgdctl.c
@@ -210,6 +210,6 @@ SRepXChangeDeviceControl (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/chgkbd.c
+++ b/nx-X11/programs/Xserver/Xi/chgkbd.c
@@ -208,5 +208,5 @@ SRepXChangeKeyboardDevice (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/chgptr.c
+++ b/nx-X11/programs/Xserver/Xi/chgptr.c
@@ -254,5 +254,5 @@ SRepXChangePointerDevice (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getbmap.c
+++ b/nx-X11/programs/Xserver/Xi/getbmap.c
@@ -126,7 +126,7 @@ ProcXGetDeviceButtonMapping (client)
     rep.nElts = b->numButtons;
     rep.length = (rep.nElts + (4-1))/4;
     WriteReplyToClient (client, sizeof (xGetDeviceButtonMappingReply), &rep);
-    (void)WriteToClient(client, rep.nElts,
+    WriteToClient(client, rep.nElts,
 			(char *)&b->map[1]);
     return Success;
     }
@@ -146,5 +146,5 @@ SRepXGetDeviceButtonMapping (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getdctl.c
+++ b/nx-X11/programs/Xserver/Xi/getdctl.c
@@ -220,6 +220,6 @@ SRepXGetDeviceControl (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/getfctl.c
+++ b/nx-X11/programs/Xserver/Xi/getfctl.c
@@ -408,5 +408,5 @@ SRepXGetFeedbackControl (client, size, rep)
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
     swaps(&rep->num_feedbacks);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getfocus.c
+++ b/nx-X11/programs/Xserver/Xi/getfocus.c
@@ -149,5 +149,5 @@ SRepXGetDeviceFocus (client, size, rep)
     swapl(&rep->length);
     swapl(&rep->focus);
     swapl(&rep->time);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getkmap.c
+++ b/nx-X11/programs/Xserver/Xi/getkmap.c
@@ -169,6 +169,6 @@ SRepXGetDeviceKeyMapping (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/getmmap.c
+++ b/nx-X11/programs/Xserver/Xi/getmmap.c
@@ -131,7 +131,7 @@ ProcXGetDeviceModifierMapping(client)
     WriteReplyToClient(client, sizeof(xGetDeviceModifierMappingReply), &rep);
 
     /* Reply with the (modified by DDX) map that SetModifierMapping passed in */
-    WriteToClient(client, 8*maxkeys, (char *)kp->modifierKeyMap);
+    WriteToClient(client, 8*maxkeys, kp->modifierKeyMap);
     return Success;
     }
 
@@ -150,5 +150,5 @@ SRepXGetDeviceModifierMapping (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getprop.c
+++ b/nx-X11/programs/Xserver/Xi/getprop.c
@@ -207,5 +207,5 @@ SRepXGetDeviceDontPropagateList (client, size, rep)
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
     swaps(&rep->count);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getselev.c
+++ b/nx-X11/programs/Xserver/Xi/getselev.c
@@ -188,5 +188,5 @@ SRepXGetSelectedExtensionEvents (client, size, rep)
     swapl(&rep->length);
     swaps(&rep->this_client_count);
     swaps(&rep->all_clients_count);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/getvers.c
+++ b/nx-X11/programs/Xserver/Xi/getvers.c
@@ -150,5 +150,5 @@ SRepXGetExtensionVersion (client, size, rep)
     swapl(&rep->length);
     swaps(&rep->major_version);
     swaps(&rep->minor_version);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/grabdev.c
+++ b/nx-X11/programs/Xserver/Xi/grabdev.c
@@ -221,5 +221,5 @@ SRepXGrabDevice (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/gtmotion.c
+++ b/nx-X11/programs/Xserver/Xi/gtmotion.c
@@ -180,7 +180,7 @@ ProcXGetDeviceMotionEvents(client)
 		bufptr++;
 		}
 	    }
-	WriteToClient(client, length * 4, (char *)coords);
+	WriteToClient(client, length * 4, coords);
         }
     if (coords)
 	DEALLOCATE_LOCAL(coords);
@@ -203,5 +203,5 @@ SRepXGetDeviceMotionEvents (client, size, rep)
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
     swapl(&rep->nEvents);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/listdev.c
+++ b/nx-X11/programs/Xserver/Xi/listdev.c
@@ -396,5 +396,5 @@ SRepXListInputDevices (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/opendev.c
+++ b/nx-X11/programs/Xserver/Xi/opendev.c
@@ -179,7 +179,7 @@ ProcXOpenDevice(client)
     rep.length = (j * sizeof (xInputClassInfo) + 3) >> 2;
     rep.num_classes = j;
     WriteReplyToClient (client, sizeof (xOpenDeviceReply), &rep);
-    WriteToClient(client, j * sizeof (xInputClassInfo), (char *)evbase);
+    WriteToClient(client, j * sizeof (xInputClassInfo), evbase);
     return (Success);
     }
 
@@ -198,5 +198,5 @@ SRepXOpenDevice (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/queryst.c
+++ b/nx-X11/programs/Xserver/Xi/queryst.c
@@ -206,5 +206,5 @@ SRepXQueryDeviceState (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/setbmap.c
+++ b/nx-X11/programs/Xserver/Xi/setbmap.c
@@ -162,5 +162,5 @@ SRepXSetDeviceButtonMapping (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/setdval.c
+++ b/nx-X11/programs/Xserver/Xi/setdval.c
@@ -166,5 +166,5 @@ SRepXSetDeviceValuators (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/Xi/setmmap.c
+++ b/nx-X11/programs/Xserver/Xi/setmmap.c
@@ -155,6 +155,6 @@ SRepXSetDeviceModifierMapping (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }
 

--- a/nx-X11/programs/Xserver/Xi/setmode.c
+++ b/nx-X11/programs/Xserver/Xi/setmode.c
@@ -150,5 +150,5 @@ SRepXSetDeviceMode (client, size, rep)
     {
     swaps(&rep->sequenceNumber);
     swapl(&rep->length);
-    WriteToClient(client, size, (char *)rep);
+    WriteToClient(client, size, rep);
     }

--- a/nx-X11/programs/Xserver/composite/compext.c
+++ b/nx-X11/programs/Xserver/composite/compext.c
@@ -132,7 +132,7 @@ ProcCompositeQueryVersion (ClientPtr client)
 	swapl(&rep.majorVersion);
 	swapl(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xCompositeQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xCompositeQueryVersionReply), &rep);
     return Success;
 }
 
@@ -405,7 +405,7 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.overlayWin);
     }
-    WriteToClient(client, sz_xCompositeGetOverlayWindowReply, (char *)&rep);
+    WriteToClient(client, sz_xCompositeGetOverlayWindowReply, &rep);
 
     return Success;
 }

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -160,7 +160,7 @@ ProcDamageQueryVersion(ClientPtr client)
 	swapl(&rep.majorVersion);
 	swapl(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xDamageQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDamageQueryVersionReply), &rep);
     return(client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/dbe/dbe.c
+++ b/nx-X11/programs/Xserver/dbe/dbe.c
@@ -376,7 +376,7 @@ ProcDbeGetVersion(client)
         swaps(&rep.sequenceNumber);
     }
 
-    WriteToClient(client, sizeof(xDbeGetVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDbeGetVersionReply), &rep);
 
     return(client->noClientException);
 
@@ -988,7 +988,7 @@ ProcDbeGetVisualInfo(client)
     }
 
     /* Send off reply. */
-    WriteToClient(client, sizeof(xDbeGetVisualInfoReply), (char *)&rep);
+    WriteToClient(client, sizeof(xDbeGetVisualInfoReply), &rep);
 
     for (i = 0; i < count; i++)
     {
@@ -1004,7 +1004,7 @@ ProcDbeGetVisualInfo(client)
             swapl(&data32);
         }
 
-        WriteToClient(client, sizeof(CARD32), (char *)&data32);
+        WriteToClient(client, sizeof(CARD32), &data32);
 
         /* Now send off visual info items. */
         for (j = 0; j < pScrVisInfo[i].count; j++)
@@ -1030,7 +1030,7 @@ ProcDbeGetVisualInfo(client)
             }
 
             /* Write visualID(32), depth(8), perfLevel(8), and pad(16). */
-            WriteToClient(client, 2*sizeof(CARD32), (char *)&visInfo.visualID);
+            WriteToClient(client, 2*sizeof(CARD32), &visInfo.visualID);
         }
     }
 
@@ -1098,7 +1098,7 @@ ProcDbeGetBackBufferAttributes(client)
     }
 
     WriteToClient(client, sizeof(xDbeGetBackBufferAttributesReply),
-                  (char *)&rep);
+                  &rep);
     return(client->noClientException);
 
 } /* ProcDbeGetbackBufferAttributes() */

--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -1041,7 +1041,7 @@ ProcGetModifierMapping(ClientPtr client)
     WriteReplyToClient(client, sizeof(xGetModifierMappingReply), &rep);
 
     /* Use the (modified by DDX) map that SetModifierMapping passed in */
-    (void)WriteToClient(client, (int)(keyc->maxKeysPerModifier << 3),
+    WriteToClient(client, (int)(keyc->maxKeysPerModifier << 3),
 			(char *)keyc->modifierKeyMap);
     return client->noClientException;
 }
@@ -1178,7 +1178,7 @@ ProcGetPointerMapping(ClientPtr client)
     rep.nElts = butc->numButtons;
     rep.length = ((unsigned)rep.nElts + (4-1))/4;
     WriteReplyToClient(client, sizeof(xGetPointerMappingReply), &rep);
-    (void)WriteToClient(client, (int)rep.nElts, (char *)&butc->map[1]);
+    WriteToClient(client, (int)rep.nElts, &butc->map[1]);
     return Success;    
 }
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -945,7 +945,7 @@ ProcGetAtomName(register ClientPtr client)
 	reply.sequenceNumber = client->sequence;
 	reply.nameLength = len;
 	WriteReplyToClient(client, sizeof(xGetAtomNameReply), &reply);
-	(void)WriteToClient(client, len, str);
+	WriteToClient(client, len, str);
 	return(client->noClientException);
     }
     else 
@@ -2278,7 +2278,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 			       ClientOrder(client));
 
 /* Don't split me, gcc pukes when you do */
-		(void)WriteToClient(client,
+		WriteToClient(client,
 				    (int)(nlines * widthBytesLine),
 				    pBuf);
 	    }
@@ -2322,7 +2322,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 				       ClientOrder (client));
 
 /* Don't split me, gcc pukes when you do */
-			(void)WriteToClient(client,
+			WriteToClient(client,
 					(int)(nlines * widthBytesLine),
 					pBuf);
 		    }
@@ -3441,7 +3441,7 @@ ProcGetFontPath(register ClientPtr client)
 
     WriteReplyToClient(client, sizeof(xGetFontPathReply), &reply);
     if (stringLens || numpaths)
-	(void)WriteToClient(client, stringLens + numpaths, (char *)bufferStart);
+	WriteToClient(client, stringLens + numpaths, bufferStart);
     return(client->noClientException);
 }
 
@@ -3835,8 +3835,8 @@ SendConnSetup(register ClientPtr client, char *reason)
 	if (client->swapped)
 	    WriteSConnSetupPrefix(client, &csp);
 	else
-	    (void)WriteToClient(client, sz_xConnSetupPrefix, (char *) &csp);
-        (void)WriteToClient(client, (int)csp.lengthReason, reason);
+	    WriteToClient(client, sz_xConnSetupPrefix, &csp);
+        WriteToClient(client, (int)csp.lengthReason, reason);
 	return (client->noClientException = -1);
     }
 
@@ -3893,9 +3893,9 @@ SendConnSetup(register ClientPtr client, char *reason)
     }
     else
     {
-	(void)WriteToClient(client, sizeof(xConnSetupPrefix),
+	WriteToClient(client, sizeof(xConnSetupPrefix),
 			    (char *) lconnSetupPrefix);
-	(void)WriteToClient(client, (int)(lconnSetupPrefix->length << 2),
+	WriteToClient(client, (int)(lconnSetupPrefix->length << 2),
 			    lConnectionInfo);
     }
     client->clientState = ClientStateRunning;

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -821,7 +821,7 @@ finish:
     reply.length = (stringLens + nnames + 3) >> 2;
     client->pSwapReplyFunc = ReplySwapVector[X_ListFonts];
     WriteSwappedDataToClient(client, sizeof(xListFontsReply), &reply);
-    (void) WriteToClient(client, stringLens + nnames, bufferStart);
+    WriteToClient(client, stringLens + nnames, bufferStart);
     DEALLOCATE_LOCAL(bufferStart);
 
 bail:
@@ -1081,7 +1081,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
 		pFP++;
 	    }
 	    WriteSwappedDataToClient(client, length, reply);
-	    (void) WriteToClient(client, namelen, name);
+	    WriteToClient(client, namelen, name);
 	    if (pFontInfo == &fontInfo)
  	    {
 		free(fontInfo.props);

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -4494,11 +4494,11 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 	       this event was sent with "SendEvent." */
 	    (*EventSwapVector[eventFrom->u.u.type & 0177])
 		(eventFrom, &eventTo);
-	    (void)WriteToClient(pClient, sizeof(xEvent), (char *)&eventTo);
+	    WriteToClient(pClient, sizeof(xEvent), &eventTo);
 	}
     }
     else
     {
-	(void)WriteToClient(pClient, count * sizeof(xEvent), (char *) events);
+	WriteToClient(pClient, count * sizeof(xEvent), events);
     }
 }

--- a/nx-X11/programs/Xserver/dix/swaprep.c
+++ b/nx-X11/programs/Xserver/dix/swaprep.c
@@ -86,7 +86,7 @@ Swap32Write(ClientPtr pClient, int size, register CARD32 *pbuf)
     {   
 	swapl(&pbuf[i]);
     }
-    (void)WriteToClient(pClient, size << 2, (char *) pbuf);
+    WriteToClient(pClient, size << 2, pbuf);
 }
 
 /**
@@ -130,7 +130,7 @@ CopySwap32Write(ClientPtr pClient, int size, CARD32 *pbuf)
             from++;
             to++;
 	    }
-	(void)WriteToClient (pClient, nbytes, (char *) pbufT);
+	WriteToClient (pClient, nbytes, pbufT);
 	}
 
     if (pbufT != tmpbuf)
@@ -178,7 +178,7 @@ CopySwap16Write(ClientPtr pClient, int size, short *pbuf)
             from++;
             to++;
 	    }
-	(void)WriteToClient (pClient, nbytes, (char *) pbufT);
+	WriteToClient (pClient, nbytes, pbufT);
 	}
 
     if (pbufT != tmpbuf)
@@ -191,7 +191,7 @@ void
 SGenericReply(ClientPtr pClient, int size, xGenericReply *pRep)
 {
     swaps(&pRep->sequenceNumber);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 /* Extra-large reply */
@@ -209,7 +209,7 @@ SGetWindowAttributesReply(ClientPtr pClient, int size,
     swapl(&pRep->allEventMasks);
     swapl(&pRep->yourEventMask);
     swaps(&pRep->doNotPropagateMask);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -222,7 +222,7 @@ SGetGeometryReply(ClientPtr pClient, int size, xGetGeometryReply *pRep)
     swaps(&pRep->width);
     swaps(&pRep->height);
     swaps(&pRep->borderWidth);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -233,7 +233,7 @@ SQueryTreeReply(ClientPtr pClient, int size, xQueryTreeReply *pRep)
     swapl(&pRep->root);
     swapl(&pRep->parent);
     swaps(&pRep->nChildren);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -241,7 +241,7 @@ SInternAtomReply(ClientPtr pClient, int size, xInternAtomReply *pRep)
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->atom);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -250,7 +250,7 @@ SGetAtomNameReply(ClientPtr pClient, int size, xGetAtomNameReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nameLength);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 
@@ -262,7 +262,7 @@ SGetPropertyReply(ClientPtr pClient, int size, xGetPropertyReply *pRep)
     swapl(&pRep->propertyType);
     swapl(&pRep->bytesAfter);
     swapl(&pRep->nItems);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -271,7 +271,7 @@ SListPropertiesReply(ClientPtr pClient, int size, xListPropertiesReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nProperties);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -280,7 +280,7 @@ SGetSelectionOwnerReply(ClientPtr pClient, int size,
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->owner);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 
@@ -295,7 +295,7 @@ SQueryPointerReply(ClientPtr pClient, int size, xQueryPointerReply *pRep)
     swaps(&pRep->winX);
     swaps(&pRep->winY);
     swaps(&pRep->mask);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -319,7 +319,7 @@ SwapTimeCoordWrite(ClientPtr pClient, int size, xTimecoord *pRep)
 	SwapTimecoord(pRepT);
 	pRepT++;
     }
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 
 }
 void
@@ -328,7 +328,7 @@ SGetMotionEventsReply(ClientPtr pClient, int size, xGetMotionEventsReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swapl(&pRep->nEvents);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -338,7 +338,7 @@ STranslateCoordsReply(ClientPtr pClient, int size, xTranslateCoordsReply *pRep)
     swapl(&pRep->child);
     swaps(&pRep->dstX);
     swaps(&pRep->dstY);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -346,7 +346,7 @@ SGetInputFocusReply(ClientPtr pClient, int size, xGetInputFocusReply *pRep)
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->focus);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 /* extra long reply */
@@ -355,7 +355,7 @@ SQueryKeymapReply(ClientPtr pClient, int size, xQueryKeymapReply *pRep)
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 static
@@ -420,7 +420,7 @@ void
 SQueryFontReply(ClientPtr pClient, int size, xQueryFontReply *pRep)
 {
     SwapFont(pRep, TRUE);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -434,7 +434,7 @@ SQueryTextExtentsReply(ClientPtr pClient, int size, xQueryTextExtentsReply *pRep
     swapl(&pRep->overallWidth);
     swapl(&pRep->overallLeft);
     swapl(&pRep->overallRight);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -443,7 +443,7 @@ SListFontsReply(ClientPtr pClient, int size, xListFontsReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nFonts);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -451,7 +451,7 @@ SListFontsWithInfoReply(ClientPtr pClient, int size,
                         xListFontsWithInfoReply *pRep)
 {
     SwapFont((xQueryFontReply *)pRep, FALSE);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -460,7 +460,7 @@ SGetFontPathReply(ClientPtr pClient, int size, xGetFontPathReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nPaths);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -469,7 +469,7 @@ SGetImageReply(ClientPtr pClient, int size, xGetImageReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swapl(&pRep->visual);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
     /* Fortunately, image doesn't need swapping */
 }
 
@@ -480,7 +480,7 @@ SListInstalledColormapsReply(ClientPtr pClient, int size,
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nColormaps);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -494,7 +494,7 @@ SAllocColorReply(pClient, size, pRep)
     swaps(&pRep->green);
     swaps(&pRep->blue);
     swapl(&pRep->pixel);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -508,7 +508,7 @@ SAllocNamedColorReply(ClientPtr pClient, int size, xAllocNamedColorReply *pRep)
     swaps(&pRep->screenRed);
     swaps(&pRep->screenGreen);
     swaps(&pRep->screenBlue);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -518,7 +518,7 @@ SAllocColorCellsReply(ClientPtr pClient, int size, xAllocColorCellsReply *pRep)
     swapl(&pRep->length);
     swaps(&pRep->nPixels);
     swaps(&pRep->nMasks);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 
@@ -531,7 +531,7 @@ SAllocColorPlanesReply(ClientPtr pClient, int size, xAllocColorPlanesReply *pRep
     swapl(&pRep->redMask);
     swapl(&pRep->greenMask);
     swapl(&pRep->blueMask);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -555,7 +555,7 @@ SQColorsExtend(ClientPtr pClient, int size, xrgb *prgb)
 	SwapRGB(prgbT);
 	prgbT++;
     }
-    (void)WriteToClient(pClient, size, (char *) prgb);
+    WriteToClient(pClient, size, prgb);
 }
 
 void
@@ -564,7 +564,7 @@ SQueryColorsReply(ClientPtr pClient, int size, xQueryColorsReply* pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nColors);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -577,7 +577,7 @@ SLookupColorReply(ClientPtr pClient, int size, xLookupColorReply *pRep)
     swaps(&pRep->screenRed);
     swaps(&pRep->screenGreen);
     swaps(&pRep->screenBlue);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -586,7 +586,7 @@ SQueryBestSizeReply(ClientPtr pClient, int size, xQueryBestSizeReply *pRep)
     swaps(&pRep->sequenceNumber);
     swaps(&pRep->width);
     swaps(&pRep->height);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -594,7 +594,7 @@ SListExtensionsReply(ClientPtr pClient, int size, xListExtensionsReply *pRep)
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -603,7 +603,7 @@ SGetKeyboardMappingReply(ClientPtr pClient, int size,
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -612,7 +612,7 @@ SGetPointerMappingReply(ClientPtr pClient, int size,
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -621,7 +621,7 @@ SGetModifierMappingReply(ClientPtr pClient, int size,
 {
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -632,7 +632,7 @@ SGetKeyboardControlReply(ClientPtr pClient, int size, xGetKeyboardControlReply *
     swapl(&pRep->ledMask);
     swaps(&pRep->bellPitch);
     swaps(&pRep->bellDuration);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -642,7 +642,7 @@ SGetPointerControlReply(ClientPtr pClient, int size, xGetPointerControlReply *pR
     swaps(&pRep->accelNumerator);
     swaps(&pRep->accelDenominator);
     swaps(&pRep->threshold);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -651,7 +651,7 @@ SGetScreenSaverReply(ClientPtr pClient, int size, xGetScreenSaverReply *pRep)
     swaps(&pRep->sequenceNumber);
     swaps(&pRep->timeout);
     swaps(&pRep->interval);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 void
@@ -665,7 +665,7 @@ SLHostsExtend(ClientPtr pClient, int size, char *buf)
 	swaps (&host->length);
 	bufT += sizeof (xHostEntry) + (((len + 3) >> 2) << 2);
 	}
-    (void)WriteToClient (pClient, size, buf);
+    WriteToClient (pClient, size, buf);
 }
 
 void
@@ -674,7 +674,7 @@ SListHostsReply(ClientPtr pClient, int size, xListHostsReply *pRep)
     swaps(&pRep->sequenceNumber);
     swapl(&pRep->length);
     swaps(&pRep->nHosts);
-    (void)WriteToClient(pClient, size, (char *) pRep);
+    WriteToClient(pClient, size, pRep);
 }
 
 
@@ -1148,7 +1148,7 @@ WriteSConnectionInfo(ClientPtr pClient, unsigned long size, char *pInfo)
 	return;
     }
     SwapConnSetupInfo(pInfo, pInfoTBase);
-    (void)WriteToClient(pClient, (int)size, (char *) pInfoTBase);
+    WriteToClient(pClient, (int)size, pInfoTBase);
     DEALLOCATE_LOCAL(pInfoTBase);
 }
 
@@ -1220,5 +1220,5 @@ WriteSConnSetupPrefix(ClientPtr pClient, xConnSetupPrefix *pcsp)
     xConnSetupPrefix	cspT;
 
     SwapConnSetupPrefix(pcsp, &cspT);
-    (void)WriteToClient(pClient, sizeof(cspT), (char *) &cspT);
+    WriteToClient(pClient, sizeof(cspT), &cspT);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
@@ -601,7 +601,7 @@ finish:
     reply.length = (stringLens + nnames + 3) >> 2;
     client->pSwapReplyFunc = ReplySwapVector[X_ListFonts];
     WriteSwappedDataToClient(client, sizeof(xListFontsReply), &reply);
-    (void) WriteToClient(client, stringLens + nnames, bufferStart);
+    WriteToClient(client, stringLens + nnames, bufferStart);
     DEALLOCATE_LOCAL(bufferStart);
 
 bail:
@@ -883,7 +883,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
 		pFP++;
 	    }
 	    WriteSwappedDataToClient(client, length, reply);
-	    (void) WriteToClient(client, namelen, name);
+	    WriteToClient(client, namelen, name);
 	    if (pFontInfo == &fontInfo)
  	    {
 		free(fontInfo.props);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -150,7 +150,7 @@ ProcRenderQueryVersion (ClientPtr client)
 	swapl(&rep.majorVersion);
 	swapl(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xRenderQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xRenderQueryVersionReply), &rep);
     return (client->noClientException);
 }
 
@@ -359,7 +359,7 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	swapl (&reply->numVisuals);
 	swapl (&reply->numSubpixel);
     }
-    WriteToClient(client, rlength, (char *) reply);
+    WriteToClient(client, rlength, reply);
     free (reply);
     return client->noClientException;
 }

--- a/nx-X11/programs/Xserver/include/dix.h
+++ b/nx-X11/programs/Xserver/include/dix.h
@@ -281,12 +281,12 @@ SOFTWARE.
    if ((pClient)->swapped) \
       (*ReplySwapVector[((xReq *)(pClient)->requestBuffer)->reqType]) \
            (pClient, (int)(size), pReply); \
-      else (void) WriteToClient(pClient, (int)(size), (char *)(pReply)); }
+      else WriteToClient(pClient, (int)(size), (pReply)); }
 
 #define WriteSwappedDataToClient(pClient, size, pbuf) \
    if ((pClient)->swapped) \
       (*(pClient)->pSwapReplyFunc)(pClient, (int)(size), pbuf); \
-   else (void) WriteToClient (pClient, (int)(size), (char *)(pbuf));
+   else WriteToClient (pClient, (int)(size), (pbuf));
 
 typedef struct _TimeStamp *TimeStampPtr;
 

--- a/nx-X11/programs/Xserver/include/os.h
+++ b/nx-X11/programs/Xserver/include/os.h
@@ -124,7 +124,7 @@ extern void FlushIfCriticalOutputPending(void);
 
 extern void SetCriticalOutputPending(void);
 
-extern int WriteToClient(ClientPtr /*who*/, int /*count*/, char* /*buf*/);
+extern int WriteToClient(ClientPtr /*who*/, int /*count*/, const void* /*__buf*/);
 
 extern void ResetOsBuffers(void);
 
@@ -444,7 +444,7 @@ typedef struct {
 extern CallbackListPtr ReplyCallback;
 typedef struct {
     ClientPtr client;
-    void * replyData;
+    const void * replyData;
     unsigned long dataLenBytes;
     unsigned long bytesRemaining;
     Bool startOfReply;

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -857,11 +857,12 @@ SetCriticalOutputPending(void)
  *****************/
 
 int
-WriteToClient (ClientPtr who, int count, char *buf)
+WriteToClient (ClientPtr who, int count, const void *__buf)
 {
     OsCommPtr oc;
     ConnectionOutputPtr oco;
     int padBytes;
+    const char *buf = __buf;
 #ifdef DEBUG_COMMUNICATION
     Bool multicount = FALSE;
 #endif
@@ -999,13 +1000,14 @@ WriteToClient (ClientPtr who, int count, char *buf)
  **********************/
 
 int
-FlushClient(ClientPtr who, OsCommPtr oc, char *extraBuf, int extraCount)
+FlushClient(ClientPtr who, OsCommPtr oc, const void *__extraBuf, int extraCount)
 {
     ConnectionOutputPtr oco = oc->output;
     int connection = oc->fd;
     XtransConnInfo trans_conn = oc->trans_conn;
     struct iovec iov[3];
     static char padBuffer[3];
+    const char *extraBuf = __extraBuf;
     long written;
     long padsize;
     long notWritten;
@@ -1051,7 +1053,7 @@ FlushClient(ClientPtr who, OsCommPtr oc, char *extraBuf, int extraCount)
 	}
 
 	InsertIOV ((char *)oco->buf, oco->count)
-	InsertIOV (extraBuf, extraCount)
+	InsertIOV ((char *)extraBuf, extraCount)
 	InsertIOV (padBuffer, padsize)
 
 	errno = 0;

--- a/nx-X11/programs/Xserver/os/osdep.h
+++ b/nx-X11/programs/Xserver/os/osdep.h
@@ -187,7 +187,7 @@ typedef struct _osComm {
 extern int FlushClient(
     ClientPtr /*who*/,
     OsCommPtr /*oc*/,
-    char* /*extraBuf*/,
+    const void * /*__extraBuf*/,
     int /*extraCount*/
 );
 

--- a/nx-X11/programs/Xserver/os/secauth.c
+++ b/nx-X11/programs/Xserver/os/secauth.c
@@ -181,7 +181,7 @@ AuthSecurityCheck (
     if (client->swapped)
 	WriteSConnSetupPrefix(client, &csp);
     else
-	(void)WriteToClient(client, sz_xConnSetupPrefix, (char *) &csp);
+	WriteToClient(client, sz_xConnSetupPrefix, &csp);
 
     /*
      * Next time the client sends the real auth data, we want

--- a/nx-X11/programs/Xserver/randr/rrcrtc.c
+++ b/nx-X11/programs/Xserver/randr/rrcrtc.c
@@ -1082,9 +1082,9 @@ ProcRRGetCrtcInfo(ClientPtr client)
         swaps(&rep.nOutput);
         swaps(&rep.nPossibleOutput);
     }
-    WriteToClient(client, sizeof(xRRGetCrtcInfoReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetCrtcInfoReply), &rep);
     if (extraLen) {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
 
@@ -1313,7 +1313,7 @@ ProcRRSetCrtcConfig(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.newTimestamp);
     }
-    WriteToClient(client, sizeof(xRRSetCrtcConfigReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRSetCrtcConfigReply), &rep);
 
     return Success;
 }
@@ -1382,7 +1382,7 @@ ProcRRGetPanning(ClientPtr client)
         swaps(&rep.border_right);
         swaps(&rep.border_bottom);
     }
-    WriteToClient(client, sizeof(xRRGetPanningReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetPanningReply), &rep);
     return Success;
 }
 
@@ -1453,7 +1453,7 @@ ProcRRSetPanning(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.newTimestamp);
     }
-    WriteToClient(client, sizeof(xRRSetPanningReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRSetPanningReply), &rep);
     return Success;
 }
 
@@ -1482,7 +1482,7 @@ ProcRRGetCrtcGammaSize(ClientPtr client)
         swapl(&reply.length);
         swaps(&reply.size);
     }
-    WriteToClient(client, sizeof(xRRGetCrtcGammaSizeReply), (char *) &reply);
+    WriteToClient(client, sizeof(xRRGetCrtcGammaSizeReply), &reply);
     return Success;
 }
 
@@ -1521,7 +1521,7 @@ ProcRRGetCrtcGamma(ClientPtr client)
         swapl(&reply.length);
         swaps(&reply.size);
     }
-    WriteToClient(client, sizeof(xRRGetCrtcGammaReply), (char *) &reply);
+    WriteToClient(client, sizeof(xRRGetCrtcGammaReply), &reply);
     if (crtc->gammaSize) {
         memcpy(extra, crtc->gammaRed, len);
         client->pSwapReplyFunc = (ReplySwapPtr) CopySwap16Write;
@@ -1688,7 +1688,7 @@ ProcRRGetCrtcTransform(ClientPtr client)
         swapl(&reply->length);
     }
     WriteToClient(client, sizeof(xRRGetCrtcTransformReply) + nextra,
-                  (char *) reply);
+                  reply);
     free(reply);
     return Success;
 }

--- a/nx-X11/programs/Xserver/randr/rrdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrdispatch.c
@@ -67,7 +67,7 @@ ProcRRQueryVersion(ClientPtr client)
 #ifndef NXAGENT_SERVER
     WriteToClient(client, sizeof(xRRQueryVersionReply), &rep);
 #else
-    WriteToClient(client, sizeof(xRRQueryVersionReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRQueryVersionReply), &rep);
 #endif
     return Success;
 }

--- a/nx-X11/programs/Xserver/randr/rrmode.c
+++ b/nx-X11/programs/Xserver/randr/rrmode.c
@@ -380,7 +380,7 @@ ProcRRCreateMode(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.mode);
     }
-    WriteToClient(client, sizeof(xRRCreateModeReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRCreateModeReply), &rep);
     /* Drop out reference to this mode */
     RRModeDestroy(mode);
     return Success;

--- a/nx-X11/programs/Xserver/randr/rrmonitor.c
+++ b/nx-X11/programs/Xserver/randr/rrmonitor.c
@@ -667,7 +667,7 @@ ProcRRGetMonitors(ClientPtr client)
         swapl(&rep.nmonitors);
         swapl(&rep.noutputs);
     }
-    WriteToClient(client, sizeof(xRRGetMonitorsReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetMonitorsReply), &rep);
 
     client->pSwapReplyFunc = (ReplySwapPtr) CopySwap32Write;
 
@@ -696,7 +696,7 @@ ProcRRGetMonitors(ClientPtr client)
             swapl(&info.heightInMillimeters);
         }
 
-        WriteToClient(client, sizeof(xRRMonitorInfo), (char *) &info);
+        WriteToClient(client, sizeof(xRRMonitorInfo), &info);
         WriteSwappedDataToClient(client, monitor->numOutputs * sizeof(RROutput),
                                  monitor->outputs);
     }

--- a/nx-X11/programs/Xserver/randr/rroutput.c
+++ b/nx-X11/programs/Xserver/randr/rroutput.c
@@ -534,9 +534,9 @@ ProcRRGetOutputInfo(ClientPtr client)
         swaps(&rep.nClones);
         swaps(&rep.nameLength);
     }
-    WriteToClient(client, sizeof(xRRGetOutputInfoReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetOutputInfoReply), &rep);
     if (extraLen) {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
 
@@ -662,7 +662,7 @@ ProcRRGetOutputPrimary(ClientPtr client)
         swapl(&rep.output);
     }
 
-    WriteToClient(client, sizeof(xRRGetOutputPrimaryReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetOutputPrimaryReply), &rep);
 
     return Success;
 }

--- a/nx-X11/programs/Xserver/randr/rrproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproperty.c
@@ -428,7 +428,7 @@ ProcRRListOutputProperties(ClientPtr client)
         swapl(&rep.length);
         swaps(&rep.nAtoms);
     }
-    WriteToClient(client, sizeof(xRRListOutputPropertiesReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRListOutputPropertiesReply), &rep);
 
     if (numProps) {
         /* Copy property name atoms to reply buffer */
@@ -482,7 +482,7 @@ ProcRRQueryOutputProperty(ClientPtr client)
         swaps(&rep.sequenceNumber);
         swapl(&rep.length);
     }
-    WriteToClient(client, sizeof(xRRQueryOutputPropertyReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRQueryOutputPropertyReply), &rep);
     if (prop->num_valid) {
         memcpy(extra, prop->valid_values, prop->num_valid * sizeof(INT32));
         client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
@@ -646,7 +646,7 @@ ProcRRGetOutputProperty(ClientPtr client)
             swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetOutputPropertyReply),
-                      (char *) &reply);
+                      &reply);
         return Success;
     }
 
@@ -675,7 +675,7 @@ ProcRRGetOutputProperty(ClientPtr client)
             swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetOutputPropertyReply),
-                      (char *) &reply);
+                      &reply);
         return Success;
     }
 
@@ -728,7 +728,7 @@ ProcRRGetOutputProperty(ClientPtr client)
         swapl(&reply.bytesAfter);
         swapl(&reply.nItems);
     }
-    WriteToClient(client, sizeof(xGenericReply), (char *) &reply);
+    WriteToClient(client, sizeof(xGenericReply), &reply);
     if (len) {
         memcpy(extra, (char *) prop_value->data + ind, len);
         switch (reply.format) {

--- a/nx-X11/programs/Xserver/randr/rrprovider.c
+++ b/nx-X11/programs/Xserver/randr/rrprovider.c
@@ -147,10 +147,10 @@ ProcRRGetProviders(ClientPtr client)
         swapl(&rep.timestamp);
         swaps(&rep.nProviders);
     }
-    WriteToClient(client, sizeof(xRRGetProvidersReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetProvidersReply), &rep);
     if (extraLen)
     {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
     return Success;
@@ -289,10 +289,10 @@ ProcRRGetProviderInfo(ClientPtr client)
         swaps(&rep.nOutputs);
         swaps(&rep.nameLength);
     }
-    WriteToClient(client, sizeof(xRRGetProviderInfoReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetProviderInfoReply), &rep);
     if (extraLen)
     {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
     return Success;

--- a/nx-X11/programs/Xserver/randr/rrproviderproperty.c
+++ b/nx-X11/programs/Xserver/randr/rrproviderproperty.c
@@ -432,7 +432,7 @@ ProcRRListProviderProperties(ClientPtr client)
         *temppAtoms++ = prop->propertyName;
 
     WriteToClient(client, sizeof(xRRListProviderPropertiesReply),
-                  (char *) &rep);
+                  &rep);
     if (numProps) {
         client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
         WriteSwappedDataToClient(client, numProps * sizeof(Atom), pAtoms);
@@ -479,7 +479,7 @@ ProcRRQueryProviderProperty(ClientPtr client)
         swaps(&rep.sequenceNumber);
         swapl(&rep.length);
     }
-    WriteToClient(client, sizeof(xRRQueryProviderPropertyReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRQueryProviderPropertyReply), &rep);
     if (prop->num_valid) {
         memcpy(extra, prop->valid_values, prop->num_valid * sizeof(INT32));
         client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
@@ -642,7 +642,7 @@ ProcRRGetProviderProperty(ClientPtr client)
             swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetProviderPropertyReply),
-                      (char *) &reply);
+                      &reply);
         return Success;
     }
 
@@ -671,7 +671,7 @@ ProcRRGetProviderProperty(ClientPtr client)
             swapl(&reply.nItems);
         }
         WriteToClient(client, sizeof(xRRGetProviderPropertyReply),
-                      (char *) &reply);
+                      &reply);
         return Success;
     }
 
@@ -724,7 +724,7 @@ ProcRRGetProviderProperty(ClientPtr client)
         swapl(&reply.bytesAfter);
         swapl(&reply.nItems);
     }
-    WriteToClient(client, sizeof(xGenericReply), (char *) &reply);
+    WriteToClient(client, sizeof(xGenericReply), &reply);
     if (len) {
         memcpy(extra, (char *) prop_value->data + ind, len);
         switch (reply.format) {

--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -251,7 +251,7 @@ ProcRRGetScreenSizeRange(ClientPtr client)
         swaps(&rep.maxWidth);
         swaps(&rep.maxHeight);
     }
-    WriteToClient(client, sizeof(xRRGetScreenSizeRangeReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetScreenSizeRangeReply), &rep);
     return Success;
 }
 
@@ -494,9 +494,9 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
         swaps(&rep.nModes);
         swaps(&rep.nbytesNames);
     }
-    WriteToClient(client, sizeof(xRRGetScreenResourcesReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetScreenResourcesReply), &rep);
     if (extraLen) {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
     return Success;
@@ -662,9 +662,9 @@ rrGetScreenResources(ClientPtr client, Bool query)
         swaps(&rep.nbytesNames);
     }
     WriteToClient(client, sizeof(xRRGetScreenResourcesReply),
-                  (char *) (char *) &rep);
+                  (char *) &rep);
     if (extraLen) {
-        WriteToClient(client, extraLen, (char *) (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
     return Success;
@@ -927,9 +927,9 @@ ProcRRGetScreenInfo(ClientPtr client)
         swaps(&rep.rate);
         swaps(&rep.nrateEnts);
     }
-    WriteToClient(client, sizeof(xRRGetScreenInfoReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRGetScreenInfoReply), &rep);
     if (extraLen) {
-        WriteToClient(client, extraLen, (char *) extra);
+        WriteToClient(client, extraLen, extra);
         free(extra);
     }
     return Success;
@@ -1169,7 +1169,7 @@ ProcRRSetScreenConfig(ClientPtr client)
         swapl(&rep.newConfigTimestamp);
         swapl(&rep.root);
     }
-    WriteToClient(client, sizeof(xRRSetScreenConfigReply), (char *) &rep);
+    WriteToClient(client, sizeof(xRRSetScreenConfigReply), &rep);
 
     return Success;
 }

--- a/nx-X11/programs/Xserver/randr/rrxinerama.c
+++ b/nx-X11/programs/Xserver/randr/rrxinerama.c
@@ -123,7 +123,7 @@ ProcRRXineramaQueryVersion(ClientPtr client)
         swaps(&rep.majorVersion);
         swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xPanoramiXQueryVersionReply), (char *) &rep);
+    WriteToClient(client, sizeof(xPanoramiXQueryVersionReply), &rep);
     return Success;
 }
 
@@ -168,7 +168,7 @@ ProcRRXineramaGetState(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.window);
     }
-    WriteToClient(client, sizeof(xPanoramiXGetStateReply), (char *) &rep);
+    WriteToClient(client, sizeof(xPanoramiXGetStateReply), &rep);
     return Success;
 }
 
@@ -215,7 +215,7 @@ ProcRRXineramaGetScreenCount(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.window);
     }
-    WriteToClient(client, sizeof(xPanoramiXGetScreenCountReply), (char *) &rep);
+    WriteToClient(client, sizeof(xPanoramiXGetScreenCountReply), &rep);
     return Success;
 }
 
@@ -259,7 +259,7 @@ ProcRRXineramaGetScreenSize(ClientPtr client)
         swapl(&rep.window);
         swapl(&rep.screen);
     }
-    WriteToClient(client, sizeof(xPanoramiXGetScreenSizeReply), (char *) &rep);
+    WriteToClient(client, sizeof(xPanoramiXGetScreenSizeReply), &rep);
     return Success;
 }
 
@@ -281,7 +281,7 @@ ProcRRXineramaIsActive(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.state);
     }
-    WriteToClient(client, sizeof(xXineramaIsActiveReply), (char *) &rep);
+    WriteToClient(client, sizeof(xXineramaIsActiveReply), &rep);
     return Success;
 }
 
@@ -295,7 +295,7 @@ RRXineramaWriteMonitor(ClientPtr client, RRMonitorPtr monitor)
     scratch.width = monitor->geometry.box.x2 - monitor->geometry.box.x1;
     scratch.height = monitor->geometry.box.y2 - monitor->geometry.box.y1;
 
-    WriteToClient(client, sz_XineramaScreenInfo, (char *) &scratch);
+    WriteToClient(client, sz_XineramaScreenInfo, &scratch);
 }
 
 int
@@ -326,7 +326,7 @@ ProcRRXineramaQueryScreens(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.number);
     }
-    WriteToClient(client, sizeof(xXineramaQueryScreensReply), (char *) &rep);
+    WriteToClient(client, sizeof(xXineramaQueryScreensReply), &rep);
 
     for (m = 0; m < nmonitors; m++)
         RRXineramaWriteMonitor(client, &monitors[m]);

--- a/nx-X11/programs/Xserver/record/record.c
+++ b/nx-X11/programs/Xserver/record/record.c
@@ -257,9 +257,9 @@ RecordFlushReplyBuffer(
 		      (char *)pContext->replyBuffer);
     pContext->numBufBytes = 0;
     if (len1)
-	WriteToClient(pContext->pRecordingClient, len1, (char *)data1);
+	WriteToClient(pContext->pRecordingClient, len1, data1);
     if (len2)
-	WriteToClient(pContext->pRecordingClient, len2, (char *)data2);
+	WriteToClient(pContext->pRecordingClient, len2, data2);
 } /* RecordFlushReplyBuffer */
 
 
@@ -2009,8 +2009,8 @@ ProcRecordQueryVersion(client)
 	swaps(&rep.majorVersion);
 	swaps(&rep.minorVersion);
     }
-    (void)WriteToClient(client, sizeof(xRecordQueryVersionReply),
-			(char *)&rep);
+    WriteToClient(client, sizeof(xRecordQueryVersionReply),
+			&rep);
     return (client->noClientException);
 } /* ProcRecordQueryVersion */
 
@@ -2436,8 +2436,8 @@ ProcRecordGetContext(client)
 	swapl(&rep.length);
 	swapl(&rep.nClients);
     }
-    (void)WriteToClient(client, sizeof(xRecordGetContextReply),
-			(char *)&rep);
+    WriteToClient(client, sizeof(xRecordGetContextReply),
+			&rep);
 
     /* write all the CLIENT_INFOs */
 
@@ -2456,7 +2456,7 @@ ProcRecordGetContext(client)
 	{
 	    rci.clientResource = pRCAP->pClientIDs[i];
 	    if (client->swapped) swapl(&rci.clientResource);
-	    WriteToClient(client, sizeof(xRecordClientInfo), (char *)&rci);
+	    WriteToClient(client, sizeof(xRecordClientInfo), &rci);
 	    WriteToClient(client, sizeof(xRecordRange) * pri->nRanges,
 			  (char *)pri->pRanges);
 	}

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -303,7 +303,7 @@ ProcRenderQueryVersion (ClientPtr client)
 	swapl(&rep.majorVersion);
 	swapl(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xRenderQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xRenderQueryVersionReply), &rep);
     return (client->noClientException);
 }
 #endif /* NXAGENT_SERVER */
@@ -551,7 +551,7 @@ ProcRenderQueryPictFormats (ClientPtr client)
 	swapl (&reply->numVisuals);
 	swapl (&reply->numSubpixel);
     }
-    WriteToClient(client, rlength, (char *) reply);
+    WriteToClient(client, rlength, reply);
     free (reply);
     return client->noClientException;
 }
@@ -616,7 +616,7 @@ ProcRenderQueryPictIndexValues (ClientPtr client)
 	swapl (&reply->numIndexValues);
     }
 
-    WriteToClient(client, rlength, (char *) reply);
+    WriteToClient(client, rlength, reply);
     free(reply);
     return (client->noClientException);
 }
@@ -1816,7 +1816,7 @@ ProcRenderQueryFilters (ClientPtr client)
 	swapl(&reply->numAliases);
 	swapl(&reply->numFilters);
     }
-    WriteToClient(client, total_bytes, (char *) reply);
+    WriteToClient(client, total_bytes, reply);
     free (reply);
     
     return(client->noClientException);

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -339,7 +339,7 @@ ProcXFixesGetCursorImage (ClientPtr client)
 	swapl(&rep->cursorSerial);
 	SwapLongs(image, npixels);
     }
-    (void) WriteToClient(client, sizeof (xXFixesGetCursorImageReply) +
+    WriteToClient(client, sizeof (xXFixesGetCursorImageReply) +
 			 (npixels << 2), (char *) rep);
     free (rep);
     return client->noClientException;
@@ -413,7 +413,7 @@ ProcXFixesGetCursorName (ClientPtr client)
 	swaps(&reply.nbytes);
     }
     WriteReplyToClient(client, sizeof(xXFixesGetCursorNameReply), &reply);
-    (void)WriteToClient(client, len, str);
+    WriteToClient(client, len, str);
     
     return(client->noClientException);
 }
@@ -488,7 +488,7 @@ ProcXFixesGetCursorImageAndName (ClientPtr client)
 	swaps(&rep->nbytes);
 	SwapLongs(image, npixels);
     }
-    (void) WriteToClient(client, sizeof (xXFixesGetCursorImageAndNameReply) +
+    WriteToClient(client, sizeof (xXFixesGetCursorImageAndNameReply) +
 			 (npixels << 2) + nbytesRound, (char *) rep);
     free (rep);
     return client->noClientException;

--- a/nx-X11/programs/Xserver/xfixes/region.c
+++ b/nx-X11/programs/Xserver/xfixes/region.c
@@ -592,8 +592,8 @@ ProcXFixesFetchRegion (ClientPtr client)
 	swaps(&reply->height);
 	SwapShorts((INT16 *) pRect, nBox * 4);
     }
-    (void) WriteToClient(client, sizeof (xXFixesFetchRegionReply) +
-			 nBox * sizeof (xRectangle), (char *) reply);
+    WriteToClient(client, sizeof (xXFixesFetchRegionReply) +
+			 nBox * sizeof (xRectangle), reply);
     free (reply);
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/xfixes/xfixes.c
+++ b/nx-X11/programs/Xserver/xfixes/xfixes.c
@@ -65,7 +65,7 @@ ProcXFixesQueryVersion(ClientPtr client)
 	swapl(&rep.majorVersion);
 	swapl(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xXFixesQueryVersionReply), (char *)&rep);
+    WriteToClient(client, sizeof(xXFixesQueryVersionReply), &rep);
     return(client->noClientException);
 }
 

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -204,7 +204,7 @@ ProcXkbUseExtension(ClientPtr client)
 	swaps(&rep.serverMajor);
 	swaps(&rep.serverMinor);
     }
-    WriteToClient(client,SIZEOF(xkbUseExtensionReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbUseExtensionReply), &rep);
     return client->noClientException;
 }
 
@@ -537,7 +537,7 @@ ProcXkbGetState(ClientPtr client)
 	swaps(&rep.sequenceNumber);
 	swaps(&rep.ptrBtnState);
     }
-    WriteToClient(client, SIZEOF(xkbGetStateReply), (char *)&rep);
+    WriteToClient(client, SIZEOF(xkbGetStateReply), &rep);
     return client->noClientException;
 }
 
@@ -671,7 +671,7 @@ ProcXkbGetControls(ClientPtr client)
 	swaps(&rep.axtOptsValues);
 	swaps(&rep.axOptions);
     }
-    WriteToClient(client, SIZEOF(xkbGetControlsReply), (char *)&rep);
+    WriteToClient(client, SIZEOF(xkbGetControlsReply), &rep);
     return(client->noClientException);
 }
 
@@ -1345,7 +1345,7 @@ char		*desc,*start;
 	swaps(&rep->totalSyms);
 	swaps(&rep->totalActs);
     }
-    WriteToClient(client, (i=SIZEOF(xkbGetMapReply)), (char *)rep);
+    WriteToClient(client, (i=SIZEOF(xkbGetMapReply)), rep);
     WriteToClient(client, len, start);
     DEALLOCATE_LOCAL((char *)start);
     return client->noClientException;
@@ -2536,7 +2536,7 @@ int		size;
 	swaps(&rep->nTotalSI);
     }
 
-    WriteToClient(client, SIZEOF(xkbGetCompatMapReply), (char *)rep);
+    WriteToClient(client, SIZEOF(xkbGetCompatMapReply), rep);
     if (data) {
 	WriteToClient(client, size, data);
 	DEALLOCATE_LOCAL((char *)data);
@@ -2750,7 +2750,7 @@ ProcXkbGetIndicatorState(ClientPtr client)
 	swaps(&rep.sequenceNumber);
 	swapl(&rep.state);
     }
-    WriteToClient(client, SIZEOF(xkbGetIndicatorStateReply), (char *)&rep);
+    WriteToClient(client, SIZEOF(xkbGetIndicatorStateReply), &rep);
     return client->noClientException;
 }
 
@@ -2821,9 +2821,9 @@ register unsigned	bit;
 	swapl(&rep->which);
 	swapl(&rep->realIndicators);
     }
-    WriteToClient(client, SIZEOF(xkbGetIndicatorMapReply), (char *)rep);
+    WriteToClient(client, SIZEOF(xkbGetIndicatorMapReply), rep);
     if (map) {
-	WriteToClient(client, length, (char *)map);
+	WriteToClient(client, length, map);
 	DEALLOCATE_LOCAL((char *)map);
     }
     return client->noClientException;
@@ -3025,7 +3025,7 @@ ProcXkbGetNamedIndicator(ClientPtr client)
 	swapl(&rep.ctrls);
     }
 
-    WriteToClient(client,SIZEOF(xkbGetNamedIndicatorReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbGetNamedIndicatorReply), &rep);
     if (!supported) {
 	xkbExtensionDeviceNotify        edev;
 
@@ -3432,7 +3432,7 @@ char *			desc;
 	ErrorF("BOGUS LENGTH in write names, expected %d, got %ld\n",
 					length, (unsigned long)(desc-start));
     }
-    WriteToClient(client, SIZEOF(xkbGetNamesReply), (char *)rep);
+    WriteToClient(client, SIZEOF(xkbGetNamesReply), rep);
     WriteToClient(client, length, start);
     DEALLOCATE_LOCAL((char *)start);
     return client->noClientException;
@@ -4359,7 +4359,7 @@ XkbSendGeometry(	ClientPtr		client,
 	swaps(&rep->nDoodads);
 	swaps(&rep->nKeyAliases);
     }
-    WriteToClient(client, SIZEOF(xkbGetGeometryReply), (char *)rep);
+    WriteToClient(client, SIZEOF(xkbGetGeometryReply), rep);
     if (len>0)
 	WriteToClient(client, len, start);
     if (start!=NULL)
@@ -4977,7 +4977,7 @@ ProcXkbPerClientFlags(ClientPtr client)
 	swapl(&rep.autoCtrls);
 	swapl(&rep.autoCtrlValues);
     }
-    WriteToClient(client,SIZEOF(xkbPerClientFlagsReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbPerClientFlagsReply), &rep);
     return client->noClientException;
 }
 
@@ -5106,9 +5106,9 @@ ProcXkbListComponents(ClientPtr client)
 	swaps(&rep.nGeometries);
 	swaps(&rep.extra);
     }
-    WriteToClient(client,SIZEOF(xkbListComponentsReply),(char *)&rep);
+    WriteToClient(client,SIZEOF(xkbListComponentsReply),&rep);
     if (list.nPool && list.pool) {
-	WriteToClient(client,XkbPaddedSize(list.nPool), (char *)list.pool);
+	WriteToClient(client,XkbPaddedSize(list.nPool), list.pool);
 	_XkbFree(list.pool);
 	list.pool= NULL;
     }
@@ -5368,7 +5368,7 @@ ProcXkbGetKbdByName(ClientPtr client)
 	swaps(&rep.found);
 	swaps(&rep.reported);
     }
-    WriteToClient(client,SIZEOF(xkbGetKbdByNameReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbGetKbdByNameReply), &rep);
     if (reported&(XkbGBN_SymbolsMask|XkbGBN_TypesMask))
 	XkbSendMap(client,finfo.xkb,&mrep);
     if (reported&XkbGBN_CompatMapMask)
@@ -5559,7 +5559,7 @@ int			length;
 	swapl(&wire.physIndicators);
 	swapl(&wire.state);
     }
-    WriteToClient(client,SIZEOF(xkbDeviceLedsWireDesc),(char *)&wire);
+    WriteToClient(client,SIZEOF(xkbDeviceLedsWireDesc), &wire);
     length+= SIZEOF(xkbDeviceLedsWireDesc);
     if (sli->namesPresent|sli->mapsPresent) {
 	register unsigned i,bit;
@@ -5571,7 +5571,7 @@ int			length;
 		    if (client->swapped) {
 			swapl(&awire);
 		    }
-		    WriteToClient(client,4,(char *)&awire);
+		    WriteToClient(client,4, &awire);
 		    length+= 4;
 		}
 	    }
@@ -5756,7 +5756,7 @@ char *			str;
 
 	swapl((int *)&rep.type);
     }
-    WriteToClient(client,SIZEOF(xkbGetDeviceInfoReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbGetDeviceInfoReply), &rep);
 
     str= (char*) ALLOCATE_LOCAL(nameLen);
     if (!str) 
@@ -5771,7 +5771,7 @@ char *			str;
 	xkbActionWireDesc *	awire;
 	sz= rep.nBtnsRtrn*SIZEOF(xkbActionWireDesc);
 	awire= (xkbActionWireDesc *)&dev->button->xkb_acts[rep.firstBtnRtrn];
-	WriteToClient(client,sz,(char *)awire);
+	WriteToClient(client,sz, awire);
 	length-= sz;
     }
     if (nDeviceLedFBs>0) {
@@ -6113,7 +6113,7 @@ xkbSetDebuggingFlagsReply 	rep;
 	swapl(&rep.supportedFlags);
 	swapl(&rep.supportedCtrls);
     }
-    WriteToClient(client,SIZEOF(xkbSetDebuggingFlagsReply), (char *)&rep);
+    WriteToClient(client,SIZEOF(xkbSetDebuggingFlagsReply), &rep);
     return client->noClientException;
 }
 

--- a/nx-X11/programs/Xserver/xkb/xkbEvents.c
+++ b/nx-X11/programs/Xserver/xkb/xkbEvents.c
@@ -71,7 +71,7 @@ CARD16		changed;
 		    swapl(&pNKN->time);
 		    swaps(&pNKN->changed);
 		}
-		WriteToClient(clients[i],sizeof(xEvent),(char *)pNKN);
+		WriteToClient(clients[i],sizeof(xEvent), pNKN);
 		if (changed&XkbNKN_KeycodesMask) {
 		    clients[i]->minKC= pNKN->minKeyCode;
 		    clients[i]->maxKC= pNKN->maxKeyCode;
@@ -88,9 +88,9 @@ CARD16		changed;
 	    if (clients[i]->swapped) {
 		swaps(&event.u.u.sequenceNumber);
 	    }
-	    WriteToClient(clients[i],SIZEOF(xEvent), (char *)&event);
+	    WriteToClient(clients[i],SIZEOF(xEvent), &event);
 	    event.u.mappingNotify.request= MappingModifier;
-	    WriteToClient(clients[i],SIZEOF(xEvent), (char *)&event);
+	    WriteToClient(clients[i],SIZEOF(xEvent), &event);
 	}
     }
     return;
@@ -149,7 +149,7 @@ register CARD16	changed,bState;
 		swaps(&pSN->changed);
 		swaps(&pSN->ptrBtnState);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pSN);
+	    WriteToClient(interest->client, sizeof(xEvent), pSN);
 	}
 	interest= interest->next;
     }
@@ -193,7 +193,7 @@ CARD16		changed;
 		swapl(&pMN->time);
 		swaps(&pMN->changed);
 	    }
-	    WriteToClient(clients[i],sizeof(xEvent),(char *)pMN);
+	    WriteToClient(clients[i],sizeof(xEvent), pMN);
 	}
     }
     return;
@@ -317,7 +317,7 @@ Time 		 	time = 0;
 		swapl(&pCN->enabledControlChanges);
 		swapl(&pCN->time);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pCN);
+	    WriteToClient(interest->client, sizeof(xEvent), pCN);
 	}
 	interest= interest->next;
     }
@@ -364,7 +364,7 @@ CARD32		state,changed;
 		swapl(&pEv->changed);
 		swapl(&pEv->state);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }
@@ -448,7 +448,7 @@ XID		winID = 0;
 		swapl(&bn.name);
 		swapl(&bn.window);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)&bn);
+	    WriteToClient(interest->client, sizeof(xEvent), &bn);
 	}
 	interest= interest->next;
     }
@@ -492,7 +492,7 @@ CARD16		sk_delay,db_delay;
 		swaps(&pEv->slowKeysDelay);
 		swaps(&pEv->debounceDelay);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }
@@ -540,7 +540,7 @@ CARD32		changedIndicators;
 		swapl(&pEv->changedIndicators);
 		swaps(&pEv->changedVirtualMods);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }
@@ -587,7 +587,7 @@ CARD16		firstSI = 0, nSI = 0, nTotalSI = 0;
 		swaps(&pEv->nSI);
 		swaps(&pEv->nTotalSI);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }
@@ -629,7 +629,7 @@ Time 		 time = 0;
 		swaps(&pEv->sequenceNumber);
 		swapl(&pEv->time);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }
@@ -692,7 +692,7 @@ CARD16		 reason, supported = 0;
 		swaps(&pEv->reason);
 		swaps(&pEv->supported);
 	    }
-	    WriteToClient(interest->client, sizeof(xEvent), (char *)pEv);
+	    WriteToClient(interest->client, sizeof(xEvent), pEv);
 	}
 	interest= interest->next;
     }


### PR DESCRIPTION
Backport from X.org. See commit messages of the two commits associated with this PR.
