### PR TITLE
Update X11's XKeysymDB

### DIFF
--- a/nx-X11/lib/X11/XKeysymDB
+++ b/nx-X11/lib/X11/XKeysymDB
@@ -1,4 +1,3 @@
-! $Xorg: XKeysymDB,v 1.3 2000/08/17 19:45:04 cpqbld Exp $
 ! Copyright 1993 Massachusetts Institute of Technology
 !
 ! Permission to use, copy, modify, distribute, and sell this software and
@@ -11,7 +10,6 @@
 ! suitability of this software for any purpose.  It is provided "as is"
 ! without express or implied warranty.
 !
-! $XFree86: xc/lib/X11/XKeysymDB,v 3.16 2003/02/11 02:51:10 dawes Exp $
 
 hpmute_acute		:100000A8
 hpmute_grave		:100000A9
@@ -199,6 +197,11 @@ XeroxPointerButton5	:10070005
 
 ! The definitions here should match <X11/XF86keysym.h>
 XF86ModeLock		:1008FF01
+XF86MonBrightnessUp	:1008FF02
+XF86MonBrightnessDown	:1008FF03
+XF86KbdLightOnOff	:1008FF04
+XF86KbdBrightnessUp	:1008FF05
+XF86KbdBrightnessDown	:1008FF06
 XF86Standby		:1008FF10
 XF86AudioLowerVolume	:1008FF11
 XF86AudioMute		:1008FF12
@@ -326,6 +329,29 @@ XF86WebCam		:1008FF8F
 XF86MailForward		:1008FF90
 XF86Pictures		:1008FF91
 XF86Music		:1008FF92
+XF86Battery		:1008FF93
+XF86Bluetooth		:1008FF94
+XF86WLAN		:1008FF95
+XF86UWB			:1008FF96
+XF86AudioForward	:1008FF97
+XF86AudioRepeat		:1008FF98
+XF86AudioRandomPlay	:1008FF99
+XF86Subtitle		:1008FF9A
+XF86AudioCycleTrack	:1008FF9B
+XF86CycleAngle		:1008FF9C
+XF86FrameBack		:1008FF9D
+XF86FrameForward	:1008FF9E
+XF86Time		:1008FF9F
+XF86Select		:1008FFA0
+XF86View		:1008FFA1
+XF86TopMenu		:1008FFA2
+XF86Red			:1008FFA3
+XF86Green		:1008FFA4
+XF86Yellow		:1008FFA5
+XF86Blue             	:1008FFA6
+XF86Suspend		:1008FFA7
+XF86Hibernate		:1008FFA8
+XF86TouchpadToggle	:1008FFA9
 
 ! XFree86 special action keys
 XF86_Switch_VT_1	:1008FE01

--- a/nx-X11/lib/X11/XKeysymDB
+++ b/nx-X11/lib/X11/XKeysymDB
@@ -352,6 +352,8 @@ XF86Blue             	:1008FFA6
 XF86Suspend		:1008FFA7
 XF86Hibernate		:1008FFA8
 XF86TouchpadToggle	:1008FFA9
+XF86TouchpadOn		:1008FFB0
+XF86TouchpadOff	:1008FFB1
 
 ! XFree86 special action keys
 XF86_Switch_VT_1	:1008FE01


### PR DESCRIPTION
- lib/X11/XKeysymDB: Update to last version found in X.org (between 1.3.5 and 1.3.6).
- fix-up commit from the libX11 pkg in Fedora 14.
