### PR TITLE
Fix failure on first paste from CLIPBOARD

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -1583,6 +1583,14 @@ int nxagentInitClipboard(WindowPtr pWin)
     nxagentXFixesInfo.Initialized = 1;
   }
 
+  /*
+     The first paste from CLIPBOARD did not work directly after
+     session start. Removing this code makes it work. It is unsure why
+     it was introduced in the first place so it is possible that we
+     see other effects by leaving out this code.
+
+     Fixes X2Go bug #952, see https://bugs.x2go.org/952 for details .
+
   if (nxagentSessionId[0])
   {
     #ifdef TEST
@@ -1595,6 +1603,7 @@ int nxagentInitClipboard(WindowPtr pWin)
     pWin -> eventMask |= PropertyChangeMask;
     nxagentChangeWindowAttributes(pWin, CWEventMask);
   }
+  */
 
   if (nxagentReconnectTrap)
   {


### PR DESCRIPTION
Pasting the clipboard did not work directly after session start.

I am a bit what other effects might be introduced by leaving out this code. Maybe we should find out why it was introduced in the first place...
