### PR TITLE
ensure that <X11/..> headers references use nx-X11 files if existing

### DIFF
--- a/nx-X11/include/Imakefile
+++ b/nx-X11/include/Imakefile
@@ -56,6 +56,12 @@ all::
 
 BuildIncludes($(HEADERS),nx-X11,..)
 
+includes::
+	-$(RM) $(BUILDINCDIR)/X11
+	-$(LN) nx-X11 $(BUILDINCDIR)/X11
+
+
+
 #if BuildLibraries
 InstallMultipleFlags($(HEADERS),$(INCDIR)/nx-X11,$(INSTINCFLAGS))
 #endif

--- a/nx-X11/include/Imakefile
+++ b/nx-X11/include/Imakefile
@@ -1,8 +1,4 @@
 XCOMM $Xorg: Imakefile,v 1.3 2000/08/18 04:05:43 coskrey Exp $
-
-
-
-
 XCOMM $XFree86: xc/include/Imakefile,v 3.28 2001/04/28 23:52:31 dawes Exp $
 
 NULL =
@@ -60,8 +56,6 @@ includes::
 	-$(RM) $(BUILDINCDIR)/X11
 	-$(LN) nx-X11 $(BUILDINCDIR)/X11
 
-
-
 #if BuildLibraries
 InstallMultipleFlags($(HEADERS),$(INCDIR)/nx-X11,$(INSTINCFLAGS))
 #endif
@@ -83,7 +77,7 @@ InstallDriverSDKNonExecFile(keysym.h,$(DRIVERSDKINCLUDEDIR))
 
 /* _XOPEN_SOURCE is defined where needed to move __fds_bits to fds_bits. */
 USE_FDS_BITS = fds_bits
-	
+
 Xpoll.h: Xpoll.h.in
 	sed -e "s/@USE_FDS_BITS@/$(USE_FDS_BITS)/;" < Xpoll.h.in > Xpoll.h
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Agent.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Agent.h
@@ -112,13 +112,6 @@ typedef XID KeySym64;
 #define NX_TRANS_SOCKET
 #define GC XlibGC
 #include <nx-X11/Xlib.h>
-/*
-  <X11/extension/shape.h> includes <X11/Xutil.h> but we need
-  <nx-X11/Xutil.h>. As both use the same header guard we can first
-  include <nx-X11/Xutil.h> and be ok.
-*/
-#include <nx-X11/Xutil.h>
-
 #include <X11/extensions/shape.h>
 #undef GC
 


### PR DESCRIPTION
System headers including other headers via <X11/..> now use the
nx-X11 variant (if existing).

This fixes Arctica issue #200. But we should think about dropping the
<nx-X11/..> namespace now for includes.
