### PR TITLE
Feature/reconnect checks

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1405,6 +1405,82 @@ static void nxagentParseOptions(char *name, char *value)
 
     return;
   }
+  else if (!strcmp(name, "tolerancechecks"))
+  {
+    if (strcmp(value, "strict") == 0)
+    {
+      nxagentChangeOption(ReconnectTolerance, ToleranceChecksStrict);
+    }
+    else if (strcmp(value, "safe") == 0)
+    {
+      nxagentChangeOption(ReconnectTolerance, ToleranceChecksSafe);
+    }
+    else if (strcmp(value, "risky") == 0)
+    {
+      nxagentChangeOption(ReconnectTolerance, ToleranceChecksRisky);
+    }
+    else if (strcmp(value, "none") == 0)
+    {
+      nxagentChangeOption(ReconnectTolerance, ToleranceChecksBypass);
+    }
+    else
+    {
+      /*
+       * Check for a matching integer. Or any integer, really.
+       */
+      long tolerance_parse = 0;
+
+      errno = 0;
+      tolerance_parse = strtol(value, NULL, 10);
+
+      if ((errno) && (0 == tolerance_parse))
+      {
+        fprintf(stderr, "nxagentParseOptions: Unable to convert value [%s] of option [%s]. "
+                        "Ignoring option.\n",
+                        validateString(value), validateString(name));
+
+        return;
+      }
+
+      if ((long) UINT_MAX < tolerance_parse)
+      {
+        tolerance_parse = UINT_MAX;
+
+        fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+                        "out of range, clamped to [%u].\n",
+                        validateString(value), validateString(name), tolerance_parse);
+      }
+
+      if (0 > tolerance_parse)
+      {
+        tolerance_parse = 0;
+
+        fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+                        "out of range, clamped to [%u].\n",
+                        validateString(value), validateString(name), tolerance_parse);
+      }
+
+      #ifdef TEST
+      switch (tolerance_parse) {
+        case ToleranceChecksStrict:
+        case ToleranceChecksSafe:
+        case ToleranceChecksRisky:
+        case ToleranceChecksBypass:
+                               break;
+        default:
+                               fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of "
+                                               "option [%s] unknown, will be mapped to "
+                                               "\"Bypass\" [%u] value internally.\n",
+                                       validateString(value), validateString(name),
+                                       (unsigned int)ToleranceChecksBypass);
+      }
+      #endif
+
+      nxagentChangeOption(ReconnectTolerance, tolerance_parse);
+    }
+
+    return;
+  }
   else
   {
     #ifdef DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -2647,6 +2647,7 @@ FIXME: Should the visual be ignored in this case?
 
 static int nxagentCheckForColormapsCompatibility(int flexibility)
 {
+  /* FIXME: does this also need work? */
   if (nxagentNumDefaultColormaps == nxagentNumDefaultColormapsRecBackup)
   {
     #ifdef TEST

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -2537,6 +2537,7 @@ static int nxagentCheckForPixmapFormatsCompatibility()
 
 static int nxagentInitAndCheckVisuals(int flexibility)
 {
+  /* FIXME: does this also need work? */
   XVisualInfo viTemplate;
   XVisualInfo *viList;
   XVisualInfo *newVisuals;

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -1347,6 +1347,7 @@ FIXME: Use of nxagentParentWindow is strongly deprecated.
   nxagentInitDepths();
 
   nxagentInitPixmapFormats();
+  (void) nxagentCheckForPixmapFormatsCompatibility();
 
   /*
    * Create a pixmap for each depth matching the
@@ -1727,8 +1728,6 @@ XXX: Some X server doesn't list 1 among available depths...
     }
   }
   #endif
-
-  nxagentCheckForPixmapFormatsCompatibility();
 }
 
 void nxagentSetDefaultDrawables()
@@ -2838,10 +2837,15 @@ Bool nxagentReconnectDisplay(void *p0)
    * formats are supported.
    */
 
-  /*
-   * FIXME: add an actual check here (and pass check value through nxagentInitPixmapFormats().)
-   */
   nxagentInitPixmapFormats();
+
+  if (nxagentCheckForPixmapFormatsCompatibility() == 0)
+  {
+    nxagentSetReconnectError(FAILED_RESUME_PIXMAPS_ALERT,
+                                 "Couldn't restore all the required pixmap formats.");
+
+    return False;
+  }
 
   reconnectDisplayState = GOT_PIXMAP_FORMAT_LIST;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.c
@@ -166,6 +166,8 @@ void nxagentInitOptions()
   nxagentOptions.Xinerama = 1;
 
   nxagentOptions.SleepTime = DEFAULT_SLEEP_TIME;
+
+  nxagentOptions.ReconnectTolerance = DEFAULT_TOLERANCE;
 }
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -67,6 +67,17 @@ typedef enum _ClientOsType
 
 } ClientOsType;
 
+typedef enum _ToleranceChecksMode
+{
+  ToleranceChecksStrict = 0,
+  ToleranceChecksSafe = 1,
+  ToleranceChecksRisky = 2,
+  ToleranceChecksBypass = 3
+} ToleranceChecksMode;
+
+
+#define DEFAULT_TOLERANCE ToleranceChecksStrict
+
 /*
  * Set of options affecting agent operations.
  */
@@ -413,6 +424,12 @@ typedef struct _AgentOptions
    */
 
   unsigned int SleepTime;
+
+  /*
+   * Tolerance - tightens or loosens reconnect checks.
+   */
+
+  ToleranceChecksMode ReconnectTolerance;
 
 } AgentOptionsRec;
 

--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -9063,7 +9063,8 @@ int ParseEnvironmentOptions(const char *env, int force)
                                  strcasecmp(name, "clipboard") == 0 ||
                                      strcasecmp(name, "streaming") == 0 ||
                                          strcasecmp(name, "backingstore") == 0 ||
-                                             strcasecmp(name, "sleep") == 0)
+                                             strcasecmp(name, "sleep") == 0 ||
+                                                 strcasecmp(name, "tolerancechecks") == 0)
     {
       #ifdef DEBUG
       *logofs << "Loop: Ignoring agent option '" << name

--- a/nxcomp/Misc.cpp
+++ b/nxcomp/Misc.cpp
@@ -325,7 +325,9 @@ shadowmode=s\n\
 defer=n\n\
 tile=s\n\
 menu=n\n\
-sleep=n        These options are interpreted by the NX agent. They\n\
+sleep=n\n\
+tolerancecehcks=s\n\
+               These options are interpreted by the NX agent. They\n\
                are ignored by the proxy.\n\
 \n\
   Environment:\n\


### PR DESCRIPTION
Adds the new `ReconnectTolerance` `nxagentOption` and `tolerance` `nx/nx` parameter.

The known values are `Strict` (= 0), `Safe` (= 1), `Risky` (= 2) and `None` (= 3). Any higher value is mapped to `None`.

The code within checking functions used at reconnect time has been adapted to utilize the `ReconnectTolerance` `nxagentOption` value and modify its behavior based on it. Users can now select for these checks to be less strict.
