### PR TITLE
Pr/decouple xserver

### DIFF
--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -61,7 +61,6 @@ SOFTWARE.
 #include "cursorstr.h"
 #include "dixstruct.h"
 #include "site.h"
-#define	XKB_IN_SERVER
 #ifdef XKB
 #include <xkbsrv.h>
 #endif

--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -62,7 +62,7 @@ SOFTWARE.
 #include "dixstruct.h"
 #include "site.h"
 #ifdef XKB
-#include <xkbsrv.h>
+#include "xkbsrv.h"
 #endif
 #ifdef XCSECURITY
 #define _SECURITY_SERVER

--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -63,7 +63,7 @@ SOFTWARE.
 #include "site.h"
 #define	XKB_IN_SERVER
 #ifdef XKB
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #endif
 #ifdef XCSECURITY
 #define _SECURITY_SERVER

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -110,7 +110,7 @@ int ProcInitialConnection();
 #endif
 #ifdef XKB
 #include "inputstr.h"
-#include <xkbsrv.h>
+#include "xkbsrv.h"
 #endif
 
 #define mskcnt ((MAXCLIENTS + 31) / 32)

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -109,7 +109,6 @@ int ProcInitialConnection();
 #include <nx-X11/extensions/security.h>
 #endif
 #ifdef XKB
-#define XKB_IN_SERVER
 #include "inputstr.h"
 #include <xkbsrv.h>
 #endif

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -111,7 +111,7 @@ int ProcInitialConnection();
 #ifdef XKB
 #define XKB_IN_SERVER
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #endif
 
 #define mskcnt ((MAXCLIENTS + 31) / 32)

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -129,7 +129,7 @@ of the copyright holder.
 #include "globals.h"
 
 #ifdef XKB
-#include <xkbsrv.h>
+#include "xkbsrv.h"
 extern Bool XkbFilterEvents(ClientPtr, int, xEvent *);
 #endif
 

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -129,7 +129,7 @@ of the copyright holder.
 #include "globals.h"
 
 #ifdef XKB
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 extern Bool XkbFilterEvents(ClientPtr, int, xEvent *);
 #endif
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -75,7 +75,6 @@ is" without express or implied warranty.
 
 #define XKBSRV_NEED_FILE_FUNCS
 #include <nx-X11/extensions/XKBsrv.h>
-#include <nx-X11/extensions/XKBstr.h>
 #include <nx-X11/extensions/XKBconfig.h>
 
 #include <nx-X11/extensions/XKBrules.h>

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -75,6 +75,7 @@ is" without express or implied warranty.
 
 #define XKBSRV_NEED_FILE_FUNCS
 #include <nx-X11/extensions/XKBsrv.h>
+#include <nx-X11/extensions/XKBstr.h>
 #include <nx-X11/extensions/XKBconfig.h>
 
 #include <nx-X11/extensions/XKBrules.h>

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -73,11 +73,13 @@ is" without express or implied warranty.
 
 #include <nx-X11/extensions/XKB.h>
 
-#define XKBSRV_NEED_FILE_FUNCS
+/*
+  we need the client side header here, xkbsrv.h will not work because
+  server and libX11 have different struct sizes on
+  64bit. Interestingly upstream xnest does not take care of this.
+*/
 #include <nx-X11/extensions/XKBsrv.h>
 #include <nx-X11/extensions/XKBconfig.h>
-
-#include <nx-X11/extensions/XKBrules.h>
 
 #include "Xatom.h"
 

--- a/nx-X11/programs/Xserver/include/xkbrules.h
+++ b/nx-X11/programs/Xserver/include/xkbrules.h
@@ -1,0 +1,199 @@
+#ifndef _XKBRULES_H_
+#define	_XKBRULES_H_ 1
+
+/************************************************************
+ Copyright (c) 1996 by Silicon Graphics Computer Systems, Inc.
+
+ Permission to use, copy, modify, and distribute this
+ software and its documentation for any purpose and without
+ fee is hereby granted, provided that the above copyright
+ notice appear in all copies and that both that copyright
+ notice and this permission notice appear in supporting
+ documentation, and that the name of Silicon Graphics not be 
+ used in advertising or publicity pertaining to distribution 
+ of the software without specific prior written permission.
+ Silicon Graphics makes no representation about the suitability 
+ of this software for any purpose. It is provided "as is"
+ without any express or implied warranty.
+ 
+ SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+ SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+ AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+ GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+ DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+ THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ ********************************************************/
+
+/***====================================================================***/
+
+typedef struct _XkbRF_VarDefs {
+	char *			model;
+	char *			layout;
+	char *			variant;
+	char *			options;
+	unsigned short		sz_extra;
+	unsigned short		num_extra;
+	char *			extra_names;
+	char **			extra_values;
+} XkbRF_VarDefsRec,*XkbRF_VarDefsPtr;
+
+typedef struct _XkbRF_VarDesc {
+	char *			name;
+	char *			desc;
+} XkbRF_VarDescRec, *XkbRF_VarDescPtr;
+
+typedef struct _XkbRF_DescribeVars {
+	int			sz_desc;
+	int			num_desc;
+	XkbRF_VarDescPtr	desc;
+} XkbRF_DescribeVarsRec,*XkbRF_DescribeVarsPtr;
+
+typedef struct _XkbRF_Rule {
+	int			number;
+        int			layout_num;
+        int			variant_num;
+	char *			model;
+	char *			layout;
+	char *			variant;
+	char *			option;
+	/* yields */
+	char *			keycodes;
+	char *			symbols;
+	char *			types;
+	char *			compat;
+	char *			geometry;
+	char *			keymap;
+	unsigned		flags;
+} XkbRF_RuleRec,*XkbRF_RulePtr;
+
+typedef struct _XkbRF_Group {
+	int			number;
+	char *			name;
+	char *			words;
+} XkbRF_GroupRec, *XkbRF_GroupPtr;
+
+#define	XkbRF_PendingMatch	(1L<<1)
+#define	XkbRF_Option		(1L<<2)
+#define	XkbRF_Append		(1L<<3)
+#define	XkbRF_Normal		(1L<<4)
+#define	XkbRF_Invalid		(1L<<5)
+
+typedef struct _XkbRF_Rules {
+	XkbRF_DescribeVarsRec	models;
+	XkbRF_DescribeVarsRec	layouts;
+	XkbRF_DescribeVarsRec	variants;
+	XkbRF_DescribeVarsRec	options;
+	unsigned short		sz_extra;
+	unsigned short		num_extra;
+	char **			extra_names;
+	XkbRF_DescribeVarsPtr	extra;
+
+	unsigned short		sz_rules;
+	unsigned short		num_rules;
+	XkbRF_RulePtr		rules;
+	unsigned short		sz_groups;
+	unsigned short		num_groups;
+        XkbRF_GroupPtr		groups;
+} XkbRF_RulesRec, *XkbRF_RulesPtr;
+
+/***====================================================================***/
+
+_XFUNCPROTOBEGIN
+
+extern Bool	XkbRF_GetComponents(
+    XkbRF_RulesPtr		/* rules */,
+    XkbRF_VarDefsPtr		/* var_defs */,
+    XkbComponentNamesPtr	/* names */
+);
+
+extern XkbRF_RulePtr	XkbRF_AddRule(
+    XkbRF_RulesPtr	/* rules */
+);
+
+extern XkbRF_GroupPtr XkbRF_AddGroup(XkbRF_RulesPtr  rules);
+
+extern Bool	XkbRF_LoadRules(
+    FILE *		/* file */,
+    XkbRF_RulesPtr	/* rules */
+);
+
+extern Bool XkbRF_LoadRulesByName(
+    char *		/* base */,
+    char *		/* locale */,
+    XkbRF_RulesPtr	/* rules */
+);
+
+/***====================================================================***/
+
+extern XkbRF_VarDescPtr	XkbRF_AddVarDesc(
+    XkbRF_DescribeVarsPtr	/* vars */
+);
+
+extern XkbRF_VarDescPtr	XkbRF_AddVarDescCopy(
+    XkbRF_DescribeVarsPtr	/* vars */,
+    XkbRF_VarDescPtr		/* copy_from */
+);
+
+extern XkbRF_DescribeVarsPtr XkbRF_AddVarToDescribe(
+    XkbRF_RulesPtr		/* rules */,
+    char *			/* name */
+);
+
+extern Bool	XkbRF_LoadDescriptions(
+    FILE *		/* file */,
+    XkbRF_RulesPtr	/* rules */
+);
+
+extern Bool XkbRF_LoadDescriptionsByName(
+    char *		/* base */,
+    char *		/* locale */,
+    XkbRF_RulesPtr	/* rules */
+);
+
+extern XkbRF_RulesPtr XkbRF_Load(
+    char *		/* base */,
+    char *		/* locale */,
+    Bool		/* wantDesc */,
+    Bool		/* wantRules */
+);
+
+extern XkbRF_RulesPtr XkbRF_Create(
+    int			/* sz_rules */,
+    int			/* sz_extra */
+);
+
+/***====================================================================***/
+
+extern void XkbRF_Free(
+    XkbRF_RulesPtr	/* rules */,
+    Bool		/* freeRules */
+);
+
+
+/***====================================================================***/
+
+#define	_XKB_RF_NAMES_PROP_ATOM		"_XKB_RULES_NAMES"
+#define	_XKB_RF_NAMES_PROP_MAXLEN	1024
+
+#ifndef XKB_IN_SERVER
+
+extern Bool XkbRF_GetNamesProp(
+   Display *		/* dpy */,
+   char **		/* rules_file_rtrn */,
+   XkbRF_VarDefsPtr	/* var_defs_rtrn */
+);
+
+extern Bool XkbRF_SetNamesProp(
+   Display *		/* dpy */,
+   char *		/* rules_file */,
+   XkbRF_VarDefsPtr	/* var_defs */
+);
+
+#endif
+
+_XFUNCPROTOEND
+
+#endif /* _XKBRULES_H_ */

--- a/nx-X11/programs/Xserver/include/xkbrules.h
+++ b/nx-X11/programs/Xserver/include/xkbrules.h
@@ -178,21 +178,6 @@ extern void XkbRF_Free(
 #define	_XKB_RF_NAMES_PROP_ATOM		"_XKB_RULES_NAMES"
 #define	_XKB_RF_NAMES_PROP_MAXLEN	1024
 
-#ifndef XKB_IN_SERVER
-
-extern Bool XkbRF_GetNamesProp(
-   Display *		/* dpy */,
-   char **		/* rules_file_rtrn */,
-   XkbRF_VarDefsPtr	/* var_defs_rtrn */
-);
-
-extern Bool XkbRF_SetNamesProp(
-   Display *		/* dpy */,
-   char *		/* rules_file */,
-   XkbRF_VarDefsPtr	/* var_defs */
-);
-
-#endif
 
 _XFUNCPROTOEND
 

--- a/nx-X11/programs/Xserver/include/xkbsrv.h
+++ b/nx-X11/programs/Xserver/include/xkbsrv.h
@@ -1098,7 +1098,7 @@ extern void XkbSendNewKeyboardNotify(
 #ifdef XKBSRV_NEED_FILE_FUNCS
 
 #include <nx-X11/extensions/XKMformat.h>
-#include <nx-X11/extensions/XKBfile.h>
+#include "xkbfile.h"
 #include "xkbrules.h"
 
 #define	_XkbListKeymaps		0

--- a/nx-X11/programs/Xserver/include/xkbsrv.h
+++ b/nx-X11/programs/Xserver/include/xkbsrv.h
@@ -1099,7 +1099,7 @@ extern void XkbSendNewKeyboardNotify(
 
 #include <nx-X11/extensions/XKMformat.h>
 #include <nx-X11/extensions/XKBfile.h>
-#include <nx-X11/extensions/XKBrules.h>
+#include "xkbrules.h"
 
 #define	_XkbListKeymaps		0
 #define	_XkbListKeycodes	1

--- a/nx-X11/programs/Xserver/include/xkbsrv.h
+++ b/nx-X11/programs/Xserver/include/xkbsrv.h
@@ -64,8 +64,8 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define	XkbUpdateActionVirtualMods	SrvXkbUpdateActionVirtualMods
 #define XkbUpdateKeyTypeVirtualMods	SrvXkbUpdateKeyTypeVirtualMods
 
-#include <nx-X11/extensions/XKBstr.h>
 #include <nx-X11/extensions/XKBproto.h>
+#include "xkbstr.h"
 #include "inputstr.h"
 
 #ifdef NXAGENT_SERVER

--- a/nx-X11/programs/Xserver/include/xkbsrv.h
+++ b/nx-X11/programs/Xserver/include/xkbsrv.h
@@ -1,0 +1,1189 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifndef _XKBSRV_H_
+#define	_XKBSRV_H_
+
+#define XkbAllocClientMap		SrvXkbAllocClientMap
+#define XkbAllocServerMap		SrvXkbAllocServerMap
+#define XkbChangeTypesOfKey		SrvXkbChangeTypesOfKey
+#define	XkbAddKeyType			SrvXkbAddKeyType
+#define XkbCopyKeyType			SrvXkbCopyKeyType
+#define XkbCopyKeyTypes			SrvXkbCopyKeyTypes
+#define XkbFreeClientMap		SrvXkbFreeClientMap
+#define XkbFreeServerMap		SrvXkbFreeServerMap
+#define XkbInitCanonicalKeyTypes	SrvXkbInitCanonicalKeyTypes
+#define	XkbKeyTypesForCoreSymbols	SrvXkbKeyTypesForCoreSymbols
+#define	XkbApplyCompatMapToKey		SrvXkbApplyCompatMapToKey
+#define	XkbUpdateMapFromCore		SrvXkbUpdateMapFromCore
+#define XkbResizeKeyActions		SrvXkbResizeKeyActions
+#define XkbResizeKeySyms		SrvXkbResizeKeySyms
+#define XkbResizeKeyType		SrvXkbResizeKeyType
+#define XkbAllocCompatMap		SrvXkbAllocCompatMap
+#define XkbAllocControls		SrvXkbAllocControls
+#define XkbAllocIndicatorMaps		SrvXkbAllocIndicatorMaps
+#define XkbAllocKeyboard		SrvXkbAllocKeyboard
+#define XkbAllocNames			SrvXkbAllocNames
+#define XkbFreeCompatMap		SrvXkbFreeCompatMap
+#define XkbFreeControls			SrvXkbFreeControls
+#define XkbFreeIndicatorMaps		SrvXkbFreeIndicatorMaps
+#define XkbFreeKeyboard			SrvXkbFreeKeyboard
+#define XkbFreeNames			SrvXkbFreeNames
+#define	XkbAddDeviceLedInfo		SrvXkbAddDeviceLedInfo
+#define	XkbAllocDeviceInfo		SrvXkbAllocDeviceInfo
+#define	XkbFreeDeviceInfo		SrvXkbFreeDeviceInfo
+#define	XkbResizeDeviceButtonActions	SrvXkbResizeDeviceButtonActions
+#define XkbLatchModifiers		SrvXkbLatchModifiers
+#define XkbLatchGroup			SrvXkbLatchGroup
+#define XkbVirtualModsToReal		SrvXkbVirtualModsToReal
+#define	XkbChangeKeycodeRange		SrvXkbChangeKeycodeRange
+#define	XkbApplyVirtualModChanges	SrvXkbApplyVirtualModChanges
+#define	XkbUpdateActionVirtualMods	SrvXkbUpdateActionVirtualMods
+#define XkbUpdateKeyTypeVirtualMods	SrvXkbUpdateKeyTypeVirtualMods
+
+#include <nx-X11/extensions/XKBstr.h>
+#include <nx-X11/extensions/XKBproto.h>
+#include "inputstr.h"
+
+#ifdef NXAGENT_SERVER
+extern char *_NXGetXkbBasePath(const char *path);
+extern char *_NXGetXkbCompPath(const char *path);
+#endif
+
+typedef struct _XkbInterest {
+	DeviceIntPtr		dev;
+	ClientPtr		client;
+	XID			resource;
+	struct _XkbInterest *	next;
+	CARD16			extDevNotifyMask;
+	CARD16			stateNotifyMask;
+	CARD16			namesNotifyMask;
+	CARD32 			ctrlsNotifyMask;
+	CARD8			compatNotifyMask;
+	BOOL			bellNotifyMask;
+	BOOL			actionMessageMask;
+	CARD16			accessXNotifyMask;
+	CARD32			iStateNotifyMask;
+	CARD32			iMapNotifyMask;
+	CARD16			altSymsNotifyMask;
+	CARD32			autoCtrls;
+	CARD32			autoCtrlValues;
+} XkbInterestRec,*XkbInterestPtr;
+
+typedef struct _XkbRadioGroup {
+	CARD8		flags;
+	CARD8		nMembers;
+	CARD8		dfltDown;
+	CARD8		currentDown;
+	CARD8		members[XkbRGMaxMembers];
+} XkbRadioGroupRec, *XkbRadioGroupPtr;
+
+typedef struct	_XkbEventCause {
+	CARD8		kc;
+	CARD8		event;
+	CARD8		mjr;
+	CARD8		mnr;
+	ClientPtr	client;
+} XkbEventCauseRec,*XkbEventCausePtr;
+#define	XkbSetCauseKey(c,k,e)	{ (c)->kc= (k),(c)->event= (e),\
+				  (c)->mjr= (c)->mnr= 0; \
+				  (c)->client= NULL; }
+#define	XkbSetCauseReq(c,j,n,cl) { (c)->kc= (c)->event= 0,\
+				  (c)->mjr= (j),(c)->mnr= (n);\
+				  (c)->client= (cl); }
+#define	XkbSetCauseCoreReq(c,e,cl) XkbSetCauseReq(c,e,0,cl)
+#define	XkbSetCauseXkbReq(c,e,cl)  XkbSetCauseReq(c,XkbReqCode,e,cl)
+#define	XkbSetCauseUnknown(c)	   XkbSetCauseKey(c,0,0)
+
+#define	_OFF_TIMER		0
+#define	_KRG_WARN_TIMER		1
+#define	_KRG_TIMER		2
+#define	_SK_TIMEOUT_TIMER	3
+#define	_ALL_TIMEOUT_TIMER	4
+
+#define	_BEEP_NONE		0
+#define	_BEEP_FEATURE_ON	1
+#define	_BEEP_FEATURE_OFF	2
+#define	_BEEP_FEATURE_CHANGE	3
+#define	_BEEP_SLOW_WARN		4
+#define	_BEEP_SLOW_PRESS	5
+#define	_BEEP_SLOW_ACCEPT	6
+#define	_BEEP_SLOW_REJECT	7
+#define	_BEEP_SLOW_RELEASE	8
+#define	_BEEP_STICKY_LATCH	9
+#define	_BEEP_STICKY_LOCK	10
+#define	_BEEP_STICKY_UNLOCK	11
+#define	_BEEP_LED_ON		12
+#define	_BEEP_LED_OFF		13
+#define	_BEEP_LED_CHANGE	14
+#define	_BEEP_BOUNCE_REJECT	15
+
+typedef struct _XkbSrvInfo {
+	XkbStateRec	 prev_state;
+	XkbStateRec	 state;
+	XkbDescPtr	 desc;
+
+	DeviceIntPtr	 device;
+	KbdCtrlProcPtr	 kbdProc;
+
+	XkbRadioGroupPtr radioGroups;
+	CARD8		 nRadioGroups;
+	CARD8		 clearMods;
+	CARD8		 setMods;
+	INT16		 groupChange;
+
+	CARD16		 dfltPtrDelta;
+
+	double		 mouseKeysCurve;
+	double		 mouseKeysCurveFactor;
+	INT16		 mouseKeysDX;
+	INT16		 mouseKeysDY;
+	CARD8		 mouseKeysFlags;
+	Bool		 mouseKeysAccel;
+	CARD8		 mouseKeysCounter;
+
+	CARD8		 lockedPtrButtons;
+	CARD8		 shiftKeyCount;
+	KeyCode		 mouseKey;
+	KeyCode		 inactiveKey;
+	KeyCode		 slowKey;
+	KeyCode		 repeatKey;
+	CARD8		 krgTimerActive;
+	CARD8		 beepType;
+	CARD8		 beepCount;
+
+	CARD32		 flags;
+	CARD32		 lastPtrEventTime;
+	CARD32		 lastShiftEventTime;
+	OsTimerPtr	 beepTimer;
+	OsTimerPtr	 mouseKeyTimer;
+	OsTimerPtr	 slowKeysTimer;
+	OsTimerPtr	 bounceKeysTimer;
+	OsTimerPtr	 repeatKeyTimer;
+	OsTimerPtr	 krgTimer;
+} XkbSrvInfoRec, *XkbSrvInfoPtr;
+
+#define	XkbSLI_IsDefault	(1L<<0)
+#define	XkbSLI_HasOwnState	(1L<<1)
+
+typedef struct	_XkbSrvLedInfo {
+	CARD16			flags;
+	CARD16			class;
+	CARD16			id;
+	union {
+	    KbdFeedbackPtr	kf;
+	    LedFeedbackPtr	lf;
+	} 			fb;
+
+	CARD32			physIndicators;
+	CARD32			autoState;
+	CARD32			explicitState;
+	CARD32			effectiveState;
+
+	CARD32			mapsPresent;
+	CARD32			namesPresent;
+	XkbIndicatorMapPtr	maps;
+	Atom *			names;
+
+	CARD32			usesBase;
+	CARD32			usesLatched;
+	CARD32			usesLocked;
+	CARD32			usesEffective;
+	CARD32			usesCompat;
+	CARD32			usesControls;
+
+	CARD32			usedComponents;
+} XkbSrvLedInfoRec, *XkbSrvLedInfoPtr;
+
+/*
+ * Settings for xkbClientFlags field (used by DIX)
+ * These flags _must_ not overlap with XkbPCF_*
+ */
+#define	_XkbClientInitialized		(1<<15)
+
+#define	_XkbWantsDetectableAutoRepeat(c)\
+	((c)->xkbClientFlags&XkbPCF_DetectableAutoRepeatMask)
+
+/*
+ * Settings for flags field
+ */
+#define	_XkbStateNotifyInProgress	(1<<0)
+
+typedef struct
+{
+    ProcessInputProc processInputProc;
+    ProcessInputProc realInputProc;
+    DeviceUnwrapProc unwrapProc;
+} xkbDeviceInfoRec, *xkbDeviceInfoPtr;
+
+#define WRAP_PROCESS_INPUT_PROC(device, oldprocs, proc, unwrapproc) \
+	device->public.processInputProc = proc; \
+	oldprocs->processInputProc = \
+	oldprocs->realInputProc = device->public.realInputProc; \
+	device->public.realInputProc = proc; \
+	oldprocs->unwrapProc = device->unwrapProc; \
+	device->unwrapProc = unwrapproc;
+
+#define COND_WRAP_PROCESS_INPUT_PROC(device, oldprocs, proc, unwrapproc) \
+	if (device->public.processInputProc == device->public.realInputProc)\
+	    device->public.processInputProc = proc; \
+	oldprocs->processInputProc = \
+	oldprocs->realInputProc = device->public.realInputProc; \
+	device->public.realInputProc = proc; \
+	oldprocs->unwrapProc = device->unwrapProc; \
+	device->unwrapProc = unwrapproc;
+
+#define UNWRAP_PROCESS_INPUT_PROC(device, oldprocs) \
+	device->public.processInputProc = oldprocs->processInputProc; \
+	device->public.realInputProc = oldprocs->realInputProc; \
+	device->unwrapProc = oldprocs->unwrapProc;
+
+#define XKBDEVICEINFO(dev) ((xkbDeviceInfoPtr) (dev)->devPrivates[xkbDevicePrivateIndex].ptr)
+
+/***====================================================================***/
+
+
+/***====================================================================***/
+
+#define XkbAX_KRGMask	 (XkbSlowKeysMask|XkbBounceKeysMask)
+#define	XkbAllFilteredEventsMask \
+	(XkbAccessXKeysMask|XkbRepeatKeysMask|XkbMouseKeysAccelMask|XkbAX_KRGMask)
+
+/***====================================================================***/
+
+extern int	XkbReqCode;
+extern int	XkbEventBase;
+extern int	XkbKeyboardErrorCode;
+extern int	XkbDisableLockActions;
+extern char *	XkbBaseDirectory;
+extern char *	XkbBinDirectory;
+extern char *	XkbInitialMap;
+extern int	_XkbClientMajor;
+extern int	_XkbClientMinor;
+extern unsigned	int XkbXIUnsupported;
+
+extern char *	XkbModelUsed,*XkbLayoutUsed,*XkbVariantUsed,*XkbOptionsUsed;
+extern Bool	noXkbExtension;
+extern Bool	XkbWantRulesProp;
+
+extern void *	XkbLastRepeatEvent;
+
+extern CARD32	xkbDebugFlags;
+extern CARD32	xkbDebugCtrls;
+
+
+#define	_XkbAlloc(s)		malloc((s))
+#define	_XkbCalloc(n,s)		calloc((n), (s))
+#define	_XkbRealloc(o,s)	realloc((o),(s))
+#define	_XkbTypedAlloc(t)	((t *)malloc(sizeof(t)))
+#define	_XkbTypedCalloc(n,t)	((t *)calloc((n), sizeof(t)))
+#define	_XkbTypedRealloc(o,n,t) \
+	((o)?(t *)realloc((o),(n)*sizeof(t)):_XkbTypedCalloc(n,t))
+#define	_XkbClearElems(a,f,l,t)	bzero(&(a)[f],((l)-(f)+1)*sizeof(t))
+#define	_XkbFree(p)		free(p)
+
+
+#define	_XkbLibError(c,l,d) \
+	{ _XkbErrCode= (c); _XkbErrLocation= (l); _XkbErrData= (d); }
+#define	_XkbErrCode2(a,b) ((XID)((((unsigned int)(a))<<24)|((b)&0xffffff)))
+#define	_XkbErrCode3(a,b,c)	_XkbErrCode2(a,(((unsigned int)(b))<<16)|(c))
+#define	_XkbErrCode4(a,b,c,d) _XkbErrCode3(a,b,((((unsigned int)(c))<<8)|(d)))
+
+extern	int	DeviceKeyPress,DeviceKeyRelease;
+extern	int	DeviceButtonPress,DeviceButtonRelease;
+
+#ifdef XINPUT
+#define	_XkbIsPressEvent(t)	(((t)==KeyPress)||((t)==DeviceKeyPress))
+#define	_XkbIsReleaseEvent(t)	(((t)==KeyRelease)||((t)==DeviceKeyRelease))
+#else
+#define	_XkbIsPressEvent(t)	((t)==KeyPress)
+#define	_XkbIsReleaseEvent(t)	((t)==KeyRelease)
+#endif
+
+#define	_XkbCoreKeycodeInRange(c,k)	(((k)>=(c)->curKeySyms.minKeyCode)&&\
+					 ((k)<=(c)->curKeySyms.maxKeyCode))
+#define	_XkbCoreNumKeys(c)	((c)->curKeySyms.maxKeyCode-\
+				 (c)->curKeySyms.minKeyCode+1)
+
+#define	XConvertCase(s,l,u)	XkbConvertCase(s,l,u)
+#undef	IsKeypadKey
+#define	IsKeypadKey(s)		XkbKSIsKeypad(s)
+
+#define	Status		int
+#define	XPointer	void *
+#define	Display		struct _XDisplay
+
+#ifndef True
+#define	True	1
+#define	False	0
+#endif
+
+#ifndef PATH_MAX
+#ifdef MAXPATHLEN
+#define	PATH_MAX MAXPATHLEN
+#else
+#define	PATH_MAX 1024
+#endif
+#endif
+
+_XFUNCPROTOBEGIN
+
+extern void XkbUseMsg(
+    void
+);
+
+extern int XkbProcessArguments(
+    int				/* argc */,
+    char **			/* argv */,
+    int				/* i */
+);
+
+extern	void	XkbSetExtension(DeviceIntPtr device, ProcessInputProc proc);
+
+extern	void	XkbFreeCompatMap(
+    XkbDescPtr			/* xkb */,
+    unsigned int		/* which */,
+    Bool			/* freeMap */
+);
+
+extern	void XkbFreeNames(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	Bool			/* freeMap */
+);
+
+extern DeviceIntPtr _XkbLookupAnyDevice(
+    int			/* id */,
+    int *		/* why_rtrn */
+);
+
+extern DeviceIntPtr _XkbLookupKeyboard(
+    int			/* id */,
+    int *		/* why_rtrn */
+);
+
+extern DeviceIntPtr _XkbLookupBellDevice(
+    int			/* id */,
+    int *		/* why_rtrn */
+);
+
+extern DeviceIntPtr _XkbLookupLedDevice(
+    int			/* id */,
+    int *		/* why_rtrn */
+);
+
+extern DeviceIntPtr _XkbLookupButtonDevice(
+    int			/* id */,
+    int *		/* why_rtrn */
+);
+
+extern	XkbDescPtr XkbAllocKeyboard(
+	void
+);
+
+extern	Status XkbAllocClientMap(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	unsigned int		/* nTypes */
+);
+
+extern	Status XkbAllocServerMap(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	unsigned int		/* nNewActions */
+);
+
+extern	void	XkbFreeClientMap(
+    XkbDescPtr			/* xkb */,
+    unsigned int		/* what */,
+    Bool			/* freeMap */
+);
+
+extern	void	XkbFreeServerMap(
+    XkbDescPtr			/* xkb */,
+    unsigned int		/* what */,
+    Bool			/* freeMap */
+);
+
+extern	Status XkbAllocIndicatorMaps(
+	XkbDescPtr		/* xkb */
+);
+
+extern	Status	XkbAllocCompatMap(
+    XkbDescPtr			/* xkb */,
+    unsigned int		/* which */,
+    unsigned int		/* nInterpret */
+);
+
+extern	Status XkbAllocNames(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	int			/* nTotalRG */,
+	int			/* nTotalAliases */
+);
+
+extern	Status	XkbAllocControls(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which*/
+);
+
+extern	Status	XkbCopyKeyType(
+    XkbKeyTypePtr		/* from */,
+    XkbKeyTypePtr		/* into */
+);
+
+extern	Status	XkbCopyKeyTypes(
+    XkbKeyTypePtr		/* from */,
+    XkbKeyTypePtr		/* into */,
+    int				/* num_types */
+);
+
+extern	Status	XkbResizeKeyType(
+    XkbDescPtr		/* xkb */,
+    int			/* type_ndx */,
+    int			/* map_count */,
+    Bool		/* want_preserve */,
+    int			/* new_num_lvls */
+);
+
+extern	void	XkbFreeKeyboard(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	Bool			/* freeDesc */
+);
+
+extern  void XkbSetActionKeyMods(
+	XkbDescPtr		/* xkb */,
+	XkbAction *		/* act */,
+	unsigned int 		/* mods */
+);
+
+extern Bool XkbCheckActionVMods(
+	XkbDescPtr		/* xkb */,
+	XkbAction *		/* act */,
+	unsigned int 		/* changed */
+);
+
+extern Bool XkbApplyVModChanges(
+    XkbSrvInfoPtr	/* xkbi */,
+    unsigned int	/* changed */,
+    XkbChangesPtr	/* pChanges */,
+    unsigned int *	/* needChecksRtrn */,
+    XkbEventCausePtr	/* cause */
+);
+
+extern void XkbApplyVModChangesToAllDevices(
+    DeviceIntPtr	/* dev */,
+    XkbDescPtr 		/* xkb */,
+    unsigned int 	/* changed */,
+    XkbEventCausePtr	/* cause */
+);
+
+extern	unsigned int XkbMaskForVMask(
+    XkbDescPtr		/* xkb */,
+    unsigned int	/* vmask */
+);
+
+extern Bool XkbVirtualModsToReal(
+	XkbDescPtr	/* xkb */,
+	unsigned int	/* virtua_mask */,
+	unsigned int *	/* mask_rtrn */
+);
+
+extern	unsigned int	XkbAdjustGroup(
+    int			/* group */,
+    XkbControlsPtr	/* ctrls */
+);
+
+extern KeySym *XkbResizeKeySyms(
+    XkbDescPtr		/* xkb */,
+    int 		/* key */,
+    int 		/* needed */
+);
+
+extern XkbAction *XkbResizeKeyActions(
+    XkbDescPtr		/* xkb */,
+    int 		/* key */,
+    int 		/* needed */
+);
+
+extern void XkbUpdateKeyTypesFromCore(
+    DeviceIntPtr	/* pXDev */,
+    KeyCode 		/* first */,
+    CARD8 		/* num */,
+    XkbChangesPtr	/* pChanges */
+);
+
+extern	void XkbUpdateDescActions(	
+    XkbDescPtr		/* xkb */,
+    KeyCode		/* first */,
+    CARD8		/* num */,
+    XkbChangesPtr	/* changes */
+);
+
+extern void XkbUpdateActions(
+    DeviceIntPtr	/* pXDev */,
+    KeyCode 		/* first */,
+    CARD8 		/* num */,
+    XkbChangesPtr  	/* pChanges */,
+    unsigned int *	/* needChecksRtrn */,
+    XkbEventCausePtr	/* cause */
+);
+
+extern void XkbUpdateCoreDescription(
+    DeviceIntPtr	/* keybd */,
+    Bool		/* resize */
+);
+
+extern void XkbApplyMappingChange(
+    DeviceIntPtr	/* pXDev */,
+    CARD8 		/* request */,
+    KeyCode 		/* firstKey */,
+    CARD8 		/* num */,
+    ClientPtr		/* client */
+);
+
+extern void XkbSetIndicators(
+    DeviceIntPtr		/* pXDev */,
+    CARD32			/* affect */,
+    CARD32			/* values */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbUpdateIndicators(
+    DeviceIntPtr		/* keybd */,
+    CARD32		 	/* changed */,
+    Bool			/* check_edevs */,
+    XkbChangesPtr		/* pChanges */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern XkbSrvLedInfoPtr XkbAllocSrvLedInfo(
+    DeviceIntPtr		/* dev */,
+    KbdFeedbackPtr		/* kf */,
+    LedFeedbackPtr		/* lf */,
+    unsigned int		/* needed_parts */
+);
+
+extern XkbSrvLedInfoPtr XkbFindSrvLedInfo(
+    DeviceIntPtr		/* dev */,
+    unsigned int		/* class */,
+    unsigned int		/* id */,
+    unsigned int		/* needed_parts */
+);
+
+extern void XkbApplyLedNameChanges(
+    DeviceIntPtr		/* dev */,
+    XkbSrvLedInfoPtr		/* sli */,
+    unsigned int		/* changed_names */,
+    xkbExtensionDeviceNotify *	/* ed */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbApplyLedMapChanges(
+    DeviceIntPtr		/* dev */,
+    XkbSrvLedInfoPtr		/* sli */,
+    unsigned int		/* changed_maps */,
+    xkbExtensionDeviceNotify *	/* ed */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbApplyLedStateChanges(
+    DeviceIntPtr		/* dev */,
+    XkbSrvLedInfoPtr		/* sli */,
+    unsigned int		/* changed_leds */,
+    xkbExtensionDeviceNotify *	/* ed */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbUpdateLedAutoState(
+    DeviceIntPtr		/* dev */,
+    XkbSrvLedInfoPtr		/* sli */,
+    unsigned int		/* maps_to_check */,
+    xkbExtensionDeviceNotify *	/* ed */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbFlushLedEvents(	
+    DeviceIntPtr		/* dev */,
+    DeviceIntPtr		/* kbd */,
+    XkbSrvLedInfoPtr		/* sli */,
+    xkbExtensionDeviceNotify *	/* ed */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbUpdateAllDeviceIndicators(
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern unsigned int XkbIndicatorsToUpdate(
+    DeviceIntPtr		/* dev */,
+    unsigned long		/* state_changes */,
+    Bool			/* enabled_ctrl_changes */
+);
+
+extern void XkbComputeDerivedState(
+    XkbSrvInfoPtr		/* xkbi */
+);
+
+extern void XkbCheckSecondaryEffects(
+    XkbSrvInfoPtr		/* xkbi */,
+    unsigned int		/* which */,
+    XkbChangesPtr		/* changes */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbCheckIndicatorMaps(
+    DeviceIntPtr		/* dev */,
+    XkbSrvLedInfoPtr		/* sli */,
+    unsigned int		/* which */
+);
+
+extern unsigned int XkbStateChangedFlags(
+    XkbStatePtr			/* old */,
+    XkbStatePtr			/* new */
+);
+
+extern	void XkbSendStateNotify(
+       DeviceIntPtr	/* kbd */,
+       xkbStateNotify *	/* pSN */
+);
+
+extern	void XkbSendMapNotify(
+       DeviceIntPtr	/* kbd */,
+       xkbMapNotify *	/* ev */
+);
+
+extern	int  XkbComputeControlsNotify(
+	DeviceIntPtr		/* kbd */,
+	XkbControlsPtr		/* old */,
+	XkbControlsPtr		/* new */,
+	xkbControlsNotify *	/* pCN */,
+	Bool			/* forceCtrlProc */
+);
+
+extern	void XkbSendControlsNotify(
+       DeviceIntPtr		/* kbd */,
+       xkbControlsNotify *	/* ev */
+);
+
+extern	void XkbSendCompatMapNotify(
+	DeviceIntPtr		/* kbd */,
+	xkbCompatMapNotify *	/* ev */
+);
+
+extern	void XkbSendIndicatorNotify(
+       DeviceIntPtr		/* kbd */,
+       int			/* xkbType */,
+       xkbIndicatorNotify *	/* ev */
+);
+
+extern	void XkbHandleBell(
+       BOOL		/* force */,
+       BOOL		/* eventOnly */,
+       DeviceIntPtr	/* kbd */,
+       CARD8		/* percent */,
+       void * 		/* ctrl */,
+       CARD8		/* class */,
+       Atom		/* name */,
+       WindowPtr	/* pWin */,
+       ClientPtr	/* pClient */
+);
+
+extern	void XkbSendAccessXNotify(
+       DeviceIntPtr		/* kbd */,
+       xkbAccessXNotify *	/* pEv */
+);
+
+extern	void XkbSendNamesNotify(
+       DeviceIntPtr	/* kbd */,
+       xkbNamesNotify *	/* ev */
+);
+
+extern	void XkbSendCompatNotify(
+       DeviceIntPtr		/* kbd */,
+       xkbCompatMapNotify *	/* ev */
+);
+
+extern	void XkbSendActionMessage(
+       DeviceIntPtr		/* kbd */,
+       xkbActionMessage *	/* ev */
+);
+
+extern	void XkbSendExtensionDeviceNotify(
+       DeviceIntPtr			/* kbd */,
+       ClientPtr			/* client */,
+       xkbExtensionDeviceNotify *	/* ev */
+);
+
+extern void XkbSendNotification(
+    DeviceIntPtr		/* kbd */,
+    XkbChangesPtr		/* pChanges */,
+    XkbEventCausePtr		/* cause */
+);
+
+extern void XkbProcessKeyboardEvent(
+    struct _xEvent * 		/* xE */,
+    DeviceIntPtr		/* keybd */,
+    int 			/* count */
+);
+
+extern void XkbProcessOtherEvent(
+    struct _xEvent * 		/* xE */,
+    DeviceIntPtr		/* keybd */,
+    int 			/* count */
+);
+
+extern void XkbHandleActions(
+    DeviceIntPtr		/* dev */,
+    DeviceIntPtr		/* kbd */,
+    struct _xEvent * 		/* xE */,
+    int 			/* count */
+);
+
+extern Bool XkbEnableDisableControls(
+    XkbSrvInfoPtr	/* xkbi */,
+    unsigned long	/* change */,
+    unsigned long	/* newValues */,
+    XkbChangesPtr	/* changes */,
+    XkbEventCausePtr	/* cause */
+);
+
+extern void AccessXInit(
+    DeviceIntPtr        /* dev */
+);
+
+extern Bool AccessXFilterPressEvent(
+    register struct _xEvent *	/* xE */,
+    register DeviceIntPtr	/* keybd */,
+    int				/* count */
+);
+
+extern Bool AccessXFilterReleaseEvent(
+    register struct _xEvent *	/* xE */,
+    register DeviceIntPtr	/* keybd */,
+    int				/* count */
+);
+
+extern void AccessXCancelRepeatKey(
+    XkbSrvInfoPtr	/* xkbi */,
+    KeyCode		/* key */
+);
+
+extern void AccessXComputeCurveFactor(
+    XkbSrvInfoPtr	/* xkbi */,
+    XkbControlsPtr	/* ctrls */
+);
+
+extern	XkbDeviceLedInfoPtr	XkbAddDeviceLedInfo(
+	XkbDeviceInfoPtr	/* devi */,
+	unsigned int		/* ledClass */,
+	unsigned int		/* ledId */
+);
+
+extern	XkbDeviceInfoPtr	XkbAllocDeviceInfo(
+	unsigned int		/* deviceSpec */,
+	unsigned int		/* nButtons */,
+	unsigned int		/* szLeds */
+);
+
+extern	void XkbFreeDeviceInfo(
+	XkbDeviceInfoPtr	/* devi */,
+	unsigned int		/* which */,
+	Bool			/* freeDevI */
+);
+
+extern Status XkbResizeDeviceButtonActions(
+	XkbDeviceInfoPtr        /* devi */,
+	unsigned int            /* newTotal */
+);
+
+extern	XkbInterestPtr XkbFindClientResource(
+       DevicePtr	/* inDev */,
+       ClientPtr	/* client */
+);
+
+extern	XkbInterestPtr XkbAddClientResource(
+       DevicePtr	/* inDev */,
+       ClientPtr	/* client */,
+       XID		/* id */
+);
+
+extern	int XkbRemoveClient(
+       DevicePtr	/* inDev */,
+       ClientPtr	/* client */
+);
+
+extern	int XkbRemoveResourceClient(
+       DevicePtr	/* inDev */,
+       XID		/* id */
+);
+
+extern int XkbDDXInitDevice(
+    DeviceIntPtr        /* dev */
+);
+
+extern	int XkbDDXAccessXBeep(
+    DeviceIntPtr        /* dev */,
+    unsigned int	/* what */,
+    unsigned int	/* which */
+);
+
+extern	void XkbDDXKeyClick(
+    DeviceIntPtr	/* dev */,
+    int			/* keycode */,
+    int			/* synthetic */
+);
+
+extern 	int XkbDDXUsesSoftRepeat(
+    DeviceIntPtr	/* dev */
+);
+
+extern	void XkbDDXKeybdCtrlProc(
+	DeviceIntPtr	/* dev */,
+	KeybdCtrl *	/* ctrl */
+);
+
+extern void XkbDDXChangeControls(
+	DeviceIntPtr	/* dev */,
+	XkbControlsPtr 	/* old */,
+	XkbControlsPtr 	/* new */
+);
+
+extern void XkbDDXUpdateIndicators(
+	DeviceIntPtr	/* keybd */,
+	CARD32		/* newState */
+);
+
+extern void XkbDDXUpdateDeviceIndicators(
+	DeviceIntPtr		/* dev */,
+	XkbSrvLedInfoPtr	/* sli */,
+	CARD32			/* newState */
+);
+
+extern void XkbDDXFakePointerButton(
+	int 		/* event */,
+	int		/* button */
+);
+
+extern void XkbDDXFakePointerMotion(
+ 	unsigned int	/* flags */,
+	int		/* x */,
+	int		/* y */
+);
+
+extern void XkbDDXFakeDeviceButton(
+	DeviceIntPtr	/* dev */,
+	Bool		/* press */,
+	int		/* button */
+);
+
+extern int XkbDDXTerminateServer(
+	DeviceIntPtr	/* dev */,
+	KeyCode		/* key */,
+	XkbAction *	/* act */
+);
+
+extern int XkbDDXSwitchScreen(
+	DeviceIntPtr	/* dev */,
+	KeyCode		/* key */,
+	XkbAction *	/* act */
+);
+
+extern int XkbDDXPrivate(
+	DeviceIntPtr	/* dev */,
+	KeyCode		/* key */,
+	XkbAction *	/* act */
+);
+
+extern void XkbDisableComputedAutoRepeats(
+	DeviceIntPtr 	/* pXDev */,
+	unsigned int	/* key */
+);
+
+extern void XkbSetRepeatKeys(
+	DeviceIntPtr 	/* pXDev */,
+	int		/* key */,
+	int	 	/* onoff */
+);
+
+extern	int XkbLatchModifiers(
+	DeviceIntPtr 	/* pXDev */,
+	CARD8 		/* mask */,
+	CARD8 		/* latches */
+);
+
+extern	int XkbLatchGroup(
+	DeviceIntPtr  	/* pXDev */,
+	int	  	/* group */
+);
+
+extern	void XkbClearAllLatchesAndLocks(
+	DeviceIntPtr		/* dev */,
+	XkbSrvInfoPtr		/* xkbi */,
+	Bool			/* genEv */,
+	XkbEventCausePtr	/* cause */
+);
+
+extern	void	XkbSetRulesDflts(
+	char *			/* rulesFile */,
+	char *			/* model */,
+	char *			/* layout */,
+	char *			/* variant */,
+	char *			/* options */
+);
+
+extern	void	XkbInitDevice(
+	DeviceIntPtr 	/* pXDev */
+);
+
+extern	Bool	XkbInitKeyboardDeviceStruct(
+	DeviceIntPtr 		/* pXDev */,
+	XkbComponentNamesPtr	/* pNames */,
+	KeySymsPtr		/* pSyms */,
+	CARD8 			/* pMods */[],
+	BellProcPtr		/* bellProc */,
+	KbdCtrlProcPtr		/* ctrlProc */
+);
+
+extern	int SProcXkbDispatch(
+	ClientPtr		/* client */
+);
+
+extern XkbGeometryPtr XkbLookupNamedGeometry(
+	DeviceIntPtr		/* dev */,
+	Atom			/* name */,
+	Bool *			/* shouldFree */
+);
+
+extern char *	_XkbDupString(
+	char *			/* str */
+);
+
+extern void	XkbConvertCase(
+	KeySym 			/* sym */,
+	KeySym *		/* lower */,
+	KeySym *		/* upper */
+);
+
+extern	Status	 XkbChangeKeycodeRange(	
+	XkbDescPtr		/* xkb */,
+	int 			/* minKC */,
+	int 			/* maxKC */,
+	XkbChangesPtr		/* changes */
+);
+
+extern int XkbFinishDeviceInit(
+	DeviceIntPtr		/* pXDev */
+);
+
+extern void XkbFreeSrvLedInfo(
+	XkbSrvLedInfoPtr	/* sli */
+);
+
+extern void XkbFreeInfo(
+	XkbSrvInfoPtr		/* xkbi */
+);
+
+extern Status XkbChangeTypesOfKey(
+	XkbDescPtr		/* xkb */,
+	int			/* key */,
+	int			/* nGroups */,
+	unsigned int		/* groups */,
+	int *			/* newTypesIn */,
+	XkbMapChangesPtr	/* changes */
+);
+
+extern XkbKeyTypePtr XkbAddKeyType(
+	XkbDescPtr		/* xkb */,
+	Atom			/* name */,
+	int			/* map_count */,
+	Bool			/* want_preserve */,
+	int			/* num_lvls */
+);
+
+extern Status XkbInitCanonicalKeyTypes(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	int			/* keypadVMod */
+);
+
+extern int XkbKeyTypesForCoreSymbols(
+	XkbDescPtr		/* xkb */,
+	int			/* map_width */,
+	KeySym *		/* core_syms */,
+	unsigned int		/* protected */,
+	int *			/* types_inout */,
+	KeySym *		/* xkb_syms_rtrn */
+);
+
+extern Bool XkbApplyCompatMapToKey(
+	XkbDescPtr		/* xkb */,
+	KeyCode			/* key */,
+	XkbChangesPtr		/* changes */
+);
+
+extern Bool XkbUpdateMapFromCore(
+	XkbDescPtr		/* xkb */,
+	KeyCode			/* first_key */,
+	int			/* num_keys */,
+	int			/* map_width */,
+	KeySym *		/* core_keysyms */,
+	XkbChangesPtr		/* changes */
+);
+
+extern void XkbFreeControls(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* which */,
+	Bool			/* freeMap */
+);
+
+extern void XkbFreeIndicatorMaps(
+	XkbDescPtr		/* xkb */
+);
+
+extern Bool XkbApplyVirtualModChanges(
+	XkbDescPtr		/* xkb */,
+	unsigned int		/* changed */,
+	XkbChangesPtr		/* changes */
+);
+
+extern Bool XkbUpdateActionVirtualMods(
+	XkbDescPtr		/* xkb */,
+	XkbAction *		/* act */,
+	unsigned int		/* changed */
+);
+
+extern void XkbUpdateKeyTypeVirtualMods(
+	XkbDescPtr		/* xkb */,
+	XkbKeyTypePtr		/* type */,
+	unsigned int		/* changed */,
+	XkbChangesPtr		/* changes */
+);
+
+extern void XkbSendNewKeyboardNotify(
+	DeviceIntPtr		/* kbd */,
+	xkbNewKeyboardNotify *	/* pNKN */
+);
+
+#ifdef XKBSRV_NEED_FILE_FUNCS
+
+#include <nx-X11/extensions/XKMformat.h>
+#include <nx-X11/extensions/XKBfile.h>
+#include <nx-X11/extensions/XKBrules.h>
+
+#define	_XkbListKeymaps		0
+#define	_XkbListKeycodes	1
+#define	_XkbListTypes		2
+#define	_XkbListCompat		3
+#define	_XkbListSymbols		4
+#define	_XkbListGeometry	5
+#define	_XkbListNumComponents	6
+
+typedef struct _XkbSrvListInfo {
+	int		szPool;
+	int		nPool;
+	char *		pool;
+
+	int		maxRtrn;
+	int		nTotal;
+
+	char *		pattern[_XkbListNumComponents];
+	int		nFound[_XkbListNumComponents];
+} XkbSrvListInfoRec,*XkbSrvListInfoPtr;
+
+char *
+XkbGetRulesDflts(
+	XkbRF_VarDefsPtr	/* defs */
+);
+
+extern void	XkbSetRulesUsed(
+	XkbRF_VarDefsPtr	/* defs */
+);
+
+
+extern	Status	XkbDDXList(
+	DeviceIntPtr		/* dev */,
+	XkbSrvListInfoPtr	/* listing */,
+	ClientPtr		/* client */
+);
+
+extern	unsigned int XkbDDXLoadKeymapByNames(
+	DeviceIntPtr		/* keybd */,
+	XkbComponentNamesPtr	/* names */,
+	unsigned int		/* want */,
+	unsigned int		/* need */,
+	XkbFileInfoPtr		/* finfoRtrn */,
+	char *			/* keymapNameRtrn */,
+	int 			/* keymapNameRtrnLen */
+);
+
+extern	Bool XkbDDXNamesFromRules(
+	DeviceIntPtr		/* keybd */,
+	char *			/* rules */,
+	XkbRF_VarDefsPtr	/* defs */,
+	XkbComponentNamesPtr	/* names */
+);
+
+extern	FILE *XkbDDXOpenConfigFile(
+	char *	/* mapName */,
+	char *	/* fileNameRtrn */,
+	int	/* fileNameRtrnLen */
+);
+
+extern	Bool XkbDDXApplyConfig(
+	XPointer	/* cfg_in */,
+	XkbSrvInfoPtr	/* xkbi */
+);
+
+extern XPointer XkbDDXPreloadConfig(
+	char **			/* rulesFileRtrn */,
+	XkbRF_VarDefsPtr	/* defs */,
+	XkbComponentNamesPtr	/* names */,
+	DeviceIntPtr		/* dev */
+);
+
+extern	int _XkbStrCaseCmp(
+	char *			/* str1 */,
+	char *			/* str2 */
+);
+
+#endif /* XKBSRV_NEED_FILE_FUNCS */
+
+
+_XFUNCPROTOEND
+
+#define	XkbAtomGetString(d,s)	NameForAtom(s)
+
+#endif /* _XKBSRV_H_ */
+
+

--- a/nx-X11/programs/Xserver/include/xkbsrv.h
+++ b/nx-X11/programs/Xserver/include/xkbsrv.h
@@ -1095,7 +1095,6 @@ extern void XkbSendNewKeyboardNotify(
 	xkbNewKeyboardNotify *	/* pNKN */
 );
 
-#ifdef XKBSRV_NEED_FILE_FUNCS
 
 #include <nx-X11/extensions/XKMformat.h>
 #include "xkbfile.h"
@@ -1177,7 +1176,6 @@ extern	int _XkbStrCaseCmp(
 	char *			/* str2 */
 );
 
-#endif /* XKBSRV_NEED_FILE_FUNCS */
 
 
 _XFUNCPROTOEND

--- a/nx-X11/programs/Xserver/include/xkbstr.h
+++ b/nx-X11/programs/Xserver/include/xkbstr.h
@@ -1,0 +1,608 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifndef _XKBSTR_H_
+#define	_XKBSTR_H_
+
+#include <nx-X11/extensions/XKB.h>
+
+#define	XkbCharToInt(v)		((v)&0x80?(int)((v)|(~0xff)):(int)((v)&0x7f))
+#define	XkbIntTo2Chars(i,h,l)	(((h)=((i>>8)&0xff)),((l)=((i)&0xff)))
+
+#define	Xkb2CharsToInt(h,l)	((short)(((h)<<8)|(l)))
+
+	/*
+	 * Common data structures and access macros
+	 */
+
+typedef struct _XkbStateRec {
+	unsigned char	group;
+	unsigned char   locked_group;
+	unsigned short	base_group;
+	unsigned short	latched_group;
+	unsigned char	mods;
+	unsigned char	base_mods;
+	unsigned char	latched_mods;
+	unsigned char	locked_mods;
+	unsigned char	compat_state;
+	unsigned char	grab_mods;
+	unsigned char	compat_grab_mods;
+	unsigned char	lookup_mods;
+	unsigned char	compat_lookup_mods;
+	unsigned short	ptr_buttons;
+} XkbStateRec,*XkbStatePtr;
+#define	XkbModLocks(s)	 ((s)->locked_mods)
+#define	XkbStateMods(s)	 ((s)->base_mods|(s)->latched_mods|XkbModLocks(s))
+#define	XkbGroupLock(s)	 ((s)->locked_group)
+#define	XkbStateGroup(s) ((s)->base_group+(s)->latched_group+XkbGroupLock(s))
+#define	XkbStateFieldFromRec(s)	XkbBuildCoreState((s)->lookup_mods,(s)->group)
+#define	XkbGrabStateFromRec(s)	XkbBuildCoreState((s)->grab_mods,(s)->group)
+
+typedef struct _XkbMods {
+	unsigned char	mask;	/* effective mods */
+	unsigned char	real_mods;
+	unsigned short	vmods;
+} XkbModsRec,*XkbModsPtr;
+
+typedef struct _XkbKTMapEntry {
+	Bool		active;
+	unsigned char	level;
+	XkbModsRec	mods;
+} XkbKTMapEntryRec,*XkbKTMapEntryPtr;
+
+typedef struct _XkbKeyType {
+	XkbModsRec		mods;
+	unsigned char	  	num_levels;
+	unsigned char	  	map_count;
+	XkbKTMapEntryPtr  	map;
+	XkbModsPtr  		preserve;
+	Atom		  	name;
+	Atom *			level_names;
+} XkbKeyTypeRec, *XkbKeyTypePtr;
+
+#define	XkbNumGroups(g)			((g)&0x0f)
+#define	XkbOutOfRangeGroupInfo(g)	((g)&0xf0)
+#define	XkbOutOfRangeGroupAction(g)	((g)&0xc0)
+#define	XkbOutOfRangeGroupNumber(g)	(((g)&0x30)>>4)
+#define	XkbSetGroupInfo(g,w,n)	(((w)&0xc0)|(((n)&3)<<4)|((g)&0x0f))
+#define	XkbSetNumGroups(g,n)	(((g)&0xf0)|((n)&0x0f))
+
+	/*
+	 * Structures and access macros used primarily by the server
+	 */
+
+typedef struct _XkbBehavior {
+	unsigned char	type;
+	unsigned char	data;
+} XkbBehavior;
+
+#define	XkbAnyActionDataSize 7
+typedef	struct _XkbAnyAction {
+	unsigned char	type;
+	unsigned char	data[XkbAnyActionDataSize];
+} XkbAnyAction;
+
+typedef struct _XkbModAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	mask;
+	unsigned char	real_mods;
+	unsigned char	vmods1;
+	unsigned char	vmods2;
+} XkbModAction;
+#define	XkbModActionVMods(a)      \
+	((short)(((a)->vmods1<<8)|((a)->vmods2)))
+#define	XkbSetModActionVMods(a,v) \
+	(((a)->vmods1=(((v)>>8)&0xff)),(a)->vmods2=((v)&0xff))
+
+typedef struct _XkbGroupAction {
+	unsigned char	type;
+	unsigned char	flags;
+	char		group_XXX;
+} XkbGroupAction;
+#define	XkbSAGroup(a)		(XkbCharToInt((a)->group_XXX))
+#define	XkbSASetGroup(a,g)	((a)->group_XXX=(g))
+
+typedef struct _XkbISOAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	mask;
+	unsigned char	real_mods;
+	char		group_XXX;
+	unsigned char	affect;
+	unsigned char	vmods1;
+	unsigned char	vmods2;
+} XkbISOAction;
+
+typedef struct _XkbPtrAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	high_XXX;
+	unsigned char	low_XXX;
+	unsigned char	high_YYY;
+	unsigned char	low_YYY;
+} XkbPtrAction;
+#define	XkbPtrActionX(a)      (Xkb2CharsToInt((a)->high_XXX,(a)->low_XXX))
+#define	XkbPtrActionY(a)      (Xkb2CharsToInt((a)->high_YYY,(a)->low_YYY))
+#define	XkbSetPtrActionX(a,x) (XkbIntTo2Chars(x,(a)->high_XXX,(a)->low_XXX))
+#define	XkbSetPtrActionY(a,y) (XkbIntTo2Chars(y,(a)->high_YYY,(a)->low_YYY))
+
+typedef struct _XkbPtrBtnAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	count;
+	unsigned char	button;
+} XkbPtrBtnAction;
+
+typedef struct _XkbPtrDfltAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	affect;
+	char		valueXXX;
+} XkbPtrDfltAction;
+#define	XkbSAPtrDfltValue(a)		(XkbCharToInt((a)->valueXXX))
+#define	XkbSASetPtrDfltValue(a,c)	((a)->valueXXX= ((c)&0xff))
+
+typedef struct _XkbSwitchScreenAction {
+	unsigned char	type;
+	unsigned char	flags;
+	char		screenXXX;
+} XkbSwitchScreenAction;
+#define	XkbSAScreen(a)			(XkbCharToInt((a)->screenXXX))
+#define	XkbSASetScreen(a,s)		((a)->screenXXX= ((s)&0xff))
+
+typedef struct _XkbCtrlsAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	ctrls3;
+	unsigned char	ctrls2;
+	unsigned char	ctrls1;
+	unsigned char	ctrls0;
+} XkbCtrlsAction;
+#define	XkbActionSetCtrls(a,c)	(((a)->ctrls3=(((c)>>24)&0xff)),\
+					((a)->ctrls2=(((c)>>16)&0xff)),\
+					((a)->ctrls1=(((c)>>8)&0xff)),\
+					((a)->ctrls0=((c)&0xff)))
+#define	XkbActionCtrls(a) ((((unsigned int)(a)->ctrls3)<<24)|\
+			   (((unsigned int)(a)->ctrls2)<<16)|\
+			   (((unsigned int)(a)->ctrls1)<<8)|\
+			   ((unsigned int)((a)->ctrls0)))
+
+typedef struct _XkbMessageAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	message[6];
+} XkbMessageAction;
+
+typedef struct	_XkbRedirectKeyAction {
+	unsigned char	type;
+	unsigned char	new_key;
+	unsigned char	mods_mask;
+	unsigned char	mods;
+	unsigned char	vmods_mask0;
+	unsigned char	vmods_mask1;
+	unsigned char	vmods0;
+	unsigned char	vmods1;
+} XkbRedirectKeyAction;
+
+#define	XkbSARedirectVMods(a)		((((unsigned int)(a)->vmods1)<<8)|\
+					((unsigned int)(a)->vmods0))
+#define	XkbSARedirectSetVMods(a,m)	(((a)->vmods_mask1=(((m)>>8)&0xff)),\
+					 ((a)->vmods_mask0=((m)&0xff)))
+#define	XkbSARedirectVModsMask(a)	((((unsigned int)(a)->vmods_mask1)<<8)|\
+					((unsigned int)(a)->vmods_mask0))
+#define	XkbSARedirectSetVModsMask(a,m)	(((a)->vmods_mask1=(((m)>>8)&0xff)),\
+					 ((a)->vmods_mask0=((m)&0xff)))
+
+typedef struct _XkbDeviceBtnAction {
+	unsigned char	type;
+	unsigned char	flags;
+	unsigned char	count;
+	unsigned char	button;
+	unsigned char	device;
+} XkbDeviceBtnAction;
+
+typedef struct _XkbDeviceValuatorAction {
+	unsigned char	type;
+	unsigned char	device;
+	unsigned char	v1_what;
+	unsigned char	v1_ndx;
+	unsigned char	v1_value;
+	unsigned char	v2_what;
+	unsigned char	v2_ndx;
+	unsigned char	v2_value;
+} XkbDeviceValuatorAction;
+
+typedef	union _XkbAction {
+	XkbAnyAction		any;
+	XkbModAction		mods;
+	XkbGroupAction		group;
+	XkbISOAction		iso;
+	XkbPtrAction		ptr;
+	XkbPtrBtnAction		btn;
+	XkbPtrDfltAction	dflt;
+	XkbSwitchScreenAction	screen;
+	XkbCtrlsAction		ctrls;
+	XkbMessageAction	msg;
+	XkbRedirectKeyAction	redirect;
+	XkbDeviceBtnAction	devbtn;
+	XkbDeviceValuatorAction	devval;
+	unsigned char 		type;
+} XkbAction;
+
+typedef	struct _XkbControls {
+	unsigned char	mk_dflt_btn;
+	unsigned char	num_groups;
+	unsigned char	groups_wrap;
+	XkbModsRec	internal;
+	XkbModsRec	ignore_lock;
+	unsigned int	enabled_ctrls;
+	unsigned short	repeat_delay;
+	unsigned short	repeat_interval;
+	unsigned short	slow_keys_delay;
+	unsigned short	debounce_delay;
+	unsigned short	mk_delay;
+	unsigned short	mk_interval;
+	unsigned short	mk_time_to_max;
+	unsigned short	mk_max_speed;
+		 short	mk_curve;
+	unsigned short	ax_options;
+	unsigned short	ax_timeout;
+	unsigned short	axt_opts_mask;
+	unsigned short	axt_opts_values;
+	unsigned int	axt_ctrls_mask;
+	unsigned int	axt_ctrls_values;
+	unsigned char	per_key_repeat[XkbPerKeyBitArraySize];
+} XkbControlsRec, *XkbControlsPtr;
+
+#define	XkbAX_AnyFeedback(c)	((c)->enabled_ctrls&XkbAccessXFeedbackMask)
+#define	XkbAX_NeedOption(c,w)	((c)->ax_options&(w))
+#define	XkbAX_NeedFeedback(c,w)	(XkbAX_AnyFeedback(c)&&XkbAX_NeedOption(c,w))
+
+typedef struct _XkbServerMapRec {
+	unsigned short		 num_acts;
+	unsigned short		 size_acts;
+	XkbAction		*acts;
+
+	XkbBehavior		*behaviors;
+	unsigned short		*key_acts;
+#if defined(__cplusplus) || defined(c_plusplus)
+	/* explicit is a C++ reserved word */
+	unsigned char		*c_explicit;
+#else
+	unsigned char		*explicit;
+#endif
+	unsigned char		 vmods[XkbNumVirtualMods];
+	unsigned short		*vmodmap;
+} XkbServerMapRec, *XkbServerMapPtr;
+
+#define	XkbSMKeyActionsPtr(m,k) (&(m)->acts[(m)->key_acts[k]])
+
+	/*
+	 * Structures and access macros used primarily by clients
+	 */
+
+typedef	struct _XkbSymMapRec {
+	unsigned char	 kt_index[XkbNumKbdGroups];
+	unsigned char	 group_info;
+	unsigned char	 width;
+	unsigned short	 offset;
+} XkbSymMapRec, *XkbSymMapPtr;
+
+typedef struct _XkbClientMapRec {
+	unsigned char		 size_types;
+	unsigned char		 num_types;
+	XkbKeyTypePtr		 types;
+
+	unsigned short		 size_syms;
+	unsigned short		 num_syms;
+	KeySym			*syms;
+	XkbSymMapPtr		 key_sym_map;
+
+	unsigned char		*modmap;
+} XkbClientMapRec, *XkbClientMapPtr;
+
+#define	XkbCMKeyGroupInfo(m,k)  ((m)->key_sym_map[k].group_info)
+#define	XkbCMKeyNumGroups(m,k)	 (XkbNumGroups((m)->key_sym_map[k].group_info))
+#define	XkbCMKeyGroupWidth(m,k,g) (XkbCMKeyType(m,k,g)->num_levels)
+#define	XkbCMKeyGroupsWidth(m,k) ((m)->key_sym_map[k].width)
+#define	XkbCMKeyTypeIndex(m,k,g) ((m)->key_sym_map[k].kt_index[g&0x3])
+#define	XkbCMKeyType(m,k,g)	 (&(m)->types[XkbCMKeyTypeIndex(m,k,g)])
+#define	XkbCMKeyNumSyms(m,k) (XkbCMKeyGroupsWidth(m,k)*XkbCMKeyNumGroups(m,k))
+#define	XkbCMKeySymsOffset(m,k)	((m)->key_sym_map[k].offset)
+#define	XkbCMKeySymsPtr(m,k)	(&(m)->syms[XkbCMKeySymsOffset(m,k)])
+
+	/*
+	 * Compatibility structures and access macros
+	 */
+
+typedef struct _XkbSymInterpretRec {
+	KeySym		sym;
+	unsigned char	flags;
+	unsigned char	match;
+	unsigned char	mods;
+	unsigned char	virtual_mod;
+	XkbAnyAction	act;
+} XkbSymInterpretRec,*XkbSymInterpretPtr;
+
+typedef struct _XkbCompatMapRec {
+	XkbSymInterpretPtr	 sym_interpret;
+	XkbModsRec		 groups[XkbNumKbdGroups];
+	unsigned short		 num_si;
+	unsigned short		 size_si;
+} XkbCompatMapRec, *XkbCompatMapPtr;
+
+typedef struct _XkbIndicatorMapRec {
+	unsigned char	flags;
+	unsigned char	which_groups;
+	unsigned char	groups;
+	unsigned char	which_mods;
+	XkbModsRec	mods;
+	unsigned int	ctrls;
+} XkbIndicatorMapRec, *XkbIndicatorMapPtr;
+
+#define	XkbIM_IsAuto(i)	((((i)->flags&XkbIM_NoAutomatic)==0)&&\
+			    (((i)->which_groups&&(i)->groups)||\
+			     ((i)->which_mods&&(i)->mods.mask)||\
+			     ((i)->ctrls)))
+#define	XkbIM_InUse(i)	(((i)->flags)||((i)->which_groups)||\
+					((i)->which_mods)||((i)->ctrls))
+	
+
+typedef struct _XkbIndicatorRec {
+	unsigned long	  	phys_indicators;
+	XkbIndicatorMapRec	maps[XkbNumIndicators];
+} XkbIndicatorRec,*XkbIndicatorPtr;
+
+typedef	struct _XkbKeyNameRec {
+	char	name[XkbKeyNameLength];
+} XkbKeyNameRec,*XkbKeyNamePtr;
+
+typedef struct _XkbKeyAliasRec {
+	char	real[XkbKeyNameLength];
+	char	alias[XkbKeyNameLength];
+} XkbKeyAliasRec,*XkbKeyAliasPtr;
+
+	/*
+	 * Names for everything 
+	 */
+typedef struct _XkbNamesRec {
+	Atom		  keycodes;
+	Atom		  geometry;
+	Atom		  symbols;
+	Atom              types;
+	Atom		  compat;
+	Atom		  vmods[XkbNumVirtualMods];
+	Atom		  indicators[XkbNumIndicators];
+	Atom		  groups[XkbNumKbdGroups];
+	XkbKeyNamePtr	  keys;
+	XkbKeyAliasPtr	  key_aliases;
+	Atom		 *radio_groups;
+	Atom		  phys_symbols;
+
+	unsigned char	  num_keys;
+	unsigned char	  num_key_aliases;
+	unsigned short	  num_rg;
+} XkbNamesRec,*XkbNamesPtr;
+
+typedef	struct _XkbGeometry	*XkbGeometryPtr;
+	/*
+	 * Tie it all together into one big keyboard description
+	 */
+typedef	struct _XkbDesc {
+	struct _XDisplay *	dpy;
+	unsigned short	 	flags;
+	unsigned short		device_spec;
+	KeyCode			min_key_code;
+	KeyCode			max_key_code;
+
+	XkbControlsPtr		ctrls;
+	XkbServerMapPtr		server;
+	XkbClientMapPtr		map;
+	XkbIndicatorPtr		indicators;
+	XkbNamesPtr		names;
+	XkbCompatMapPtr		compat;
+	XkbGeometryPtr		geom;
+} XkbDescRec, *XkbDescPtr;
+#define	XkbKeyKeyTypeIndex(d,k,g)	(XkbCMKeyTypeIndex((d)->map,k,g))
+#define	XkbKeyKeyType(d,k,g)		(XkbCMKeyType((d)->map,k,g))
+#define	XkbKeyGroupWidth(d,k,g)		(XkbCMKeyGroupWidth((d)->map,k,g))
+#define	XkbKeyGroupsWidth(d,k)		(XkbCMKeyGroupsWidth((d)->map,k))
+#define	XkbKeyGroupInfo(d,k)		(XkbCMKeyGroupInfo((d)->map,(k)))
+#define	XkbKeyNumGroups(d,k)		(XkbCMKeyNumGroups((d)->map,(k)))
+#define	XkbKeyNumSyms(d,k)		(XkbCMKeyNumSyms((d)->map,(k)))
+#define	XkbKeySymsPtr(d,k)		(XkbCMKeySymsPtr((d)->map,(k)))
+#define	XkbKeySym(d,k,n)		(XkbKeySymsPtr(d,k)[n])
+#define	XkbKeySymEntry(d,k,sl,g) \
+	(XkbKeySym(d,k,((XkbKeyGroupsWidth(d,k)*(g))+(sl))))
+#define	XkbKeyAction(d,k,n) \
+	(XkbKeyHasActions(d,k)?&XkbKeyActionsPtr(d,k)[n]:NULL)
+#define	XkbKeyActionEntry(d,k,sl,g) \
+	(XkbKeyHasActions(d,k)?\
+		XkbKeyAction(d,k,((XkbKeyGroupsWidth(d,k)*(g))+(sl))):NULL)
+
+#define	XkbKeyHasActions(d,k)	((d)->server->key_acts[k]!=0)
+#define	XkbKeyNumActions(d,k)	(XkbKeyHasActions(d,k)?XkbKeyNumSyms(d,k):1)
+#define	XkbKeyActionsPtr(d,k)	(XkbSMKeyActionsPtr((d)->server,k))
+#define	XkbKeycodeInRange(d,k)	(((k)>=(d)->min_key_code)&&\
+				 ((k)<=(d)->max_key_code))
+#define	XkbNumKeys(d)		((d)->max_key_code-(d)->min_key_code+1)
+
+
+	/*
+	 * The following structures can be used to track changes
+	 * to a keyboard device
+	 */
+typedef struct _XkbMapChanges {
+	unsigned short		 changed;
+	KeyCode			 min_key_code;
+	KeyCode			 max_key_code;
+	unsigned char		 first_type;
+	unsigned char		 num_types;
+	KeyCode			 first_key_sym;
+	unsigned char		 num_key_syms;
+	KeyCode			 first_key_act;
+	unsigned char		 num_key_acts;
+	KeyCode			 first_key_behavior;
+	unsigned char		 num_key_behaviors;
+	KeyCode 		 first_key_explicit;
+	unsigned char		 num_key_explicit;
+	KeyCode			 first_modmap_key;
+	unsigned char		 num_modmap_keys;
+	KeyCode			 first_vmodmap_key;
+	unsigned char		 num_vmodmap_keys;
+	unsigned char		 pad;
+	unsigned short		 vmods;
+} XkbMapChangesRec,*XkbMapChangesPtr;
+
+typedef struct _XkbControlsChanges {
+	unsigned int 		 changed_ctrls;
+	unsigned int		 enabled_ctrls_changes;
+	Bool			 num_groups_changed;
+} XkbControlsChangesRec,*XkbControlsChangesPtr;
+
+typedef struct _XkbIndicatorChanges {
+	unsigned int		 state_changes;
+	unsigned int		 map_changes;
+} XkbIndicatorChangesRec,*XkbIndicatorChangesPtr;
+
+typedef struct _XkbNameChanges {
+	unsigned int 		changed;
+	unsigned char		first_type;
+	unsigned char		num_types;
+	unsigned char		first_lvl;
+	unsigned char		num_lvls;
+	unsigned char		num_aliases;
+	unsigned char		num_rg;
+	unsigned char		first_key;
+	unsigned char		num_keys;
+	unsigned short		changed_vmods;
+	unsigned long		changed_indicators;
+	unsigned char		changed_groups;
+} XkbNameChangesRec,*XkbNameChangesPtr;
+
+typedef struct _XkbCompatChanges {
+	unsigned char		changed_groups;
+	unsigned short		first_si;
+	unsigned short		num_si;
+} XkbCompatChangesRec,*XkbCompatChangesPtr;
+
+typedef struct _XkbChanges {
+	unsigned short		 device_spec;
+	unsigned short		 state_changes;
+	XkbMapChangesRec	 map;
+	XkbControlsChangesRec	 ctrls;
+	XkbIndicatorChangesRec	 indicators;
+	XkbNameChangesRec	 names;
+	XkbCompatChangesRec	 compat;
+} XkbChangesRec, *XkbChangesPtr;
+
+	/*
+	 * These data structures are used to construct a keymap from 
+	 * a set of components or to list components in the server
+	 * database.
+	 */
+typedef struct _XkbComponentNames {
+	char *			 keymap;
+	char *			 keycodes;
+	char *			 types;
+	char *			 compat;
+	char *			 symbols;
+	char *			 geometry;
+} XkbComponentNamesRec, *XkbComponentNamesPtr;
+
+typedef struct _XkbComponentName {
+	unsigned short		flags;
+	char *			name;
+} XkbComponentNameRec,*XkbComponentNamePtr;
+
+typedef struct _XkbComponentList {
+	int			num_keymaps;
+	int			num_keycodes;
+	int			num_types;
+	int			num_compat;
+	int			num_symbols;
+	int			num_geometry;
+	XkbComponentNamePtr	keymaps;
+	XkbComponentNamePtr 	keycodes;
+	XkbComponentNamePtr	types;
+	XkbComponentNamePtr	compat;
+	XkbComponentNamePtr	symbols;
+	XkbComponentNamePtr	geometry;
+} XkbComponentListRec, *XkbComponentListPtr;
+
+	/*
+	 * The following data structures describe and track changes to a 
+	 * non-keyboard extension device 
+	 */
+typedef struct _XkbDeviceLedInfo {
+	unsigned short			led_class;
+	unsigned short			led_id;
+	unsigned int			phys_indicators;
+	unsigned int			maps_present;
+	unsigned int			names_present;
+	unsigned int			state;
+	Atom 				names[XkbNumIndicators];
+	XkbIndicatorMapRec		maps[XkbNumIndicators];
+} XkbDeviceLedInfoRec,*XkbDeviceLedInfoPtr;
+
+typedef struct _XkbDeviceInfo {
+	char *			name;
+	Atom			type;
+	unsigned short		device_spec;
+	Bool			has_own_state;
+	unsigned short		supported;
+	unsigned short		unsupported;
+
+	unsigned short		num_btns;
+	XkbAction *		btn_acts;
+
+	unsigned short		sz_leds;
+	unsigned short		num_leds;
+	unsigned short		dflt_kbd_fb;
+	unsigned short		dflt_led_fb;
+	XkbDeviceLedInfoPtr	leds;
+} XkbDeviceInfoRec,*XkbDeviceInfoPtr;
+
+#define	XkbXI_DevHasBtnActs(d)	(((d)->num_btns>0)&&((d)->btn_acts!=NULL))
+#define	XkbXI_LegalDevBtn(d,b)	(XkbXI_DevHasBtnActs(d)&&((b)<(d)->num_btns))
+#define	XkbXI_DevHasLeds(d)	(((d)->num_leds>0)&&((d)->leds!=NULL))
+
+typedef struct _XkbDeviceLedChanges {
+	unsigned short		led_class;
+	unsigned short		led_id;
+	unsigned int		defined; /* names or maps changed */
+	struct _XkbDeviceLedChanges *next;
+} XkbDeviceLedChangesRec,*XkbDeviceLedChangesPtr;
+
+typedef struct _XkbDeviceChanges {
+	unsigned int		changed;
+	unsigned short		first_btn;
+	unsigned short		num_btns;
+	XkbDeviceLedChangesRec 	leds;
+} XkbDeviceChangesRec,*XkbDeviceChangesPtr;
+
+#endif /* _XKBSTR_H_ */

--- a/nx-X11/programs/Xserver/os/Imakefile
+++ b/nx-X11/programs/Xserver/os/Imakefile
@@ -114,12 +114,12 @@ BOOTSTRAPCFLAGS =
            SRCS = WaitFor.c access.c connection.c io.c $(COLOR_SRCS) \
                   osinit.c utils.c log.c auth.c mitauth.c secauth.c \
                   $(XDMAUTHSRCS) $(RPCSRCS) xdmcp.c OtherSources \
-                  transport.c $(SNPRINTF_SRCS) $(STRLCAT_SRCS) \
+                  xstrans.c $(SNPRINTF_SRCS) $(STRLCAT_SRCS) \
 		  xprintf.c
            OBJS = WaitFor.o access.o connection.o io.o $(COLOR_OBJS) \
                   osinit.o utils.o log.o auth.o mitauth.o secauth.o \
                   $(XDMAUTHOBJS) $(RPCOBJS) xdmcp.o OtherObjects \
-                  transport.o $(SNPRINTF_OBJS) $(STRLCAT_OBJS) \
+                  xstrans.o $(SNPRINTF_OBJS) $(STRLCAT_OBJS) \
 		  xprintf.o
 
 #if UseMemLeak
@@ -135,7 +135,7 @@ BOOTSTRAPCFLAGS =
 #if HasPam && HasPamMisc
     PAM_DEFINES = -DUSE_PAM
 #endif
-        DEFINES = -DXSERV_t -DTRANS_SERVER $(CONNECTION_FLAGS) $(MEM_DEFINES) \
+        DEFINES = $(CONNECTION_FLAGS) $(MEM_DEFINES) \
 		  $(XDMAUTHDEFS) $(RPCDEFS) $(SIGNAL_DEFINES) $(OS_DEFINES) \
 		  $(RGB_DEFINES) $(GETPEER_DEFINES) \
 		  $(RANDOM_DEFINES) $(BUGMSG) $(XTRANS_FAILDEFINES) $(NX_DEFINES)
@@ -172,8 +172,6 @@ SpecialCObjectRule(auth,$(ICONFIGFILES),$(XDMCP_DEFINES))
 SpecialCObjectRule(xdmauth,$(ICONFIGFILES),$(XDMCP_DEFINES))
 SpecialCObjectRule(xdmcp,$(ICONFIGFILES),$(SOCK_DEFINES) $(XDMCP_DEFINES))
 SpecialCObjectRule(connection,$(ICONFIGFILES),$(SOCK_DEFINES) $(XDMCP_DEFINES))
-SpecialCObjectRule(transport,$(ICONFIGFILES),$(TRANS_INCLUDES) $(CONN_DEFINES) $(SOCK_DEFINES))
-LinkSourceFile(transport.c,$(TRANSCOMMSRC))
 SpecialCObjectRule(osinit,$(ICONFIGFILES),$(ADM_DEFINES))
 SpecialCObjectRule(WaitFor,$(ICONFIGFILES),$(EXT_DEFINES))
 SpecialCObjectRule(io,$(ICONFIGFILES),$(EXT_DEFINES))

--- a/nx-X11/programs/Xserver/os/access.c
+++ b/nx-X11/programs/Xserver/os/access.c
@@ -1699,7 +1699,7 @@ GetHosts (
         for (host = validhosts; host; host = host->next)
 	{
 	    len = host->len;
-            if ((ptr + sizeof(xHostEntry) + len) > (data + n))
+            if ((ptr + sizeof(xHostEntry) + len) > ((unsigned char *) *data + n))
                 break;
 	    ((xHostEntry *)ptr)->family = host->family;
 	    ((xHostEntry *)ptr)->length = len;

--- a/nx-X11/programs/Xserver/os/access.c
+++ b/nx-X11/programs/Xserver/os/access.c
@@ -1171,7 +1171,7 @@ ResetHosts (char *display)
     struct dn_naddr 	dnaddr, *dnaddrp, *dnet_addr();
 #endif
     int			family = 0;
-    void		*addr;
+    void		*addr = NULL;
     int 		len;
 
     siTypesInitialize();
@@ -1309,8 +1309,8 @@ ResetHosts (char *display)
 		    for (a = addresses ; a != NULL ; a = a->ai_next) {
 			len = a->ai_addrlen;
 			f = ConvertAddr(a->ai_addr,&len,(void **)&addr);
-			if ( (family == f) || 
-			     ((family == FamilyWild) && (f != -1)) ) {
+			if (addr && ((family == f) ||
+			    ((family == FamilyWild) && (f != -1)))) {
 			    NewHost(f, addr, len, FALSE);
 			}			
 		    }
@@ -1778,7 +1778,7 @@ InvalidHost (
     ClientPtr			client)
 {
     int 			family;
-    void			*addr;
+    void			*addr = NULL;
     register HOST 		*selfhost, *host;
 
     if (!AccessEnabled)   /* just let them in */
@@ -1809,11 +1809,11 @@ InvalidHost (
     for (host = validhosts; host; host = host->next)
     {
 	if ((host->family == FamilyServerInterpreted)) {
-	    if (siAddrMatch (family, addr, len, host, client)) {
+	    if (addr && siAddrMatch (family, addr, len, host, client)) {
 		return (0);
 	    }
 	} else {
-	    if (addrEqual (family, addr, len, host))
+	    if (addr && addrEqual (family, addr, len, host))
 		return (0);
 	}
 
@@ -2085,7 +2085,7 @@ siHostnameAddrMatch(int family, void * addr, int len,
 	struct addrinfo *addresses;
 	struct addrinfo *a;
 	int f, hostaddrlen;
-	void * hostaddr;
+	void * hostaddr = NULL;
 
 	if (siAddrLen >= sizeof(hostname)) 
 	    return FALSE;
@@ -2097,7 +2097,7 @@ siHostnameAddrMatch(int family, void * addr, int len,
 	    for (a = addresses ; a != NULL ; a = a->ai_next) {
 		hostaddrlen = a->ai_addrlen;
 		f = ConvertAddr(a->ai_addr,&hostaddrlen,&hostaddr);
-		if ((f == family) && (len == hostaddrlen) &&
+		if ((f == family) && (len == hostaddrlen) && hostaddr &&
 		  (acmp (addr, hostaddr, len) == 0) ) {
 		    res = TRUE;
 		    break;

--- a/nx-X11/programs/Xserver/os/access.c
+++ b/nx-X11/programs/Xserver/os/access.c
@@ -64,6 +64,9 @@ SOFTWARE.
 
 #include <stdio.h>
 #include <stdlib.h>
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
 #include <nx-X11/Xtrans/Xtrans.h>
 #include <nx-X11/Xauth.h>
 #include <nx-X11/X.h>

--- a/nx-X11/programs/Xserver/os/access.c
+++ b/nx-X11/programs/Xserver/os/access.c
@@ -1809,7 +1809,7 @@ InvalidHost (
     for (host = validhosts; host; host = host->next)
     {
 	if ((host->family == FamilyServerInterpreted)) {
-	    if (addr && siAddrMatch (family, addr, len, host, client)) {
+	    if (siAddrMatch (family, addr, len, host, client)) {
 		return (0);
 	    }
 	} else {

--- a/nx-X11/programs/Xserver/os/connection.c
+++ b/nx-X11/programs/Xserver/os/connection.c
@@ -70,15 +70,9 @@ SOFTWARE.
 #endif
 #include <nx-X11/X.h>
 #include <nx-X11/Xproto.h>
-#ifndef XSERV_t
-# define XSERV_t
-#endif
-#ifndef TRANS_SERVER
-# define TRANS_SERVER
-#endif
-#ifndef TRANS_REOPEN
-# define TRANS_REOPEN
-#endif
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
 #include <nx-X11/Xtrans/Xtrans.h>
 #include <errno.h>
 #include <signal.h>

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -64,6 +64,9 @@ SOFTWARE.
 #include <nx-X11/Xwinsock.h>
 #endif
 #include <stdio.h>
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
 #include <nx-X11/Xtrans/Xtrans.h>
 #include <nx-X11/Xmd.h>
 #include <errno.h>

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -90,6 +90,9 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdio.h>
 #include "misc.h"
 #include <nx-X11/X.h>
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
 #include <nx-X11/Xtrans/Xtrans.h>
 #include "input.h"
 #include "dixfont.h"

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -141,7 +141,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #endif
 
 #ifdef XKB
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #endif
 #ifdef XCSECURITY
 #define _SECURITY_SERVER

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -144,7 +144,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #endif
 
 #ifdef XKB
-#include <xkbsrv.h>
+#include "xkbsrv.h"
 #endif
 #ifdef XCSECURITY
 #define _SECURITY_SERVER

--- a/nx-X11/programs/Xserver/os/xdmauth.c
+++ b/nx-X11/programs/Xserver/os/xdmauth.c
@@ -69,8 +69,8 @@ XdmAuthenticationValidator (ARRAY8Ptr privateData, ARRAY8Ptr incomingData,
 {
     XdmAuthKeyPtr	incoming;
 
-    XdmcpUnwrap (incomingData->data, &privateKey,
-			      incomingData->data,incomingData->length);
+    XdmcpUnwrap (incomingData->data, (unsigned char *)&privateKey,
+		             incomingData->data,incomingData->length);
     if (packet_type == ACCEPT) {
     	if (incomingData->length != 8)
 	    return FALSE;
@@ -89,7 +89,8 @@ XdmAuthenticationGenerator (ARRAY8Ptr privateData, ARRAY8Ptr outgoingData,
     outgoingData->data = 0;
     if (packet_type == REQUEST) {
 	if (XdmcpAllocARRAY8 (outgoingData, 8))
-	    XdmcpWrap (&rho, &privateKey, outgoingData->data, 8);
+            XdmcpWrap ((unsigned char *)&rho, (unsigned char *)&privateKey,
+                       outgoingData->data, 8);
     }
     return TRUE;
 }
@@ -99,7 +100,8 @@ XdmAuthenticationAddAuth (int name_len, char *name,
     int data_len, char *data)
 {
     Bool    ret;
-    XdmcpUnwrap (data, (unsigned char *)&privateKey, data, data_len);
+    XdmcpUnwrap ((unsigned char *)data, (unsigned char *)&privateKey,
+                (unsigned char *)data, data_len);
     authFromXDMCP = TRUE;
     ret = AddAuthorization (name_len, name, data_len, data);
     authFromXDMCP = FALSE;
@@ -152,11 +154,11 @@ XdmAuthenticationInit (char *cookie, int cookie_len)
     }
     XdmcpGenerateKey (&rho);
     XdmcpRegisterAuthentication (XdmAuthenticationName, XdmAuthenticationNameLen,
-				 (unsigned char *)&rho,
+                                 (char *)&rho,
 				 sizeof (rho),
-				 XdmAuthenticationValidator,
-				 XdmAuthenticationGenerator,
-				 XdmAuthenticationAddAuth);
+                                 (ValidatorFunc)XdmAuthenticationValidator,
+                                 (GeneratorFunc)XdmAuthenticationGenerator,
+                                 (AddAuthorFunc)XdmAuthenticationAddAuth);
 }
 
 #endif /* XDMCP */
@@ -387,7 +389,7 @@ XdmCheckCookie (unsigned short cookie_length, char *cookie,
     if (!plain)
 	return (XID) -1;
     for (auth = xdmAuth; auth; auth=auth->next) {
-	XdmcpUnwrap (cookie, (unsigned char *)&auth->key, plain, cookie_length);
+        XdmcpUnwrap ((unsigned char *)cookie, (unsigned char *)&auth->key, plain, cookie_length);
 	if ((client = XdmAuthorizationValidate (plain, cookie_length, &auth->rho, xclient, reason)) != NULL)
 	{
 	    client->next = xdmClients;
@@ -432,7 +434,7 @@ XdmToID (unsigned short cookie_length, char *cookie)
     if (!plain)
 	return (XID) -1;
     for (auth = xdmAuth; auth; auth=auth->next) {
-	XdmcpUnwrap (cookie, (unsigned char *)&auth->key, plain, cookie_length);
+        XdmcpUnwrap ((unsigned char *)cookie, (unsigned char *)&auth->key, plain, cookie_length);
 	if ((client = XdmAuthorizationValidate (plain, cookie_length, &auth->rho, NULL, NULL)) != NULL)
 	{
 	    free (client);

--- a/nx-X11/programs/Xserver/os/xdmauth.c
+++ b/nx-X11/programs/Xserver/os/xdmauth.c
@@ -39,6 +39,9 @@ from The Open Group.
 
 #include <stdio.h>
 #include <nx-X11/X.h>
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
 #include <nx-X11/Xtrans/Xtrans.h>
 #include "os.h"
 #include "osdep.h"

--- a/nx-X11/programs/Xserver/os/xdmcp.c
+++ b/nx-X11/programs/Xserver/os/xdmcp.c
@@ -19,6 +19,10 @@
 
 #ifdef WIN32
 #include <nx-X11/Xwinsock.h>
+#define XSERV_t
+#define TRANS_SERVER
+#define TRANS_REOPEN
+#include <nx-X11/Xtrans/Xtrans.h>
 #endif
 
 #include <nx-X11/Xos.h>

--- a/nx-X11/programs/Xserver/os/xstrans.c
+++ b/nx-X11/programs/Xserver/os/xstrans.c
@@ -1,0 +1,17 @@
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#endif
+
+#include <nx-X11/Xfuncproto.h>
+
+/* ErrorF is used by xtrans */
+#ifndef HAVE_DIX_CONFIG_H
+extern _X_EXPORT void
+ErrorF(const char *f, ...)
+_X_ATTRIBUTE_PRINTF(1, 2);
+#endif
+
+#define TRANS_REOPEN
+#define TRANS_SERVER
+#define XSERV_t
+#include <nx-X11/Xtrans/transport.c>

--- a/nx-X11/programs/Xserver/xkb/Imakefile
+++ b/nx-X11/programs/Xserver/xkb/Imakefile
@@ -55,7 +55,7 @@ XF86INCLUDES = -I$(XF86COMSRC) -I$(XF86OSSRC)
 	      `pkg-config --cflags-only-I pixman-1`
    LINTLIBS = ../dix/llib-ldix.ln ../os/llib-los.ln
 
-DEFINES = -DXKB_IN_SERVER $(EXTRA_ALLOC_DEFINES) $(XKB_DDXDEFS) $(NX_DEFINES)
+DEFINES = $(EXTRA_ALLOC_DEFINES) $(XKB_DDXDEFS) $(NX_DEFINES)
 XKB_DEFINES = -DXKB_BASE_DIRECTORY=\"$(LIBDIR)/xkb\" $(XKB_DISABLE)
 
 NormalLibraryObjectRule()

--- a/nx-X11/programs/Xserver/xkb/Imakefile
+++ b/nx-X11/programs/Xserver/xkb/Imakefile
@@ -72,12 +72,6 @@ AllTarget($(XF86_OBJS))
 
 SpecialCObjectRule(xkbInit,$(ICONFIGFILES),$(XKB_DEFINES))
 
-XCOMM avoid clash between XKBMisc.c and xkbmisc.c on NT
-LinkSourceFile(XKBMisc.c,$(XLIBSRC))
-LinkSourceFile(XKBMAlloc.c,$(XLIBSRC))
-LinkSourceFile(XKBAlloc.c,$(XLIBSRC))
-LinkSourceFile(XKBGAlloc.c,$(XLIBSRC))
-
 LinkSourceFile(modinit.h,../Xext/extmod)
 
 #if BuildLibraries

--- a/nx-X11/programs/Xserver/xkb/XKBAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBAlloc.c
@@ -46,7 +46,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 
 #endif /* XKB_IN_SERVER */

--- a/nx-X11/programs/Xserver/xkb/XKBAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBAlloc.c
@@ -1,0 +1,498 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#elif defined(HAVE_CONFIG_H)
+#include <config.h>
+#endif
+
+#ifndef XKB_IN_SERVER
+
+#include <stdio.h>
+#include "Xlibint.h"
+#include "XKBlibint.h"
+#include <nx-X11/extensions/XKBgeom.h>
+#include <nx-X11/extensions/XKBproto.h>
+#include "XKBlibint.h"
+
+#else 
+
+#include <stdio.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
+#include "misc.h"
+#include "inputstr.h"
+#include <nx-X11/extensions/XKBsrv.h>
+#include <nx-X11/extensions/XKBgeom.h>
+
+#endif /* XKB_IN_SERVER */
+
+/***===================================================================***/
+
+/*ARGSUSED*/
+Status
+XkbAllocCompatMap(XkbDescPtr xkb,unsigned which,unsigned nSI)
+{
+XkbCompatMapPtr	compat;
+XkbSymInterpretRec *prev_interpret;
+
+    if (!xkb)
+	return BadMatch;
+    if (xkb->compat) {
+	if (xkb->compat->size_si>=nSI)
+	    return Success;
+	compat= xkb->compat;
+	compat->size_si= nSI;
+	if (compat->sym_interpret==NULL)
+	    compat->num_si= 0;
+	prev_interpret = compat->sym_interpret;
+	compat->sym_interpret= _XkbTypedRealloc(compat->sym_interpret,
+						     nSI,XkbSymInterpretRec);
+	if (compat->sym_interpret==NULL) {
+	    _XkbFree(prev_interpret);
+	    compat->size_si= compat->num_si= 0;
+	    return BadAlloc;
+	}
+	if (compat->num_si!=0) {
+	    _XkbClearElems(compat->sym_interpret,compat->num_si,
+					compat->size_si-1,XkbSymInterpretRec);
+	}
+	return Success;
+    }
+    compat= _XkbTypedCalloc(1,XkbCompatMapRec);
+    if (compat==NULL)
+	return BadAlloc;
+    if (nSI>0) {
+	compat->sym_interpret= _XkbTypedCalloc(nSI,XkbSymInterpretRec);
+	if (!compat->sym_interpret) {
+	    _XkbFree(compat);
+	    return BadAlloc;
+	}
+    }
+    compat->size_si= nSI;
+    compat->num_si= 0;
+    bzero((char *)&compat->groups[0],XkbNumKbdGroups*sizeof(XkbModsRec));
+    xkb->compat= compat;
+    return Success;
+}
+
+
+void
+XkbFreeCompatMap(XkbDescPtr xkb,unsigned which,Bool freeMap)
+{
+register XkbCompatMapPtr compat;
+
+    if ((xkb==NULL)||(xkb->compat==NULL))
+	return;
+    compat= xkb->compat;
+    if (freeMap)
+	which= XkbAllCompatMask;
+    if (which&XkbGroupCompatMask)
+	bzero((char *)&compat->groups[0],XkbNumKbdGroups*sizeof(XkbModsRec));
+    if (which&XkbSymInterpMask) {
+	if ((compat->sym_interpret)&&(compat->size_si>0))
+	    _XkbFree(compat->sym_interpret);
+	compat->size_si= compat->num_si= 0;
+	compat->sym_interpret= NULL;
+    }
+    if (freeMap) {
+	_XkbFree(compat);
+	xkb->compat= NULL;
+    }
+    return;
+}
+
+/***===================================================================***/
+
+Status
+XkbAllocNames(XkbDescPtr xkb,unsigned which,int nTotalRG,int nTotalAliases)
+{
+XkbNamesPtr	names;
+
+    if (xkb==NULL)
+	return BadMatch;
+    if (xkb->names==NULL) {
+	xkb->names = _XkbTypedCalloc(1,XkbNamesRec);
+	if (xkb->names==NULL)
+	    return BadAlloc;
+    }
+    names= xkb->names;
+    if ((which&XkbKTLevelNamesMask)&&(xkb->map!=NULL)&&(xkb->map->types!=NULL)){
+	register int	i;
+	XkbKeyTypePtr	type;
+
+	type= xkb->map->types;
+	for (i=0;i<xkb->map->num_types;i++,type++) {
+	    if (type->level_names==NULL) {
+		type->level_names= _XkbTypedCalloc(type->num_levels,Atom);
+		if (type->level_names==NULL)
+		    return BadAlloc;
+	    }
+	}
+    }
+    if ((which&XkbKeyNamesMask)&&(names->keys==NULL)) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code)) 
+	    return BadValue;
+	names->keys= _XkbTypedCalloc((xkb->max_key_code+1),XkbKeyNameRec);
+	if (names->keys==NULL)
+	    return BadAlloc;
+    }
+    if ((which&XkbKeyAliasesMask)&&(nTotalAliases>0)) {
+	if (names->key_aliases==NULL) {
+	    names->key_aliases= _XkbTypedCalloc(nTotalAliases,XkbKeyAliasRec);
+	}
+	else if (nTotalAliases>names->num_key_aliases) {
+	    XkbKeyAliasRec *prev_aliases = names->key_aliases;
+
+	    names->key_aliases= _XkbTypedRealloc(names->key_aliases,
+						nTotalAliases,XkbKeyAliasRec);
+	    if (names->key_aliases!=NULL) {
+		_XkbClearElems(names->key_aliases,names->num_key_aliases,
+						nTotalAliases-1,XkbKeyAliasRec);
+	    } else {
+		_XkbFree(prev_aliases);
+	    }
+	}
+	if (names->key_aliases==NULL) {
+	    names->num_key_aliases= 0;
+	    return BadAlloc;
+	}
+	names->num_key_aliases= nTotalAliases;
+    }
+    if ((which&XkbRGNamesMask)&&(nTotalRG>0)) {
+	if (names->radio_groups==NULL) {
+	    names->radio_groups= _XkbTypedCalloc(nTotalRG,Atom);
+	}
+	else if (nTotalRG>names->num_rg) {
+	    Atom *prev_radio_groups = names->radio_groups;
+
+	    names->radio_groups= _XkbTypedRealloc(names->radio_groups,nTotalRG,
+									Atom);
+	    if (names->radio_groups!=NULL) {
+		_XkbClearElems(names->radio_groups,names->num_rg,nTotalRG-1,
+									Atom);
+	    } else {
+		_XkbFree(prev_radio_groups);
+	    }
+	}
+	if (names->radio_groups==NULL)
+	    return BadAlloc;
+	names->num_rg= nTotalRG;
+    }
+    return Success;
+}
+
+void
+XkbFreeNames(XkbDescPtr xkb,unsigned which,Bool freeMap)
+{
+XkbNamesPtr	names;
+
+    if ((xkb==NULL)||(xkb->names==NULL))
+	return;
+    names= xkb->names;
+    if (freeMap)
+	which= XkbAllNamesMask; 
+    if (which&XkbKTLevelNamesMask) {
+	XkbClientMapPtr	map= xkb->map;
+	if ((map!=NULL)&&(map->types!=NULL)) {
+	    register int 		i;
+	    register XkbKeyTypePtr	type;
+	    type= map->types;
+	    for (i=0;i<map->num_types;i++,type++) {
+		if (type->level_names!=NULL) {
+		    _XkbFree(type->level_names);
+		    type->level_names= NULL;
+		}
+	    }
+	}
+    }
+    if ((which&XkbKeyNamesMask)&&(names->keys!=NULL)) {
+	_XkbFree(names->keys);
+	names->keys= NULL;
+	names->num_keys= 0;
+    }
+    if ((which&XkbKeyAliasesMask)&&(names->key_aliases)){
+	_XkbFree(names->key_aliases);
+	names->key_aliases=NULL;
+	names->num_key_aliases=0;
+    }
+    if ((which&XkbRGNamesMask)&&(names->radio_groups)) {
+	_XkbFree(names->radio_groups);
+	names->radio_groups= NULL;
+	names->num_rg= 0;
+    }
+    if (freeMap) {
+	_XkbFree(names);
+	xkb->names= NULL;
+    }
+    return;
+}
+
+/***===================================================================***/
+
+/*ARGSUSED*/
+Status
+XkbAllocControls(XkbDescPtr xkb,unsigned which)
+{
+    if (xkb==NULL)
+	return BadMatch;
+
+    if (xkb->ctrls==NULL) {
+	xkb->ctrls= _XkbTypedCalloc(1,XkbControlsRec);
+	if (!xkb->ctrls)
+	    return BadAlloc;
+    }
+    return Success;
+}
+
+/*ARGSUSED*/
+void
+XkbFreeControls(XkbDescPtr xkb,unsigned which,Bool freeMap)
+{
+    if (freeMap && (xkb!=NULL) && (xkb->ctrls!=NULL)) {
+	_XkbFree(xkb->ctrls);
+	xkb->ctrls= NULL;
+    }
+    return;
+}
+
+/***===================================================================***/
+
+Status 
+XkbAllocIndicatorMaps(XkbDescPtr xkb)
+{
+    if (xkb==NULL)
+	return BadMatch;
+    if (xkb->indicators==NULL) {
+	xkb->indicators= _XkbTypedCalloc(1,XkbIndicatorRec);
+	if (!xkb->indicators)
+	    return BadAlloc;
+    }
+    return Success;
+}
+
+void
+XkbFreeIndicatorMaps(XkbDescPtr xkb)
+{
+    if ((xkb!=NULL)&&(xkb->indicators!=NULL)) {
+	_XkbFree(xkb->indicators);
+	xkb->indicators= NULL;
+    }
+    return;
+}
+
+/***====================================================================***/
+
+XkbDescRec	*
+XkbAllocKeyboard(void)
+{
+XkbDescRec *xkb;
+
+    xkb = _XkbTypedCalloc(1,XkbDescRec);
+    if (xkb)
+	xkb->device_spec= XkbUseCoreKbd;
+    return xkb;
+}
+
+void
+XkbFreeKeyboard(XkbDescPtr xkb,unsigned which,Bool freeAll)
+{
+    if (xkb==NULL)
+	return;
+    if (freeAll)
+	which= XkbAllComponentsMask;
+    if (which&XkbClientMapMask)
+	XkbFreeClientMap(xkb,XkbAllClientInfoMask,True);
+    if (which&XkbServerMapMask)
+	XkbFreeServerMap(xkb,XkbAllServerInfoMask,True);
+    if (which&XkbCompatMapMask)
+	XkbFreeCompatMap(xkb,XkbAllCompatMask,True);
+    if (which&XkbIndicatorMapMask)
+	XkbFreeIndicatorMaps(xkb);
+    if (which&XkbNamesMask)
+	XkbFreeNames(xkb,XkbAllNamesMask,True);
+    if ((which&XkbGeometryMask) && (xkb->geom!=NULL))
+	XkbFreeGeometry(xkb->geom,XkbGeomAllMask,True);
+    if (which&XkbControlsMask)
+	XkbFreeControls(xkb,XkbAllControlsMask,True);
+    if (freeAll)
+	_XkbFree(xkb);
+    return;
+}
+
+/***====================================================================***/
+
+XkbDeviceLedInfoPtr
+XkbAddDeviceLedInfo(XkbDeviceInfoPtr devi,unsigned ledClass,unsigned ledId)
+{
+XkbDeviceLedInfoPtr	devli;
+register int		i;
+
+    if ((!devi)||(!XkbSingleXIClass(ledClass))||(!XkbSingleXIId(ledId)))
+	return NULL;
+    for (i=0,devli=devi->leds;i<devi->num_leds;i++,devli++) {
+	if ((devli->led_class==ledClass)&&(devli->led_id==ledId))
+	    return devli;
+    }
+    if (devi->num_leds>=devi->sz_leds) {
+	XkbDeviceLedInfoRec *prev_leds = devi->leds;
+	
+	if (devi->sz_leds>0)	devi->sz_leds*= 2;
+	else			devi->sz_leds= 1;
+	devi->leds= _XkbTypedRealloc(devi->leds,devi->sz_leds,
+							XkbDeviceLedInfoRec);
+	if (!devi->leds) {
+	    _XkbFree(prev_leds);
+	    devi->sz_leds= devi->num_leds= 0;
+	    return NULL;
+	}
+	i= devi->num_leds;
+	for (devli=&devi->leds[i];i<devi->sz_leds;i++,devli++) {
+	    bzero(devli,sizeof(XkbDeviceLedInfoRec));
+	    devli->led_class= XkbXINone;
+	    devli->led_id= XkbXINone;
+	}
+    }
+    devli= &devi->leds[devi->num_leds++];
+    bzero(devli,sizeof(XkbDeviceLedInfoRec));
+    devli->led_class= ledClass;
+    devli->led_id= ledId;
+    return devli;
+}
+
+Status
+XkbResizeDeviceButtonActions(XkbDeviceInfoPtr devi,unsigned newTotal)
+{
+    XkbAction *prev_btn_acts;
+
+    if ((!devi)||(newTotal>255))
+	return BadValue;
+    if ((devi->btn_acts!=NULL)&&(newTotal==devi->num_btns))
+	return Success;
+    if (newTotal==0) {
+	if (devi->btn_acts!=NULL) {
+	    _XkbFree(devi->btn_acts);
+	    devi->btn_acts= NULL;
+	}
+	devi->num_btns= 0;
+	return Success;
+    }
+    prev_btn_acts = devi->btn_acts;
+    devi->btn_acts= _XkbTypedRealloc(devi->btn_acts,newTotal,XkbAction);
+    if (devi->btn_acts==NULL) {
+	_XkbFree(prev_btn_acts);
+	devi->num_btns= 0;
+	return BadAlloc;
+    }
+    if (newTotal>devi->num_btns) {
+	XkbAction *act;
+	act= &devi->btn_acts[devi->num_btns];
+	bzero((char *)act,(newTotal-devi->num_btns)*sizeof(XkbAction));
+    }
+    devi->num_btns= newTotal;
+    return Success;
+}
+
+/*ARGSUSED*/
+XkbDeviceInfoPtr
+XkbAllocDeviceInfo(unsigned deviceSpec,unsigned nButtons,unsigned szLeds)
+{
+XkbDeviceInfoPtr	devi;
+
+    devi= _XkbTypedCalloc(1,XkbDeviceInfoRec);
+    if (devi!=NULL) {
+	devi->device_spec= deviceSpec;
+	devi->has_own_state= False;
+	devi->num_btns= 0;
+	devi->btn_acts= NULL;
+	if (nButtons>0) {
+	    devi->num_btns= nButtons;
+	    devi->btn_acts= _XkbTypedCalloc(nButtons,XkbAction);
+	    if (!devi->btn_acts) {
+		_XkbFree(devi);
+		return NULL;
+	    }
+	}
+	devi->dflt_kbd_fb= XkbXINone;
+	devi->dflt_led_fb= XkbXINone;
+	devi->num_leds= 0;
+	devi->sz_leds= 0;
+	devi->leds= NULL;
+	if (szLeds>0) {
+	    devi->sz_leds= szLeds;
+	    devi->leds= _XkbTypedCalloc(szLeds,XkbDeviceLedInfoRec);
+	    if (!devi->leds) {
+		if (devi->btn_acts)
+		    _XkbFree(devi->btn_acts);
+		_XkbFree(devi);
+		return NULL;
+	    }
+	}
+    }
+    return devi;
+}
+
+
+void 
+XkbFreeDeviceInfo(XkbDeviceInfoPtr devi,unsigned which,Bool freeDevI)
+{
+    if (devi) {
+	if (freeDevI) {
+	    which= XkbXI_AllDeviceFeaturesMask;
+	    if (devi->name) {
+		_XkbFree(devi->name);
+		devi->name= NULL;
+	    }
+	}
+	if ((which&XkbXI_ButtonActionsMask)&&(devi->btn_acts)) {
+	    _XkbFree(devi->btn_acts);
+	    devi->num_btns= 0;
+	    devi->btn_acts= NULL;
+	}
+	if ((which&XkbXI_IndicatorsMask)&&(devi->leds)) {
+	    register int i;
+	    if ((which&XkbXI_IndicatorsMask)==XkbXI_IndicatorsMask) {
+		_XkbFree(devi->leds);
+		devi->sz_leds= devi->num_leds= 0;
+		devi->leds= NULL;
+	    }
+	    else {
+		XkbDeviceLedInfoPtr	devli;
+		for (i=0,devli=devi->leds;i<devi->num_leds;i++,devli++) {
+		    if (which&XkbXI_IndicatorMapsMask)
+			 bzero((char *)&devli->maps[0],sizeof(devli->maps));
+		    else bzero((char *)&devli->names[0],sizeof(devli->names));
+		}
+	    }
+	}
+	if (freeDevI)
+	    _XkbFree(devi);
+    }
+    return;
+}

--- a/nx-X11/programs/Xserver/xkb/XKBAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBAlloc.c
@@ -30,16 +30,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <config.h>
 #endif
 
-#ifndef XKB_IN_SERVER
-
-#include <stdio.h>
-#include "Xlibint.h"
-#include "XKBlibint.h"
-#include "xkbgeom.h"
-#include <nx-X11/extensions/XKBproto.h>
-#include "XKBlibint.h"
-
-#else 
 
 #include <stdio.h>
 #include <nx-X11/X.h>
@@ -49,7 +39,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 
-#endif /* XKB_IN_SERVER */
 
 /***===================================================================***/
 

--- a/nx-X11/programs/Xserver/xkb/XKBAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBAlloc.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdio.h>
 #include "Xlibint.h"
 #include "XKBlibint.h"
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include <nx-X11/extensions/XKBproto.h>
 #include "XKBlibint.h"
 
@@ -47,7 +47,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #endif /* XKB_IN_SERVER */
 

--- a/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
@@ -30,15 +30,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <config.h>
 #endif
 
-#ifndef XKB_IN_SERVER
-
-#include <stdio.h>
-#include "Xlibint.h"
-#include "XKBlibint.h"
-#include "xkbgeom.h"
-#include <nx-X11/extensions/XKBproto.h>
-
-#else 
 
 #include <stdio.h>
 #include <nx-X11/X.h>
@@ -48,7 +39,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 
-#endif /* XKB_IN_SERVER */
 
 #ifdef X_NOT_POSIX
 #define Size_t unsigned int

--- a/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdio.h>
 #include "Xlibint.h"
 #include "XKBlibint.h"
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include <nx-X11/extensions/XKBproto.h>
 
 #else 
@@ -46,7 +46,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #endif /* XKB_IN_SERVER */
 

--- a/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
@@ -1,0 +1,1016 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#elif defined(HAVE_CONFIG_H)
+#include <config.h>
+#endif
+
+#ifndef XKB_IN_SERVER
+
+#include <stdio.h>
+#include "Xlibint.h"
+#include "XKBlibint.h"
+#include <nx-X11/extensions/XKBgeom.h>
+#include <nx-X11/extensions/XKBproto.h>
+
+#else 
+
+#include <stdio.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
+#include "misc.h"
+#include "inputstr.h"
+#include <nx-X11/extensions/XKBsrv.h>
+#include <nx-X11/extensions/XKBgeom.h>
+
+#endif /* XKB_IN_SERVER */
+
+#ifdef X_NOT_POSIX
+#define Size_t unsigned int
+#else
+#define Size_t size_t
+#endif
+
+/***====================================================================***/
+
+static void 
+_XkbFreeGeomLeafElems(	Bool			freeAll,
+			int			first,
+			int 			count,
+			unsigned short *	num_inout,
+			unsigned short *	sz_inout,
+			char **			elems,
+			unsigned int		elem_sz)
+{
+    if ((freeAll)||(*elems==NULL)) {
+	*num_inout= *sz_inout= 0;
+	if (*elems!=NULL) {
+	    _XkbFree(*elems);
+	    *elems= NULL;
+	}	
+	return;
+    }
+
+    if ((first>=(*num_inout))||(first<0)||(count<1))
+	return;
+
+    if (first+count>=(*num_inout)) { 
+	/* truncating the array is easy */
+	(*num_inout)= first;
+    }
+    else {
+	char *	ptr;
+	int 	extra;
+	ptr= *elems;
+	extra= ((*num_inout)-(first+count))*elem_sz;
+	if (extra>0)
+	    memmove(&ptr[first*elem_sz],&ptr[(first+count)*elem_sz],extra);
+	(*num_inout)-= count;
+    }
+    return;
+}
+
+typedef void (*ContentsClearFunc)(
+		char *		/* priv */
+);
+
+static void 
+_XkbFreeGeomNonLeafElems(	Bool			freeAll,
+				int			first,
+				int 			count,
+				unsigned short *	num_inout,
+				unsigned short *	sz_inout,
+				char **			elems,
+				unsigned int		elem_sz,
+				ContentsClearFunc	freeFunc)
+{
+register int i;
+register char *ptr;
+
+    if (freeAll) {
+	first= 0;
+	count= (*num_inout);
+    }
+    else if ((first>=(*num_inout))||(first<0)||(count<1))
+	return;
+    else if (first+count>(*num_inout))
+	count= (*num_inout)-first;
+    if (*elems==NULL)
+	return;
+
+    if (freeFunc) {
+	ptr= *elems;
+	ptr+= first*elem_sz;
+	for (i=0;i<count;i++) {
+	    (*freeFunc)(ptr);
+	    ptr+= elem_sz;
+	}
+    }
+    if (freeAll) {
+	(*num_inout)= (*sz_inout)= 0;
+	if (*elems) {
+	    _XkbFree(*elems);
+	    *elems= NULL;
+	}
+    }
+    else if (first+count>=(*num_inout))
+	*num_inout= first;
+    else {
+	i= ((*num_inout)-(first+count))*elem_sz;
+	ptr= *elems;
+	memmove(&ptr[first*elem_sz],&ptr[(first+count)*elem_sz],i);
+	(*num_inout)-= count;
+    }
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearProperty(char *prop_in)
+{
+XkbPropertyPtr	prop= (XkbPropertyPtr)prop_in;
+
+    if (prop->name) {
+	_XkbFree(prop->name);
+	prop->name= NULL;
+    }
+    if (prop->value) {
+	_XkbFree(prop->value);
+	prop->value= NULL;
+    }
+    return;
+}
+
+void
+XkbFreeGeomProperties(	XkbGeometryPtr	geom,
+			int		first,
+			int		count,
+			Bool		freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&geom->num_properties,&geom->sz_properties,
+				(char **)&geom->properties,
+				sizeof(XkbPropertyRec),_XkbClearProperty);
+    return;
+}
+
+/***====================================================================***/
+
+void
+XkbFreeGeomKeyAliases(	XkbGeometryPtr	geom,
+			int		first,
+			int		count,
+			Bool		freeAll)
+{	
+    _XkbFreeGeomLeafElems(freeAll,first,count,
+				&geom->num_key_aliases,&geom->sz_key_aliases,
+				(char **)&geom->key_aliases,
+				sizeof(XkbKeyAliasRec));
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearColor(char *color_in)
+{
+XkbColorPtr	color= (XkbColorPtr)color_in;
+
+    if (color->spec)
+	_XkbFree(color->spec);
+    return;
+}
+
+void
+XkbFreeGeomColors(XkbGeometryPtr geom,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&geom->num_colors,&geom->sz_colors,
+				(char **)&geom->colors,
+				sizeof(XkbColorRec),_XkbClearColor);
+    return;
+}
+
+/***====================================================================***/
+
+void
+XkbFreeGeomPoints(XkbOutlinePtr outline,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomLeafElems(freeAll,first,count,
+				&outline->num_points,&outline->sz_points,
+				(char **)&outline->points,
+				sizeof(XkbPointRec));
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearOutline(char *outline_in)
+{
+XkbOutlinePtr	outline= (XkbOutlinePtr)outline_in;
+
+    if (outline->points!=NULL)
+	XkbFreeGeomPoints(outline,0,outline->num_points,True);
+    return;
+}
+
+void
+XkbFreeGeomOutlines(XkbShapePtr	shape,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&shape->num_outlines,&shape->sz_outlines,
+				(char **)&shape->outlines,
+				sizeof(XkbOutlineRec),_XkbClearOutline);
+	
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearShape(char *shape_in)
+{
+XkbShapePtr	shape= (XkbShapePtr)shape_in;
+
+    if (shape->outlines)
+	XkbFreeGeomOutlines(shape,0,shape->num_outlines,True);
+    return;
+}
+
+void
+XkbFreeGeomShapes(XkbGeometryPtr geom,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&geom->num_shapes,&geom->sz_shapes,
+				(char **)&geom->shapes,
+				sizeof(XkbShapeRec),_XkbClearShape);
+    return;
+}
+
+/***====================================================================***/
+
+void 
+XkbFreeGeomOverlayKeys(XkbOverlayRowPtr row,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomLeafElems(freeAll,first,count,
+				&row->num_keys,&row->sz_keys,
+				(char **)&row->keys,
+				sizeof(XkbOverlayKeyRec));
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearOverlayRow(char *row_in)
+{
+XkbOverlayRowPtr	row= (XkbOverlayRowPtr)row_in;
+
+    if (row->keys!=NULL)
+	XkbFreeGeomOverlayKeys(row,0,row->num_keys,True);
+    return;
+}
+
+void
+XkbFreeGeomOverlayRows(XkbOverlayPtr overlay,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&overlay->num_rows,&overlay->sz_rows,
+				(char **)&overlay->rows,
+				sizeof(XkbOverlayRowRec),_XkbClearOverlayRow);
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearOverlay(char *overlay_in)
+{
+XkbOverlayPtr	overlay= (XkbOverlayPtr)overlay_in;
+
+    if (overlay->rows!=NULL)
+	XkbFreeGeomOverlayRows(overlay,0,overlay->num_rows,True);
+    return;
+}
+
+void
+XkbFreeGeomOverlays(XkbSectionPtr section,int first,int	count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&section->num_overlays,&section->sz_overlays,
+				(char **)&section->overlays,
+				sizeof(XkbOverlayRec),_XkbClearOverlay);
+    return;
+}
+
+/***====================================================================***/
+
+void
+XkbFreeGeomKeys(XkbRowPtr row,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomLeafElems(freeAll,first,count,
+				&row->num_keys,&row->sz_keys,
+				(char **)&row->keys,
+				sizeof(XkbKeyRec));
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearRow(char *row_in)
+{
+XkbRowPtr	row= (XkbRowPtr)row_in;
+
+    if (row->keys!=NULL)
+	XkbFreeGeomKeys(row,0,row->num_keys,True);
+    return;
+}
+
+void
+XkbFreeGeomRows(XkbSectionPtr section,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&section->num_rows,&section->sz_rows,
+				(char **)&section->rows,
+				sizeof(XkbRowRec),_XkbClearRow);
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearSection(char *section_in)
+{
+XkbSectionPtr	section= (XkbSectionPtr)section_in;
+
+    if (section->rows!=NULL)
+	XkbFreeGeomRows(section,0,section->num_rows,True);
+    if (section->doodads!=NULL) {
+	XkbFreeGeomDoodads(section->doodads,section->num_doodads,True);
+	section->doodads= NULL;
+    }
+    return;
+}
+
+void
+XkbFreeGeomSections(XkbGeometryPtr geom,int first,int count,Bool freeAll)
+{
+    _XkbFreeGeomNonLeafElems(freeAll,first,count,
+				&geom->num_sections,&geom->sz_sections,
+				(char **)&geom->sections,
+				sizeof(XkbSectionRec),_XkbClearSection);
+    return;
+}
+
+/***====================================================================***/
+
+static void
+_XkbClearDoodad(char *doodad_in)
+{
+XkbDoodadPtr	doodad= (XkbDoodadPtr)doodad_in;
+
+    switch (doodad->any.type) {
+   	case XkbTextDoodad: 
+	    {
+		if (doodad->text.text!=NULL) {
+		    _XkbFree(doodad->text.text);
+		    doodad->text.text= NULL;
+		}
+		if (doodad->text.font!=NULL) {
+		    _XkbFree(doodad->text.font);
+		    doodad->text.font= NULL;
+		}
+	    }
+	    break;
+   	case XkbLogoDoodad: 
+	    {
+		if (doodad->logo.logo_name!=NULL) {
+		    _XkbFree(doodad->logo.logo_name);
+		    doodad->logo.logo_name= NULL;
+		}
+	    }
+	    break;
+    }
+    return;
+}
+
+void
+XkbFreeGeomDoodads(XkbDoodadPtr doodads,int nDoodads,Bool freeAll)
+{
+register int 		i;
+register XkbDoodadPtr	doodad;
+
+    if (doodads) {
+	for (i=0,doodad= doodads;i<nDoodads;i++,doodad++) {
+	    _XkbClearDoodad((char *)doodad);
+	}
+	if (freeAll)
+	    _XkbFree(doodads);
+    }
+    return;
+}
+
+void
+XkbFreeGeometry(XkbGeometryPtr geom,unsigned which,Bool freeMap)
+{
+    if (geom==NULL)
+	return;
+    if (freeMap)
+	which= XkbGeomAllMask;
+    if ((which&XkbGeomPropertiesMask)&&(geom->properties!=NULL))
+	XkbFreeGeomProperties(geom,0,geom->num_properties,True);
+    if ((which&XkbGeomColorsMask)&&(geom->colors!=NULL))
+	XkbFreeGeomColors(geom,0,geom->num_colors,True);
+    if ((which&XkbGeomShapesMask)&&(geom->shapes!=NULL))
+	XkbFreeGeomShapes(geom,0,geom->num_shapes,True);
+    if ((which&XkbGeomSectionsMask)&&(geom->sections!=NULL))
+	XkbFreeGeomSections(geom,0,geom->num_sections,True);
+    if ((which&XkbGeomDoodadsMask)&&(geom->doodads!= NULL)) {
+	XkbFreeGeomDoodads(geom->doodads,geom->num_doodads,True);
+	geom->doodads= NULL;
+	geom->num_doodads= geom->sz_doodads= 0;
+    }
+    if ((which&XkbGeomKeyAliasesMask)&&(geom->key_aliases!=NULL))
+	XkbFreeGeomKeyAliases(geom,0,geom->num_key_aliases,True);
+    if (freeMap) {
+	if (geom->label_font!=NULL) {
+	    _XkbFree(geom->label_font);
+	    geom->label_font= NULL;
+	}
+	_XkbFree(geom);
+    }
+    return;
+}
+
+/***====================================================================***/
+
+static Status
+_XkbGeomAlloc(	XPointer *		old,
+		unsigned short *	num,
+		unsigned short *	total,
+		int			num_new,
+		Size_t			sz_elem)
+{
+    if (num_new<1)
+	return Success;
+    if ((*old)==NULL)
+	*num= *total= 0;
+
+    if ((*num)+num_new<=(*total))
+	return Success;
+
+    *total= (*num)+num_new;
+    if ((*old)!=NULL)
+	 (*old)= (XPointer)_XkbRealloc((*old),(*total)*sz_elem);
+    else (*old)= (XPointer)_XkbCalloc((*total),sz_elem);
+    if ((*old)==NULL) {
+	*total= *num= 0;
+	return BadAlloc;
+    }
+
+    if (*num>0) {
+	char *tmp= (char *)(*old);
+	bzero(&tmp[sz_elem*(*num)],(num_new*sz_elem));
+    }
+    return Success;
+}
+
+#define	_XkbAllocProps(g,n) _XkbGeomAlloc((XPointer *)&(g)->properties,\
+				&(g)->num_properties,&(g)->sz_properties,\
+				(n),sizeof(XkbPropertyRec))
+#define	_XkbAllocColors(g,n) _XkbGeomAlloc((XPointer *)&(g)->colors,\
+				&(g)->num_colors,&(g)->sz_colors,\
+				(n),sizeof(XkbColorRec))
+#define	_XkbAllocShapes(g,n) _XkbGeomAlloc((XPointer *)&(g)->shapes,\
+				&(g)->num_shapes,&(g)->sz_shapes,\
+				(n),sizeof(XkbShapeRec))
+#define	_XkbAllocSections(g,n) _XkbGeomAlloc((XPointer *)&(g)->sections,\
+				&(g)->num_sections,&(g)->sz_sections,\
+				(n),sizeof(XkbSectionRec))
+#define	_XkbAllocDoodads(g,n) _XkbGeomAlloc((XPointer *)&(g)->doodads,\
+				&(g)->num_doodads,&(g)->sz_doodads,\
+				(n),sizeof(XkbDoodadRec))
+#define	_XkbAllocKeyAliases(g,n) _XkbGeomAlloc((XPointer *)&(g)->key_aliases,\
+				&(g)->num_key_aliases,&(g)->sz_key_aliases,\
+				(n),sizeof(XkbKeyAliasRec))
+
+#define	_XkbAllocOutlines(s,n) _XkbGeomAlloc((XPointer *)&(s)->outlines,\
+				&(s)->num_outlines,&(s)->sz_outlines,\
+				(n),sizeof(XkbOutlineRec))
+#define	_XkbAllocRows(s,n) _XkbGeomAlloc((XPointer *)&(s)->rows,\
+				&(s)->num_rows,&(s)->sz_rows,\
+				(n),sizeof(XkbRowRec))
+#define	_XkbAllocPoints(o,n) _XkbGeomAlloc((XPointer *)&(o)->points,\
+				&(o)->num_points,&(o)->sz_points,\
+				(n),sizeof(XkbPointRec))
+#define	_XkbAllocKeys(r,n) _XkbGeomAlloc((XPointer *)&(r)->keys,\
+				&(r)->num_keys,&(r)->sz_keys,\
+				(n),sizeof(XkbKeyRec))
+#define	_XkbAllocOverlays(s,n) _XkbGeomAlloc((XPointer *)&(s)->overlays,\
+				&(s)->num_overlays,&(s)->sz_overlays,\
+				(n),sizeof(XkbOverlayRec))
+#define	_XkbAllocOverlayRows(o,n) _XkbGeomAlloc((XPointer *)&(o)->rows,\
+				&(o)->num_rows,&(o)->sz_rows,\
+				(n),sizeof(XkbOverlayRowRec))
+#define	_XkbAllocOverlayKeys(r,n) _XkbGeomAlloc((XPointer *)&(r)->keys,\
+				&(r)->num_keys,&(r)->sz_keys,\
+				(n),sizeof(XkbOverlayKeyRec))
+    
+Status
+XkbAllocGeomProps(XkbGeometryPtr geom,int nProps)
+{
+    return _XkbAllocProps(geom,nProps);
+}
+
+Status
+XkbAllocGeomColors(XkbGeometryPtr geom,int nColors)
+{
+    return _XkbAllocColors(geom,nColors);
+}
+
+Status
+XkbAllocGeomKeyAliases(XkbGeometryPtr geom,int nKeyAliases)
+{
+    return _XkbAllocKeyAliases(geom,nKeyAliases);
+}
+
+Status
+XkbAllocGeomShapes(XkbGeometryPtr geom,int nShapes)
+{
+    return _XkbAllocShapes(geom,nShapes);
+}
+
+Status
+XkbAllocGeomSections(XkbGeometryPtr geom,int nSections)
+{
+    return _XkbAllocSections(geom,nSections);
+}
+
+Status
+XkbAllocGeomOverlays(XkbSectionPtr section,int nOverlays)
+{
+    return _XkbAllocOverlays(section,nOverlays);
+}
+
+Status
+XkbAllocGeomOverlayRows(XkbOverlayPtr overlay,int nRows)
+{
+    return _XkbAllocOverlayRows(overlay,nRows);
+}
+
+Status
+XkbAllocGeomOverlayKeys(XkbOverlayRowPtr row,int nKeys)
+{
+    return _XkbAllocOverlayKeys(row,nKeys);
+}
+
+Status
+XkbAllocGeomDoodads(XkbGeometryPtr geom,int nDoodads)
+{
+    return _XkbAllocDoodads(geom,nDoodads);
+}
+
+Status
+XkbAllocGeomSectionDoodads(XkbSectionPtr section,int nDoodads)
+{
+    return _XkbAllocDoodads(section,nDoodads);
+}
+
+Status
+XkbAllocGeomOutlines(XkbShapePtr shape,int nOL)
+{
+    return _XkbAllocOutlines(shape,nOL);
+}
+
+Status
+XkbAllocGeomRows(XkbSectionPtr section,int nRows)
+{
+    return _XkbAllocRows(section,nRows);
+}
+
+Status
+XkbAllocGeomPoints(XkbOutlinePtr ol,int nPts)
+{
+    return _XkbAllocPoints(ol,nPts);
+}
+
+Status
+XkbAllocGeomKeys(XkbRowPtr row,int nKeys)
+{
+    return _XkbAllocKeys(row,nKeys);
+}
+
+Status
+XkbAllocGeometry(XkbDescPtr xkb,XkbGeometrySizesPtr sizes)
+{
+XkbGeometryPtr	geom;
+Status		rtrn;
+
+    if (xkb->geom==NULL) {
+	xkb->geom= _XkbTypedCalloc(1,XkbGeometryRec);
+	if (!xkb->geom)
+	    return BadAlloc;
+    }
+    geom= xkb->geom;
+    if ((sizes->which&XkbGeomPropertiesMask)&&
+	((rtrn=_XkbAllocProps(geom,sizes->num_properties))!=Success)) {
+	goto BAIL;
+    }
+    if ((sizes->which&XkbGeomColorsMask)&&
+	((rtrn=_XkbAllocColors(geom,sizes->num_colors))!=Success)) {
+	goto BAIL;
+    }
+    if ((sizes->which&XkbGeomShapesMask)&&
+	((rtrn=_XkbAllocShapes(geom,sizes->num_shapes))!=Success)) {
+	goto BAIL;
+    }
+    if ((sizes->which&XkbGeomSectionsMask)&&
+	((rtrn=_XkbAllocSections(geom,sizes->num_sections))!=Success)) {
+	goto BAIL;
+    }
+    if ((sizes->which&XkbGeomDoodadsMask)&&
+	((rtrn=_XkbAllocDoodads(geom,sizes->num_doodads))!=Success)) {
+	goto BAIL;
+    }
+    if ((sizes->which&XkbGeomKeyAliasesMask)&&
+	((rtrn=_XkbAllocKeyAliases(geom,sizes->num_key_aliases))!=Success)) {
+	goto BAIL;
+    }
+    return Success;
+BAIL:
+    XkbFreeGeometry(geom,XkbGeomAllMask,True);
+    xkb->geom= NULL;
+    return rtrn;
+}
+
+/***====================================================================***/
+
+XkbPropertyPtr
+XkbAddGeomProperty(XkbGeometryPtr geom,char *name,char *value)
+{
+register int i;
+register XkbPropertyPtr prop;
+
+    if ((!geom)||(!name)||(!value))
+	return NULL;
+    for (i=0,prop=geom->properties;i<geom->num_properties;i++,prop++) {
+	if ((prop->name)&&(strcmp(name,prop->name)==0)) {
+	    if (prop->value)
+		_XkbFree(prop->value);
+	    prop->value= (char *)_XkbAlloc(strlen(value)+1);
+	    if (prop->value)
+		strcpy(prop->value,value);
+	    return prop;
+	}    
+    }
+    if ((geom->num_properties>=geom->sz_properties)&&
+					(_XkbAllocProps(geom,1)!=Success)) {
+	return NULL;
+    }
+    prop= &geom->properties[geom->num_properties];
+    prop->name= (char *)_XkbAlloc(strlen(name)+1);
+    if (!name)
+	return NULL;
+    strcpy(prop->name,name);
+    prop->value= (char *)_XkbAlloc(strlen(value)+1);
+    if (!value) {
+	_XkbFree(prop->name);
+	prop->name= NULL;
+	return NULL;
+    }
+    strcpy(prop->value,value);
+    geom->num_properties++;
+    return prop;
+}
+
+XkbKeyAliasPtr
+XkbAddGeomKeyAlias(XkbGeometryPtr geom,char *aliasStr,char *realStr)
+{
+register int i;
+register XkbKeyAliasPtr alias;
+
+    if ((!geom)||(!aliasStr)||(!realStr)||(!aliasStr[0])||(!realStr[0]))
+	return NULL;
+    for (i=0,alias=geom->key_aliases;i<geom->num_key_aliases;i++,alias++) {
+	if (strncmp(alias->alias,aliasStr,XkbKeyNameLength)==0) {
+	    bzero(alias->real,XkbKeyNameLength);
+	    strncpy(alias->real,realStr,XkbKeyNameLength);
+	    return alias;
+	}
+    }
+    if ((geom->num_key_aliases>=geom->sz_key_aliases)&&
+				(_XkbAllocKeyAliases(geom,1)!=Success)) {
+	return NULL;
+    }
+    alias= &geom->key_aliases[geom->num_key_aliases];
+    bzero(alias,sizeof(XkbKeyAliasRec));
+    strncpy(alias->alias,aliasStr,XkbKeyNameLength);
+    strncpy(alias->real,realStr,XkbKeyNameLength);
+    geom->num_key_aliases++;
+    return alias;
+}
+
+XkbColorPtr
+XkbAddGeomColor(XkbGeometryPtr geom,char *spec,unsigned int pixel)
+{
+register int i;
+register XkbColorPtr color;
+
+    if ((!geom)||(!spec))
+	return NULL;
+    for (i=0,color=geom->colors;i<geom->num_colors;i++,color++) {
+	if ((color->spec)&&(strcmp(color->spec,spec)==0)) {
+	    color->pixel= pixel;
+	    return color;
+	}
+    }
+    if ((geom->num_colors>=geom->sz_colors)&&
+					(_XkbAllocColors(geom,1)!=Success)) {
+	return NULL;
+    }
+    color= &geom->colors[geom->num_colors];
+    color->pixel= pixel;
+    color->spec= (char *)_XkbAlloc(strlen(spec)+1);
+    if (!color->spec)
+	return NULL;
+    strcpy(color->spec,spec);
+    geom->num_colors++;
+    return color;
+}
+
+XkbOutlinePtr
+XkbAddGeomOutline(XkbShapePtr shape,int sz_points)
+{
+XkbOutlinePtr	outline;
+
+    if ((!shape)||(sz_points<0))
+	return NULL;
+    if ((shape->num_outlines>=shape->sz_outlines)&&
+					(_XkbAllocOutlines(shape,1)!=Success)) {
+	return NULL;
+    }
+    outline= &shape->outlines[shape->num_outlines];
+    bzero(outline,sizeof(XkbOutlineRec));
+    if ((sz_points>0)&&(_XkbAllocPoints(outline,sz_points)!=Success))
+	return NULL;
+    shape->num_outlines++;
+    return outline;
+}
+
+XkbShapePtr
+XkbAddGeomShape(XkbGeometryPtr geom,Atom name,int sz_outlines)
+{
+XkbShapePtr	shape;
+register int	i;
+
+    if ((!geom)||(!name)||(sz_outlines<0))
+	return NULL;
+    if (geom->num_shapes>0) {
+	for (shape=geom->shapes,i=0;i<geom->num_shapes;i++,shape++) {
+	    if (name==shape->name)
+		return shape;
+	}
+    }
+    if ((geom->num_shapes>=geom->sz_shapes)&&
+					(_XkbAllocShapes(geom,1)!=Success))
+	return NULL;
+    shape= &geom->shapes[geom->num_shapes];
+    bzero(shape,sizeof(XkbShapeRec));
+    if ((sz_outlines>0)&&(_XkbAllocOutlines(shape,sz_outlines)!=Success))
+	return NULL;
+    shape->name= name;
+    shape->primary= shape->approx= NULL;
+    geom->num_shapes++;
+    return shape;
+}
+
+XkbKeyPtr
+XkbAddGeomKey(XkbRowPtr row)
+{
+XkbKeyPtr	key;
+    if (!row)
+	return NULL;
+    if ((row->num_keys>=row->sz_keys)&&(_XkbAllocKeys(row,1)!=Success))
+	return NULL;
+    key= &row->keys[row->num_keys++];
+    bzero(key,sizeof(XkbKeyRec));
+    return key;
+}
+
+XkbRowPtr
+XkbAddGeomRow(XkbSectionPtr section,int sz_keys)
+{
+XkbRowPtr	row;
+
+    if ((!section)||(sz_keys<0))
+	return NULL;
+    if ((section->num_rows>=section->sz_rows)&&
+    					(_XkbAllocRows(section,1)!=Success))
+	return NULL;
+    row= &section->rows[section->num_rows];
+    bzero(row,sizeof(XkbRowRec));
+    if ((sz_keys>0)&&(_XkbAllocKeys(row,sz_keys)!=Success))
+	return NULL;
+    section->num_rows++;
+    return row;
+}
+
+XkbSectionPtr
+XkbAddGeomSection(	XkbGeometryPtr	geom,
+			Atom		name,
+			int		sz_rows,
+			int		sz_doodads,
+			int		sz_over)
+{
+register int	i;
+XkbSectionPtr	section;
+
+    if ((!geom)||(name==None)||(sz_rows<0))
+	return NULL;
+    for (i=0,section=geom->sections;i<geom->num_sections;i++,section++) {
+	if (section->name!=name)
+	    continue;
+	if (((sz_rows>0)&&(_XkbAllocRows(section,sz_rows)!=Success))||
+	    ((sz_doodads>0)&&(_XkbAllocDoodads(section,sz_doodads)!=Success))||
+	    ((sz_over>0)&&(_XkbAllocOverlays(section,sz_over)!=Success)))
+	    return NULL;
+	return section;
+    }
+    if ((geom->num_sections>=geom->sz_sections)&&
+					(_XkbAllocSections(geom,1)!=Success))
+	return NULL;
+    section= &geom->sections[geom->num_sections];
+    if ((sz_rows>0)&&(_XkbAllocRows(section,sz_rows)!=Success))
+	return NULL;
+    if ((sz_doodads>0)&&(_XkbAllocDoodads(section,sz_doodads)!=Success)) {
+	if (section->rows) {
+	    _XkbFree(section->rows);
+	    section->rows= NULL;
+	    section->sz_rows= section->num_rows= 0;
+	}
+	return NULL;
+    }
+    section->name= name;
+    geom->num_sections++;
+    return section;
+}
+
+XkbDoodadPtr
+XkbAddGeomDoodad(XkbGeometryPtr geom,XkbSectionPtr section,Atom name)
+{
+XkbDoodadPtr	old,doodad;
+register int	i,nDoodads;
+
+    if ((!geom)||(name==None))
+	return NULL;
+    if ((section!=NULL)&&(section->num_doodads>0)) {
+	old= section->doodads;
+	nDoodads= section->num_doodads;
+    }
+    else {
+	old= geom->doodads;
+	nDoodads= geom->num_doodads;
+    }
+    for (i=0,doodad=old;i<nDoodads;i++,doodad++) {
+	if (doodad->any.name==name)
+	    return doodad;
+    }
+    if (section) {
+	if ((section->num_doodads>=geom->sz_doodads)&&
+	    (_XkbAllocDoodads(section,1)!=Success)) {
+	    return NULL;
+	}
+	doodad= &section->doodads[section->num_doodads++];
+    }
+    else {
+	if ((geom->num_doodads>=geom->sz_doodads)&&
+					(_XkbAllocDoodads(geom,1)!=Success))
+	    return NULL;
+	doodad= &geom->doodads[geom->num_doodads++];
+    }
+    bzero(doodad,sizeof(XkbDoodadRec));
+    doodad->any.name= name;
+    return doodad;
+}
+
+XkbOverlayKeyPtr
+XkbAddGeomOverlayKey(	XkbOverlayPtr		overlay,
+			XkbOverlayRowPtr 	row,
+			char *			over,
+			char *			under)
+{
+register int	i;
+XkbOverlayKeyPtr key;
+XkbSectionPtr	section;
+XkbRowPtr	row_under;
+Bool		found;
+
+    if ((!overlay)||(!row)||(!over)||(!under))
+	return NULL;
+    section= overlay->section_under;
+    if (row->row_under>=section->num_rows)
+	return NULL;
+    row_under= &section->rows[row->row_under];
+    for (i=0,found=False;i<row_under->num_keys;i++) {
+	if (strncmp(under,row_under->keys[i].name.name,XkbKeyNameLength)==0) {
+	    found= True;
+	    break;
+	}
+    }
+    if (!found)
+   	return NULL; 
+    if ((row->num_keys>=row->sz_keys)&&(_XkbAllocOverlayKeys(row,1)!=Success))
+	return NULL;
+    key= &row->keys[row->num_keys];
+    strncpy(key->under.name,under,XkbKeyNameLength);
+    strncpy(key->over.name,over,XkbKeyNameLength);
+    row->num_keys++;
+    return key;
+}
+
+XkbOverlayRowPtr
+XkbAddGeomOverlayRow(XkbOverlayPtr overlay,int row_under,int sz_keys)
+{
+register int		i;
+XkbOverlayRowPtr	row;
+
+    if ((!overlay)||(sz_keys<0))
+	return NULL;
+    if (row_under>=overlay->section_under->num_rows)
+	return NULL;
+    for (i=0;i<overlay->num_rows;i++) {
+	if (overlay->rows[i].row_under==row_under) {
+	    row= &overlay->rows[i];
+	    if ((row->sz_keys<sz_keys)&&
+				(_XkbAllocOverlayKeys(row,sz_keys)!=Success)) {
+		return NULL;
+	    }
+	    return &overlay->rows[i];
+	}
+    }
+    if ((overlay->num_rows>=overlay->sz_rows)&&
+				(_XkbAllocOverlayRows(overlay,1)!=Success))
+	return NULL;
+    row= &overlay->rows[overlay->num_rows];
+    bzero(row,sizeof(XkbOverlayRowRec));
+    if ((sz_keys>0)&&(_XkbAllocOverlayKeys(row,sz_keys)!=Success))
+	return NULL;
+    row->row_under= row_under;
+    overlay->num_rows++;
+    return row;
+}
+
+XkbOverlayPtr
+XkbAddGeomOverlay(XkbSectionPtr section,Atom name,int sz_rows)
+{
+register int	i;
+XkbOverlayPtr	overlay;
+
+    if ((!section)||(name==None)||(sz_rows==0))
+	return NULL;
+
+    for (i=0,overlay=section->overlays;i<section->num_overlays;i++,overlay++) {
+	if (overlay->name==name) {
+	    if ((sz_rows>0)&&(_XkbAllocOverlayRows(overlay,sz_rows)!=Success))
+		return NULL;
+	    return overlay;
+	}
+    }
+    if ((section->num_overlays>=section->sz_overlays)&&
+				(_XkbAllocOverlays(section,1)!=Success))
+	return NULL;
+    overlay= &section->overlays[section->num_overlays];
+    if ((sz_rows>0)&&(_XkbAllocOverlayRows(overlay,sz_rows)!=Success))
+	return NULL;
+    overlay->name= name;
+    overlay->section_under= section;
+    section->num_overlays++;
+    return overlay;
+}

--- a/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBGAlloc.c
@@ -45,7 +45,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 
 #endif /* XKB_IN_SERVER */

--- a/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
@@ -47,7 +47,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include <nx-X11/keysym.h>
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #endif /* XKB_IN_SERVER */
 

--- a/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
@@ -30,15 +30,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <config.h>
 #endif
 
-#ifndef XKB_IN_SERVER
-
-#include <stdio.h>
-#include "Xlibint.h"
-#include <nx-X11/extensions/XKBproto.h>
-#include <nx-X11/keysym.h>
-#include "XKBlibint.h"
-
-#else 
 
 #include <stdio.h>
 #include <nx-X11/X.h>
@@ -49,7 +40,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
-#endif /* XKB_IN_SERVER */
 
 /***====================================================================***/
 

--- a/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
@@ -37,7 +37,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include <nx-X11/keysym.h>
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
 

--- a/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMAlloc.c
@@ -1,0 +1,1017 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#elif defined(HAVE_CONFIG_H)
+#include <config.h>
+#endif
+
+#ifndef XKB_IN_SERVER
+
+#include <stdio.h>
+#include "Xlibint.h"
+#include <nx-X11/extensions/XKBproto.h>
+#include <nx-X11/keysym.h>
+#include "XKBlibint.h"
+
+#else 
+
+#include <stdio.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
+#include "misc.h"
+#include "inputstr.h"
+#include <nx-X11/keysym.h>
+#define	XKBSRV_NEED_FILE_FUNCS
+#include <nx-X11/extensions/XKBsrv.h>
+
+#endif /* XKB_IN_SERVER */
+
+/***====================================================================***/
+
+Status
+XkbAllocClientMap(XkbDescPtr xkb,unsigned which,unsigned nTotalTypes)
+{
+register int	i;
+XkbClientMapPtr map;
+
+    if ((xkb==NULL)||((nTotalTypes>0)&&(nTotalTypes<XkbNumRequiredTypes)))
+	return BadValue;
+    if ((which&XkbKeySymsMask)&&
+	((!XkbIsLegalKeycode(xkb->min_key_code))||
+	 (!XkbIsLegalKeycode(xkb->max_key_code))||
+	 (xkb->max_key_code<xkb->min_key_code))) {
+#ifdef DEBUG
+fprintf(stderr,"bad keycode (%d,%d) in XkbAllocClientMap\n",
+				xkb->min_key_code,xkb->max_key_code);
+#endif
+	return BadValue;
+    }
+
+    if (xkb->map==NULL) {
+	map= _XkbTypedCalloc(1,XkbClientMapRec);
+	if (map==NULL)
+	    return BadAlloc;
+	xkb->map= map;
+    }
+    else map= xkb->map;
+
+    if ((which&XkbKeyTypesMask)&&(nTotalTypes>0)) {
+	if (map->types==NULL) {
+	    map->types= _XkbTypedCalloc(nTotalTypes,XkbKeyTypeRec);
+	    if (map->types==NULL)
+		return BadAlloc;
+	    map->num_types= 0;
+	    map->size_types= nTotalTypes;
+	}
+	else if (map->size_types<nTotalTypes) {
+	    XkbKeyTypeRec *prev_types = map->types;
+
+	    map->types= _XkbTypedRealloc(map->types,nTotalTypes,XkbKeyTypeRec);
+	    if (map->types==NULL) {
+		_XkbFree(prev_types);
+		map->num_types= map->size_types= 0;
+		return BadAlloc;
+	    }
+	    map->size_types= nTotalTypes;
+	    bzero(&map->types[map->num_types], 
+		  ((map->size_types-map->num_types)*sizeof(XkbKeyTypeRec)));
+	}
+    }
+    if (which&XkbKeySymsMask) {
+	int nKeys= XkbNumKeys(xkb);
+	if (map->syms==NULL) {
+	    map->size_syms= (nKeys*15)/10;
+	    map->syms= _XkbTypedCalloc(map->size_syms,KeySym);
+	    if (!map->syms) {
+		map->size_syms= 0;
+		return BadAlloc;
+	    }
+	    map->num_syms= 1;
+	    map->syms[0]= NoSymbol;
+	}
+	if (map->key_sym_map==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->key_sym_map= _XkbTypedCalloc(i,XkbSymMapRec);
+	    if (map->key_sym_map==NULL)
+		return BadAlloc;
+	}
+    }
+    if (which&XkbModifierMapMask) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code))
+	    return BadMatch;
+	if (map->modmap==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->modmap= _XkbTypedCalloc(i,unsigned char);
+	    if (map->modmap==NULL)
+		return BadAlloc;
+	}
+    }
+    return Success;
+}
+
+Status
+XkbAllocServerMap(XkbDescPtr xkb,unsigned which,unsigned nNewActions)
+{
+register int	i;
+XkbServerMapPtr map;
+
+    if (xkb==NULL)
+	return BadMatch;
+    if (xkb->server==NULL) {
+	map= _XkbTypedCalloc(1,XkbServerMapRec);
+	if (map==NULL)
+	    return BadAlloc;
+	for (i=0;i<XkbNumVirtualMods;i++) {
+	    map->vmods[i]= XkbNoModifierMask;
+	}
+	xkb->server= map;
+    }
+    else map= xkb->server;
+    if (which&XkbExplicitComponentsMask) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code))
+	    return BadMatch;
+	if (map->explicit==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->explicit= _XkbTypedCalloc(i,unsigned char);
+	    if (map->explicit==NULL)
+		return BadAlloc;
+	}
+    }
+    if (which&XkbKeyActionsMask) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code))
+	    return BadMatch;
+        if (nNewActions<1)
+	    nNewActions= 1;
+	if (map->acts==NULL) {
+	    map->acts= _XkbTypedCalloc((nNewActions+1),XkbAction);
+	    if (map->acts==NULL)
+		return BadAlloc;
+	    map->num_acts= 1;
+	    map->size_acts= nNewActions+1;
+	}
+	else if ((map->size_acts-map->num_acts)<nNewActions) {
+	    unsigned need;
+	    XkbAction *prev_acts = map->acts;
+	    need= map->num_acts+nNewActions;
+	    map->acts= _XkbTypedRealloc(map->acts,need,XkbAction);
+	    if (map->acts==NULL) {
+		_XkbFree(prev_acts);
+	        map->num_acts= map->size_acts= 0;
+	        return BadAlloc;
+	    }
+	    map->size_acts= need;
+	    bzero(&map->acts[map->num_acts], 
+		    ((map->size_acts-map->num_acts)*sizeof(XkbAction)));
+	}
+	if (map->key_acts==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->key_acts= _XkbTypedCalloc(i,unsigned short);
+	    if (map->key_acts==NULL)
+		return BadAlloc;
+	}
+    }
+    if (which&XkbKeyBehaviorsMask) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code))
+	    return BadMatch;
+	if (map->behaviors==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->behaviors= _XkbTypedCalloc(i,XkbBehavior);
+	    if (map->behaviors==NULL)
+		return BadAlloc;
+	}
+    }
+    if (which&XkbVirtualModMapMask) {
+	if ((!XkbIsLegalKeycode(xkb->min_key_code))||
+	    (!XkbIsLegalKeycode(xkb->max_key_code))||
+	    (xkb->max_key_code<xkb->min_key_code))
+	    return BadMatch;
+	if (map->vmodmap==NULL) {
+	    i= xkb->max_key_code+1;
+	    map->vmodmap= _XkbTypedCalloc(i,unsigned short);
+	    if (map->vmodmap==NULL)
+		return BadAlloc;
+	}
+    }
+    return Success;
+}
+
+/***====================================================================***/
+
+Status
+XkbCopyKeyType(XkbKeyTypePtr from,XkbKeyTypePtr into)
+{
+    if ((!from)||(!into))
+	return BadMatch;
+    if (into->map) {
+	_XkbFree(into->map);
+	into->map= NULL;
+    }
+    if (into->preserve) {
+	_XkbFree(into->preserve);
+	into->preserve= NULL;
+    }
+    if (into->level_names) {
+	_XkbFree(into->level_names);
+	into->level_names= NULL;
+    }
+    *into= *from;
+    if ((from->map)&&(into->map_count>0)) {
+	into->map= _XkbTypedCalloc(into->map_count,XkbKTMapEntryRec);
+	if (!into->map)
+	    return BadAlloc;
+	memcpy(into->map,from->map,into->map_count*sizeof(XkbKTMapEntryRec));
+    }
+    if ((from->preserve)&&(into->map_count>0)) {
+	into->preserve= _XkbTypedCalloc(into->map_count,XkbModsRec);
+	if (!into->preserve)
+	    return BadAlloc;
+	memcpy(into->preserve,from->preserve,
+				into->map_count*sizeof(XkbModsRec));
+    }
+    if ((from->level_names)&&(into->num_levels>0)) {
+	into->level_names= _XkbTypedCalloc(into->num_levels,Atom);
+	if (!into->level_names)
+	    return BadAlloc;
+	memcpy(into->level_names,from->level_names,
+				 into->num_levels*sizeof(Atom));
+    }
+    return Success;
+}
+
+Status
+XkbCopyKeyTypes(XkbKeyTypePtr from,XkbKeyTypePtr into,int num_types)
+{
+register int i,rtrn;
+
+    if ((!from)||(!into)||(num_types<0))
+	return BadMatch;
+    for (i=0;i<num_types;i++) {
+	if ((rtrn= XkbCopyKeyType(from++,into++))!=Success)
+	    return rtrn;
+    }
+    return Success;
+}
+
+XkbKeyTypePtr
+XkbAddKeyType(	XkbDescPtr	xkb,
+		Atom 		name,
+		int 		map_count,
+		Bool 		want_preserve,
+		int		num_lvls)
+{
+register int 	i;
+unsigned	tmp;
+XkbKeyTypePtr	type;
+XkbClientMapPtr	map;
+
+    if ((!xkb)||(num_lvls<1))
+	return NULL;
+    map= xkb->map;
+    if ((map)&&(map->types)) {
+	for (i=0;i<map->num_types;i++) {
+	    if (map->types[i].name==name) {
+		Status status;
+		status=XkbResizeKeyType(xkb,i,map_count,want_preserve,num_lvls);
+		return (status==Success?&map->types[i]:NULL);
+	    }
+	}
+    }
+    if ((!map)||(!map->types)||(!map->num_types<XkbNumRequiredTypes)) {
+	tmp= XkbNumRequiredTypes+1;
+	if (XkbAllocClientMap(xkb,XkbKeyTypesMask,tmp)!=Success)
+	    return NULL;
+	tmp= 0;
+	if (map->num_types<=XkbKeypadIndex)
+	    tmp|= XkbKeypadMask;
+	if (map->num_types<=XkbAlphabeticIndex)
+	    tmp|= XkbAlphabeticMask;
+	if (map->num_types<=XkbTwoLevelIndex)
+	    tmp|= XkbTwoLevelMask;
+	if (map->num_types<=XkbOneLevelIndex)
+	    tmp|= XkbOneLevelMask;
+	if (XkbInitCanonicalKeyTypes(xkb,tmp,XkbNoModifier)==Success) {
+	    for (i=0;i<map->num_types;i++) {
+		Status status;
+		if (map->types[i].name!=name)
+		    continue;
+		status=XkbResizeKeyType(xkb,i,map_count,want_preserve,num_lvls);
+		return (status==Success?&map->types[i]:NULL);
+	    }
+	}
+    }
+    if ((map->num_types<=map->size_types)&&
+	(XkbAllocClientMap(xkb,XkbKeyTypesMask,map->num_types+1)!=Success)) {
+	return NULL;
+    }
+    type= &map->types[map->num_types];
+    map->num_types++;
+    bzero((char *)type,sizeof(XkbKeyTypeRec));
+    type->num_levels=	num_lvls;
+    type->map_count=	map_count;
+    type->name=		name;
+    if (map_count>0) {
+	type->map=	_XkbTypedCalloc(map_count,XkbKTMapEntryRec);
+	if (!type->map) {
+	    map->num_types--;
+	    return NULL;
+	}
+	if (want_preserve) {
+	    type->preserve=	_XkbTypedCalloc(map_count,XkbModsRec);
+	    if (!type->preserve) {
+		_XkbFree(type->map);
+		map->num_types--;
+		return NULL;
+	    }
+	}
+    }
+    return type;
+}
+
+Status
+XkbResizeKeyType(	XkbDescPtr	xkb,
+			int		type_ndx,
+			int		map_count,
+			Bool		want_preserve,
+			int		new_num_lvls)
+{
+XkbKeyTypePtr	type;
+KeyCode		matchingKeys[XkbMaxKeyCount],nMatchingKeys;
+
+    if ((type_ndx<0)||(type_ndx>=xkb->map->num_types)||(map_count<0)||
+    							(new_num_lvls<1))
+	return BadValue;
+    switch (type_ndx) {
+	case XkbOneLevelIndex:
+	    if (new_num_lvls!=1)
+		return BadMatch;
+	    break;
+	case XkbTwoLevelIndex:
+	case XkbAlphabeticIndex:
+	case XkbKeypadIndex:
+	    if (new_num_lvls!=2)
+		return BadMatch;
+	    break;
+    }
+    type= &xkb->map->types[type_ndx];
+    if (map_count==0) {
+	if (type->map!=NULL)
+	    _XkbFree(type->map);
+	type->map= NULL;
+	if (type->preserve!=NULL)
+	    _XkbFree(type->preserve);
+	type->preserve= NULL;
+	type->map_count= 0;
+    }
+    else {
+	XkbKTMapEntryRec *prev_map = type->map;
+
+	if ((map_count>type->map_count)||(type->map==NULL))
+	    type->map=_XkbTypedRealloc(type->map,map_count,XkbKTMapEntryRec);
+	if (!type->map) {
+	    if (prev_map) 
+		_XkbFree(prev_map);
+	    return BadAlloc;
+	}
+	if (want_preserve) {
+	    XkbModsRec *prev_preserve = type->preserve;
+
+	    if ((map_count>type->map_count)||(type->preserve==NULL)) {
+		type->preserve= _XkbTypedRealloc(type->preserve,map_count,
+	     						    XkbModsRec);
+	    }
+	    if (!type->preserve) {
+		if (prev_preserve) 
+		    _XkbFree(prev_preserve);
+		return BadAlloc;
+	    }
+	}
+	else if (type->preserve!=NULL) {
+	    _XkbFree(type->preserve);
+	    type->preserve= NULL;
+	}
+	type->map_count= map_count;
+    }
+
+    if ((new_num_lvls>type->num_levels)||(type->level_names==NULL)) {
+	Atom * prev_level_names = type->level_names;
+
+	type->level_names=_XkbTypedRealloc(type->level_names,new_num_lvls,Atom);
+	if (!type->level_names) {
+	    if (prev_level_names) 
+		_XkbFree(prev_level_names);
+	    return BadAlloc;
+	}
+    }
+    /*
+     * Here's the theory:
+     *    If the width of the type changed, we might have to resize the symbol
+     * maps for any keys that use the type for one or more groups.  This is
+     * expensive, so we'll try to cull out any keys that are obviously okay:
+     * In any case:
+     *    - keys that have a group width <= the old width are okay (because
+     *      they could not possibly have been associated with the old type)
+     * If the key type increased in size:
+     *    - keys that already have a group width >= to the new width are okay
+     *    + keys that have a group width >= the old width but < the new width
+     *      might have to be enlarged.
+     * If the key type decreased in size:
+     *    - keys that have a group width > the old width don't have to be
+     *      resized (because they must have some other wider type associated 
+     *      with some group).
+     *    + keys that have a group width == the old width might have to be
+     *      shrunk.
+     * The possibilities marked with '+' require us to examine the key types
+     * associated with each group for the key.
+     */
+    bzero(matchingKeys,XkbMaxKeyCount*sizeof(KeyCode));
+    nMatchingKeys= 0;
+    if (new_num_lvls>type->num_levels) {
+	int	 		nTotal;
+	KeySym	*		newSyms;
+	int			width,match,nResize;
+	register int		i,g,nSyms;
+
+	nResize= 0;
+	for (nTotal=1,i=xkb->min_key_code;i<=xkb->max_key_code;i++) {
+	    width= XkbKeyGroupsWidth(xkb,i);
+	    if (width<type->num_levels)
+		continue;
+	    for (match=0,g=XkbKeyNumGroups(xkb,i)-1;(g>=0)&&(!match);g--) {
+		if (XkbKeyKeyTypeIndex(xkb,i,g)==type_ndx) {
+		    matchingKeys[nMatchingKeys++]= i;
+		    match= 1;
+		}
+	    }
+	    if ((!match)||(width>=new_num_lvls))
+		nTotal+= XkbKeyNumSyms(xkb,i);
+	    else {
+		nTotal+= XkbKeyNumGroups(xkb,i)*new_num_lvls;
+		nResize++;
+	    }
+	}
+	if (nResize>0) {
+	    int nextMatch;
+	    xkb->map->size_syms= (nTotal*12)/10;
+	    newSyms = _XkbTypedCalloc(xkb->map->size_syms,KeySym);
+	    if (newSyms==NULL)
+		return BadAlloc;
+	    nextMatch= 0;
+	    nSyms= 1;
+	    for (i=xkb->min_key_code;i<=xkb->max_key_code;i++) {
+		if (matchingKeys[nextMatch]==i) {
+		    KeySym *pOld;
+		    nextMatch++;
+		    width= XkbKeyGroupsWidth(xkb,i);
+		    pOld= XkbKeySymsPtr(xkb,i);
+		    for (g=XkbKeyNumGroups(xkb,i)-1;g>=0;g--) {
+			memcpy(&newSyms[nSyms+(new_num_lvls*g)],&pOld[width*g],
+							width*sizeof(KeySym));
+		    }
+		    xkb->map->key_sym_map[i].offset= nSyms;
+		    nSyms+= XkbKeyNumGroups(xkb,i)*new_num_lvls;
+		}
+		else {
+		    memcpy(&newSyms[nSyms],XkbKeySymsPtr(xkb,i),
+					XkbKeyNumSyms(xkb,i)*sizeof(KeySym));
+		    xkb->map->key_sym_map[i].offset= nSyms;
+		    nSyms+= XkbKeyNumSyms(xkb,i);
+		}
+	    }
+	    type->num_levels= new_num_lvls;
+	    _XkbFree(xkb->map->syms);
+	    xkb->map->syms= newSyms;
+	    xkb->map->num_syms= nSyms;
+	    return Success;
+	}
+    }
+    else if (new_num_lvls<type->num_levels) {
+	int 		width,match;
+	register int	g,i;
+	for (i=xkb->min_key_code;i<=xkb->max_key_code;i++) {
+	    width= XkbKeyGroupsWidth(xkb,i);
+	    if (width<type->num_levels)
+		continue;
+	    for (match=0,g=XkbKeyNumGroups(xkb,i)-1;(g>=0)&&(!match);g--) {
+		if (XkbKeyKeyTypeIndex(xkb,i,g)==type_ndx) {
+		    matchingKeys[nMatchingKeys++]= i;
+		    match= 1;
+		}
+	    }
+	}
+    }
+    if (nMatchingKeys>0) {
+	int 		key,firstClear;
+	register int	i,g;
+	if (new_num_lvls>type->num_levels)
+	     firstClear= type->num_levels;
+	else firstClear= new_num_lvls;
+	for (i=0;i<nMatchingKeys;i++) {
+	    KeySym *	pSyms;
+	    int		width,nClear;
+
+	    key= matchingKeys[i];
+	    width= XkbKeyGroupsWidth(xkb,key);
+	    nClear= width-firstClear;
+	    pSyms= XkbKeySymsPtr(xkb,key);
+	    for (g=XkbKeyNumGroups(xkb,key)-1;g>=0;g--) {
+		if (XkbKeyKeyTypeIndex(xkb,key,g)==type_ndx) {
+		    if (nClear>0)
+			bzero(&pSyms[g*width+firstClear],nClear*sizeof(KeySym));
+		}
+	    }
+	}
+    }
+    type->num_levels= new_num_lvls;
+    return Success;
+}
+
+KeySym *
+XkbResizeKeySyms(XkbDescPtr xkb,int key,int needed)
+{
+register int i,nSyms,nKeySyms;
+unsigned nOldSyms;
+KeySym	*newSyms;
+
+    if (needed==0) {
+	xkb->map->key_sym_map[key].offset= 0;
+	return xkb->map->syms;
+    }
+    nOldSyms= XkbKeyNumSyms(xkb,key);
+    if (nOldSyms>=(unsigned)needed) {
+	return XkbKeySymsPtr(xkb,key);
+    }
+    if (xkb->map->size_syms-xkb->map->num_syms>=(unsigned)needed) {
+	if (nOldSyms>0) {
+	    memcpy(&xkb->map->syms[xkb->map->num_syms],XkbKeySymsPtr(xkb,key),
+						nOldSyms*sizeof(KeySym));
+	}
+	if ((needed-nOldSyms)>0) {
+	    bzero(&xkb->map->syms[xkb->map->num_syms+XkbKeyNumSyms(xkb,key)],
+					(needed-nOldSyms)*sizeof(KeySym));
+	}
+	xkb->map->key_sym_map[key].offset = xkb->map->num_syms;
+	xkb->map->num_syms+= needed;
+	return &xkb->map->syms[xkb->map->key_sym_map[key].offset];
+    }
+    xkb->map->size_syms+= (needed>32?needed:32);
+    newSyms = _XkbTypedCalloc(xkb->map->size_syms,KeySym);
+    if (newSyms==NULL)
+	return NULL;
+    newSyms[0]= NoSymbol;
+    nSyms = 1;
+    for (i=xkb->min_key_code;i<=(int)xkb->max_key_code;i++) {
+	int nCopy;
+
+	nCopy= nKeySyms= XkbKeyNumSyms(xkb,i);
+	if ((nKeySyms==0)&&(i!=key))
+	    continue;
+	if (i==key)
+	    nKeySyms= needed;
+	if (nCopy!=0)
+	   memcpy(&newSyms[nSyms],XkbKeySymsPtr(xkb,i),nCopy*sizeof(KeySym));
+	if (nKeySyms>nCopy)
+	    bzero(&newSyms[nSyms+nCopy],(nKeySyms-nCopy)*sizeof(KeySym));
+	xkb->map->key_sym_map[i].offset = nSyms;
+	nSyms+= nKeySyms;
+    }
+    _XkbFree(xkb->map->syms);
+    xkb->map->syms = newSyms;
+    xkb->map->num_syms = nSyms;
+    return &xkb->map->syms[xkb->map->key_sym_map[key].offset];
+}
+
+static unsigned
+_ExtendRange(	unsigned int 	old_flags,
+		unsigned int	flag,
+		KeyCode		newKC,
+		KeyCode *	old_min,
+		unsigned char *	old_num)
+{
+    if ((old_flags&flag)==0) {
+	old_flags|= flag;
+	*old_min= newKC;
+	*old_num= 1;
+    }
+    else {
+	int	last= (*old_min)+(*old_num)-1;
+	if (newKC<*old_min) {
+	    *old_min= newKC;
+	    *old_num= (last-newKC)+1;
+	}
+	else if (newKC>last) {
+	    *old_num= (newKC-(*old_min))+1;
+	}
+    }
+    return old_flags;
+}
+
+Status
+XkbChangeKeycodeRange(	XkbDescPtr	xkb,
+			int 		minKC,
+			int 		maxKC,
+			XkbChangesPtr	changes)
+{
+int	tmp;
+
+    if ((!xkb)||(minKC<XkbMinLegalKeyCode)||(maxKC>XkbMaxLegalKeyCode))
+	return BadValue;
+    if (minKC>maxKC)
+	return BadMatch;
+    if (minKC<xkb->min_key_code) {
+	if (changes)
+	    changes->map.min_key_code= minKC;
+	tmp= xkb->min_key_code-minKC;
+	if (xkb->map)  {
+	    if (xkb->map->key_sym_map) {
+		bzero((char *)&xkb->map->key_sym_map[minKC],
+					tmp*sizeof(XkbSymMapRec));
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    				XkbKeySymsMask,minKC,
+	    					&changes->map.first_key_sym,
+	    					&changes->map.num_key_syms);
+		}
+	    }
+	    if (xkb->map->modmap) {
+		bzero((char *)&xkb->map->modmap[minKC],tmp);
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    				XkbModifierMapMask,minKC,
+	    					&changes->map.first_modmap_key,
+	    					&changes->map.num_modmap_keys);
+		}
+	    }
+	}
+	if (xkb->server) {
+	    if (xkb->server->behaviors) {
+		bzero((char *)&xkb->server->behaviors[minKC],
+						tmp*sizeof(XkbBehavior));
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbKeyBehaviorsMask,minKC,
+    					&changes->map.first_key_behavior,
+    					&changes->map.num_key_behaviors);
+		}
+	    }
+	    if (xkb->server->key_acts) {
+		bzero((char *)&xkb->server->key_acts[minKC],
+						tmp*sizeof(unsigned short));
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbKeyActionsMask,minKC,
+    					&changes->map.first_key_act,
+    					&changes->map.num_key_acts);
+		}
+	    }
+	    if (xkb->server->vmodmap) {
+		bzero((char *)&xkb->server->vmodmap[minKC],
+						tmp*sizeof(unsigned short));
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbVirtualModMapMask,minKC,
+		    			&changes->map.first_modmap_key,
+    					&changes->map.num_vmodmap_keys);
+		}
+	    }
+	}
+	if ((xkb->names)&&(xkb->names->keys)) {
+	    bzero((char *)&xkb->names->keys[minKC],tmp*sizeof(XkbKeyNameRec));
+	    if (changes) {
+		changes->names.changed= _ExtendRange(changes->names.changed,
+					XkbKeyNamesMask,minKC,
+					&changes->names.first_key,
+    					&changes->names.num_keys);
+	    }
+	}
+	xkb->min_key_code= minKC;
+    }
+    if (maxKC>xkb->max_key_code) {
+	if (changes)
+	    changes->map.max_key_code= maxKC;
+	tmp= maxKC-xkb->max_key_code;
+	if (xkb->map)  {
+	    if (xkb->map->key_sym_map) {
+		XkbSymMapRec *prev_key_sym_map = xkb->map->key_sym_map;
+
+		xkb->map->key_sym_map= _XkbTypedRealloc(xkb->map->key_sym_map,
+						(maxKC+1),XkbSymMapRec);
+		if (!xkb->map->key_sym_map) {
+		    _XkbFree(prev_key_sym_map);
+		    return BadAlloc;
+		}
+#ifdef NXAGENT_SERVER
+                bzero((char *)&xkb->map->key_sym_map[xkb->max_key_code+1],
+                                        tmp*sizeof(XkbSymMapRec));
+#else
+		bzero((char *)&xkb->map->key_sym_map[xkb->max_key_code],
+					tmp*sizeof(XkbSymMapRec));
+#endif
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    				XkbKeySymsMask,maxKC,
+	    					&changes->map.first_key_sym,
+	    					&changes->map.num_key_syms);
+		}
+	    }
+	    if (xkb->map->modmap) {
+		unsigned char *prev_modmap = xkb->map->modmap;
+
+		xkb->map->modmap= _XkbTypedRealloc(xkb->map->modmap,
+						(maxKC+1),unsigned char);
+		if (!xkb->map->modmap) {
+		    _XkbFree(prev_modmap);
+		    return BadAlloc;
+		}
+#ifdef NXAGENT_SERVER
+                bzero((char *)&xkb->map->modmap[xkb->max_key_code+1],tmp);
+#else
+		bzero((char *)&xkb->map->modmap[xkb->max_key_code],tmp);
+#endif
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    				XkbModifierMapMask,maxKC,
+	    					&changes->map.first_modmap_key,
+	    					&changes->map.num_modmap_keys);
+		}
+	    }
+	}
+	if (xkb->server) {
+	    if (xkb->server->behaviors) {
+		XkbBehavior *prev_behaviors = xkb->server->behaviors;
+
+		xkb->server->behaviors=_XkbTypedRealloc(xkb->server->behaviors,
+						(maxKC+1),XkbBehavior);
+		if (!xkb->server->behaviors) {
+		    _XkbFree(prev_behaviors);
+		    return BadAlloc;
+		}
+#ifdef NXAGENT_SERVER
+                bzero((char *)&xkb->server->behaviors[xkb->max_key_code+1],
+                                                tmp*sizeof(XkbBehavior));
+#else
+		bzero((char *)&xkb->server->behaviors[xkb->max_key_code],
+						tmp*sizeof(XkbBehavior));
+#endif
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbKeyBehaviorsMask,maxKC,
+    					&changes->map.first_key_behavior,
+    					&changes->map.num_key_behaviors);
+		}
+	    }
+	    if (xkb->server->key_acts) {
+		unsigned short *prev_key_acts = xkb->server->key_acts;
+
+		xkb->server->key_acts= _XkbTypedRealloc(xkb->server->key_acts,
+						(maxKC+1),unsigned short);
+		if (!xkb->server->key_acts) {
+		    _XkbFree(prev_key_acts);
+		    return BadAlloc;
+		}
+#ifdef NXAGENT_SERVER
+                bzero((char *)&xkb->server->key_acts[xkb->max_key_code+1],
+                                                tmp*sizeof(unsigned short));
+#else
+		bzero((char *)&xkb->server->key_acts[xkb->max_key_code],
+						tmp*sizeof(unsigned short));
+#endif
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbKeyActionsMask,maxKC,
+    					&changes->map.first_key_act,
+    					&changes->map.num_key_acts);
+		}
+	    }
+	    if (xkb->server->vmodmap) {
+		unsigned short *prev_vmodmap = xkb->server->vmodmap;
+
+		xkb->server->vmodmap= _XkbTypedRealloc(xkb->server->vmodmap,
+						(maxKC+1),unsigned short);
+		if (!xkb->server->vmodmap) {
+		    _XkbFree(prev_vmodmap);
+		    return BadAlloc;
+		}
+#ifdef NXAGENT_SERVER
+                bzero((char *)&xkb->server->vmodmap[xkb->max_key_code+1],
+                                                tmp*sizeof(unsigned short));
+#else
+		bzero((char *)&xkb->server->vmodmap[xkb->max_key_code],
+						tmp*sizeof(unsigned short));
+#endif
+		if (changes) {
+		    changes->map.changed= _ExtendRange(changes->map.changed,
+		    			XkbVirtualModMapMask,maxKC,
+		    			&changes->map.first_modmap_key,
+    					&changes->map.num_vmodmap_keys);
+		}
+	    }
+	}
+	if ((xkb->names)&&(xkb->names->keys)) {
+	    XkbKeyNameRec *prev_keys = xkb->names->keys;
+
+	    xkb->names->keys= _XkbTypedRealloc(xkb->names->keys,
+	    					(maxKC+1),XkbKeyNameRec);
+	    if (!xkb->names->keys) {
+		_XkbFree(prev_keys);
+		return BadAlloc;
+	    }
+#ifdef NXAGENT_SERVER
+            bzero((char *)&xkb->names->keys[xkb->max_key_code+1],
+                                                tmp*sizeof(XkbKeyNameRec));
+#else
+	    bzero((char *)&xkb->names->keys[xkb->max_key_code],
+	    					tmp*sizeof(XkbKeyNameRec));
+#endif
+	    if (changes) {
+		changes->names.changed= _ExtendRange(changes->names.changed,
+					XkbKeyNamesMask,maxKC,
+					&changes->names.first_key,
+    					&changes->names.num_keys);
+	    }
+	}
+	xkb->max_key_code= maxKC;
+    }
+    return Success;
+}
+
+XkbAction *
+XkbResizeKeyActions(XkbDescPtr xkb,int key,int needed)
+{
+register int i,nActs;
+XkbAction *newActs;
+
+    if (needed==0) {
+	xkb->server->key_acts[key]= 0;
+	return NULL;
+    }
+    if (XkbKeyHasActions(xkb,key)&&(XkbKeyNumSyms(xkb,key)>=(unsigned)needed))
+	return XkbKeyActionsPtr(xkb,key);
+    if (xkb->server->size_acts-xkb->server->num_acts>=(unsigned)needed) {
+	xkb->server->key_acts[key]= xkb->server->num_acts;
+	xkb->server->num_acts+= needed;
+	return &xkb->server->acts[xkb->server->key_acts[key]];
+    }
+    xkb->server->size_acts= xkb->server->num_acts+needed+8;
+    newActs = _XkbTypedCalloc(xkb->server->size_acts,XkbAction);
+    if (newActs==NULL)
+	return NULL;
+    newActs[0].type = XkbSA_NoAction;
+    nActs = 1;
+    for (i=xkb->min_key_code;i<=(int)xkb->max_key_code;i++) {
+	int nKeyActs,nCopy;
+
+	if ((xkb->server->key_acts[i]==0)&&(i!=key))
+	    continue;
+
+	nCopy= nKeyActs= XkbKeyNumActions(xkb,i);
+	if (i==key) {
+	    nKeyActs= needed;
+	    if (needed<nCopy)
+		nCopy= needed;
+	}
+
+	if (nCopy>0)
+	    memcpy(&newActs[nActs],XkbKeyActionsPtr(xkb,i),
+						nCopy*sizeof(XkbAction));
+	if (nCopy<nKeyActs)
+	    bzero(&newActs[nActs+nCopy],(nKeyActs-nCopy)*sizeof(XkbAction));
+	xkb->server->key_acts[i]= nActs;
+	nActs+= nKeyActs;
+    }
+    _XkbFree(xkb->server->acts);
+    xkb->server->acts = newActs;
+    xkb->server->num_acts= nActs;
+    return &xkb->server->acts[xkb->server->key_acts[key]];
+}
+
+void
+XkbFreeClientMap(XkbDescPtr xkb,unsigned what,Bool freeMap)
+{
+XkbClientMapPtr	map;
+
+    if ((xkb==NULL)||(xkb->map==NULL))
+	return;
+    if (freeMap)
+	what= XkbAllClientInfoMask;
+    map= xkb->map;
+    if (what&XkbKeyTypesMask) {
+	if (map->types!=NULL) {
+	    if (map->num_types>0) {
+		register int 	i;
+		XkbKeyTypePtr	type;
+		for (i=0,type=map->types;i<map->num_types;i++,type++) {
+		    if (type->map!=NULL) {
+			_XkbFree(type->map);
+			type->map= NULL;
+		    }
+		    if (type->preserve!=NULL) {
+			_XkbFree(type->preserve);
+			type->preserve= NULL;
+		    }
+		    type->map_count= 0;
+		    if (type->level_names!=NULL) {
+			_XkbFree(type->level_names);
+			type->level_names= NULL;
+		    }
+		}
+	    }
+	    _XkbFree(map->types);
+	    map->num_types= map->size_types= 0;
+	    map->types= NULL;
+	}
+    }
+    if (what&XkbKeySymsMask) {
+	if (map->key_sym_map!=NULL) {
+	    _XkbFree(map->key_sym_map);
+	    map->key_sym_map= NULL;
+	}
+	if (map->syms!=NULL) {
+	    _XkbFree(map->syms);
+	    map->size_syms= map->num_syms= 0;
+	    map->syms= NULL;
+	}
+    }
+    if ((what&XkbModifierMapMask)&&(map->modmap!=NULL)) {
+	_XkbFree(map->modmap);
+	map->modmap= NULL;
+    }
+    if (freeMap) {
+	_XkbFree(xkb->map);
+	xkb->map= NULL;
+    }
+    return;
+}
+
+void
+XkbFreeServerMap(XkbDescPtr xkb,unsigned what,Bool freeMap)
+{
+XkbServerMapPtr	map;
+
+    if ((xkb==NULL)||(xkb->server==NULL))
+	return;
+    if (freeMap)
+	what= XkbAllServerInfoMask;
+    map= xkb->server;
+    if ((what&XkbExplicitComponentsMask)&&(map->explicit!=NULL)) {
+	_XkbFree(map->explicit);
+	map->explicit= NULL;
+    }
+    if (what&XkbKeyActionsMask) {
+	if (map->key_acts!=NULL) {
+	    _XkbFree(map->key_acts);
+	    map->key_acts= NULL;
+	}
+	if (map->acts!=NULL) {
+	    _XkbFree(map->acts);
+	    map->num_acts= map->size_acts= 0;
+	    map->acts= NULL;
+	}
+    }
+    if ((what&XkbKeyBehaviorsMask)&&(map->behaviors!=NULL)) {
+	_XkbFree(map->behaviors);
+	map->behaviors= NULL;
+    }
+    if ((what&XkbVirtualModMapMask)&&(map->vmodmap!=NULL)) {
+	_XkbFree(map->vmodmap);
+	map->vmodmap= NULL;
+    }
+
+    if (freeMap) {
+	_XkbFree(xkb->server);
+	xkb->server= NULL;
+    }
+    return;
+}

--- a/nx-X11/programs/Xserver/xkb/XKBMisc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMisc.c
@@ -47,7 +47,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include <nx-X11/keysym.h>
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #endif /* XKB_IN_SERVER */
 

--- a/nx-X11/programs/Xserver/xkb/XKBMisc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMisc.c
@@ -30,15 +30,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <config.h>
 #endif
 
-#ifndef XKB_IN_SERVER
-
-#include <stdio.h>
-#include "Xlibint.h"
-#include <nx-X11/extensions/XKBproto.h>
-#include <nx-X11/keysym.h>
-#include "XKBlibint.h"
-
-#else 
 
 #include <stdio.h>
 #include <nx-X11/X.h>
@@ -49,7 +40,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
-#endif /* XKB_IN_SERVER */
 
 /***====================================================================***/
 

--- a/nx-X11/programs/Xserver/xkb/XKBMisc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMisc.c
@@ -37,7 +37,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include <nx-X11/keysym.h>
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
 

--- a/nx-X11/programs/Xserver/xkb/XKBMisc.c
+++ b/nx-X11/programs/Xserver/xkb/XKBMisc.c
@@ -1,0 +1,975 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#elif defined(HAVE_CONFIG_H)
+#include <config.h>
+#endif
+
+#ifndef XKB_IN_SERVER
+
+#include <stdio.h>
+#include "Xlibint.h"
+#include <nx-X11/extensions/XKBproto.h>
+#include <nx-X11/keysym.h>
+#include "XKBlibint.h"
+
+#else 
+
+#include <stdio.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
+#include "misc.h"
+#include "inputstr.h"
+#include <nx-X11/keysym.h>
+#define	XKBSRV_NEED_FILE_FUNCS
+#include <nx-X11/extensions/XKBsrv.h>
+
+#endif /* XKB_IN_SERVER */
+
+/***====================================================================***/
+
+#define	mapSize(m)	(sizeof(m)/sizeof(XkbKTMapEntryRec))
+static  XkbKTMapEntryRec map2Level[]= { 
+  { True, ShiftMask, {1, ShiftMask, 0} }
+};
+
+static  XkbKTMapEntryRec mapAlpha[]= { 
+  { True, ShiftMask, { 1, ShiftMask, 0 } },
+  { True, LockMask,  { 0,  LockMask, 0 } }
+};
+
+static	XkbModsRec preAlpha[]= {
+	{        0,        0, 0 },
+	{ LockMask, LockMask, 0 }
+};
+
+#define	NL_VMOD_MASK	0
+static  XkbKTMapEntryRec mapKeypad[]= { 
+	{ True,	ShiftMask, { 1, ShiftMask,            0 } },
+	{ False,        0, { 1,         0, NL_VMOD_MASK } }
+};
+
+static	XkbKeyTypeRec	canonicalTypes[XkbNumRequiredTypes] = {
+	{ { 0, 0, 0 }, 
+	  1,	/* num_levels */
+	  0,	/* map_count */
+	  NULL,		NULL,
+	  None,		NULL
+	},
+	{ { ShiftMask, ShiftMask, 0 }, 
+	  2,	/* num_levels */
+	  mapSize(map2Level),	/* map_count */
+	  map2Level,	NULL,
+	  None,		NULL
+	},
+	{ { ShiftMask|LockMask, ShiftMask|LockMask, 0 }, 
+	  2,				/* num_levels */
+	  mapSize(mapAlpha),		/* map_count */
+	  mapAlpha,	preAlpha,
+	  None,		NULL
+	},
+	{ { ShiftMask, ShiftMask, NL_VMOD_MASK },
+	  2,				/* num_levels */
+	  mapSize(mapKeypad),		/* map_count */
+	  mapKeypad,	NULL,
+	  None,		NULL
+	}
+};
+
+Status
+XkbInitCanonicalKeyTypes(XkbDescPtr xkb,unsigned which,int keypadVMod)
+{
+XkbClientMapPtr	map;
+XkbKeyTypePtr	from,to;
+Status		rtrn;
+
+    if (!xkb)
+	return BadMatch;
+    rtrn= XkbAllocClientMap(xkb,XkbKeyTypesMask,XkbNumRequiredTypes);
+    if (rtrn!=Success)
+	return rtrn;
+    map= xkb->map;
+    if ((which&XkbAllRequiredTypes)==0)
+	return Success;
+    rtrn= Success;
+    from= canonicalTypes;
+    to= map->types;
+    if (which&XkbOneLevelMask)
+	rtrn= XkbCopyKeyType(&from[XkbOneLevelIndex],&to[XkbOneLevelIndex]);
+    if ((which&XkbTwoLevelMask)&&(rtrn==Success))
+	rtrn= XkbCopyKeyType(&from[XkbTwoLevelIndex],&to[XkbTwoLevelIndex]);
+    if ((which&XkbAlphabeticMask)&&(rtrn==Success))
+	rtrn= XkbCopyKeyType(&from[XkbAlphabeticIndex],&to[XkbAlphabeticIndex]);
+    if ((which&XkbKeypadMask)&&(rtrn==Success)) {
+	XkbKeyTypePtr type;
+	rtrn= XkbCopyKeyType(&from[XkbKeypadIndex],&to[XkbKeypadIndex]);
+	type= &to[XkbKeypadIndex];
+	if ((keypadVMod>=0)&&(keypadVMod<XkbNumVirtualMods)&&(rtrn==Success)) {
+	    type->mods.vmods= (1<<keypadVMod);
+	    type->map[0].active= True;
+	    type->map[0].mods.mask= ShiftMask;
+	    type->map[0].mods.real_mods= ShiftMask;
+	    type->map[0].mods.vmods= 0;
+	    type->map[0].level= 1;
+	    type->map[1].active= False;
+	    type->map[1].mods.mask= 0;
+	    type->map[1].mods.real_mods= 0;
+	    type->map[1].mods.vmods= (1<<keypadVMod);
+	    type->map[1].level= 1;
+	}
+    }
+    return Success;
+}
+
+/***====================================================================***/
+
+#define	CORE_SYM(i)	(i<map_width?core_syms[i]:NoSymbol)
+#define	XKB_OFFSET(g,l)	(((g)*groupsWidth)+(l))
+
+int
+XkbKeyTypesForCoreSymbols(	XkbDescPtr	xkb,
+				int		map_width,
+				KeySym *	core_syms,
+				unsigned int 	protected,
+    				int *		types_inout,
+				KeySym *	xkb_syms_rtrn)
+{
+register int	i;
+unsigned int	empty;
+int		nSyms[XkbNumKbdGroups];
+int		nGroups,tmp,groupsWidth;
+
+    /* Section 12.2 of the protocol describes this process in more detail */
+    /* Step 1:  find the # of symbols in the core mapping per group */
+    groupsWidth= 2;
+    for (i=0;i<XkbNumKbdGroups;i++) {
+	if ((protected&(1<<i))&&(types_inout[i]<xkb->map->num_types)) {
+	    nSyms[i]= xkb->map->types[types_inout[i]].num_levels;
+	    if (nSyms[i]>groupsWidth)
+		groupsWidth= nSyms[i];
+	}
+	else {
+	    types_inout[i]= XkbTwoLevelIndex;	/* don't really know, yet */
+	    nSyms[i]= 2;
+	}
+    }
+    if (nSyms[XkbGroup1Index]<2)
+	nSyms[XkbGroup1Index]= 2;
+    if (nSyms[XkbGroup2Index]<2)
+	nSyms[XkbGroup2Index]= 2;
+    /* Step 2:	Copy the symbols from the core ordering to XKB ordering	*/
+    /*		symbols in the core are in the order:			*/
+    /*		G1L1 G1L2 G2L1 G2L2 [G1L[3-n]] [G2L[3-n]] [G3L*] [G3L*]	*/
+    xkb_syms_rtrn[XKB_OFFSET(XkbGroup1Index,0)]= CORE_SYM(0);
+    xkb_syms_rtrn[XKB_OFFSET(XkbGroup1Index,1)]= CORE_SYM(1);
+    for (i=2;i<nSyms[XkbGroup1Index];i++) {
+	xkb_syms_rtrn[XKB_OFFSET(XkbGroup1Index,i)]= CORE_SYM(2+i);
+    }
+    xkb_syms_rtrn[XKB_OFFSET(XkbGroup2Index,0)]= CORE_SYM(2);
+    xkb_syms_rtrn[XKB_OFFSET(XkbGroup2Index,1)]= CORE_SYM(3);
+    tmp= 2+(nSyms[XkbGroup1Index]-2); /* offset to extra group2 syms */
+    for (i=2;i<nSyms[XkbGroup2Index];i++) {
+	xkb_syms_rtrn[XKB_OFFSET(XkbGroup2Index,i)]= CORE_SYM(tmp+i);
+    }
+    tmp= nSyms[XkbGroup1Index]+nSyms[XkbGroup2Index];
+    if ((tmp>=map_width)&&
+	 ((protected&(XkbExplicitKeyType3Mask|XkbExplicitKeyType4Mask))==0)) {
+	nSyms[XkbGroup3Index]= 0;
+	nSyms[XkbGroup4Index]= 0;
+	nGroups= 2;
+    }
+    else {
+    	nGroups= 3;
+	for (i=0;i<nSyms[XkbGroup3Index];i++,tmp++) {
+	    xkb_syms_rtrn[XKB_OFFSET(XkbGroup3Index,i)]= CORE_SYM(tmp);
+	}
+	if ((tmp<map_width)||(protected&XkbExplicitKeyType4Mask)) {
+	    nGroups= 4;
+	    for (i=0;i<nSyms[XkbGroup4Index];i++,tmp++) {
+		xkb_syms_rtrn[XKB_OFFSET(XkbGroup4Index,i)]= CORE_SYM(tmp);
+	    }
+	}
+	else {
+	    nSyms[XkbGroup4Index]= 0;
+	}
+    }
+    /* steps 3&4: alphanumeric expansion,  assign canonical types */
+    empty= 0;
+    for (i=0;i<nGroups;i++) {
+	KeySym *syms;
+	syms= &xkb_syms_rtrn[XKB_OFFSET(i,0)];
+	if ((nSyms[i]>1)&&(syms[1]==NoSymbol)&&(syms[0]!=NoSymbol)) {
+	    KeySym upper,lower;
+	    XConvertCase(syms[0],&lower,&upper);
+	    if (upper!=lower) {
+		xkb_syms_rtrn[XKB_OFFSET(i,0)]= lower;
+		xkb_syms_rtrn[XKB_OFFSET(i,1)]= upper;
+		if ((protected&(1<<i))==0)
+		    types_inout[i]= XkbAlphabeticIndex;
+	    }
+	    else if ((protected&(1<<i))==0) {
+		types_inout[i]= XkbOneLevelIndex;
+	/*	nSyms[i]=	1;*/
+	    }
+	}
+	if (((protected&(1<<i))==0)&&(types_inout[i]==XkbTwoLevelIndex)) {
+	    if (IsKeypadKey(syms[0])||IsKeypadKey(syms[1]))
+		types_inout[i]= XkbKeypadIndex;
+	    else {
+		KeySym upper,lower;
+		XConvertCase(syms[0],&lower,&upper);
+		if ((syms[0]==lower)&&(syms[1]==upper))
+		    types_inout[i]= XkbAlphabeticIndex;
+	    }
+	}
+	if (syms[0]==NoSymbol) {
+	    register int n;
+	    Bool	found;
+	    for (n=1,found=False;(!found)&&(n<nSyms[i]);n++) {
+		found= (syms[n]!=NoSymbol);
+	    }
+	    if (!found)
+		empty|= (1<<i);
+	}
+    }
+    /* step 5: squoosh out empty groups */
+    if (empty) {
+	for (i=nGroups-1;i>=0;i--) {
+	    if (((empty&(1<<i))==0)||(protected&(1<<i)))
+		break;
+	    nGroups--;
+	}
+    }
+    if (nGroups<1)
+	return 0;
+
+    /* step 6: replicate group 1 into group two, if necessary */
+    if ((nGroups>1)&&((empty&(XkbGroup1Mask|XkbGroup2Mask))==XkbGroup2Mask)) {
+	if ((protected&(XkbExplicitKeyType1Mask|XkbExplicitKeyType2Mask))==0) {
+	    nSyms[XkbGroup2Index]= nSyms[XkbGroup1Index];
+	    types_inout[XkbGroup2Index]= types_inout[XkbGroup1Index];
+	    memcpy((char *)&xkb_syms_rtrn[2],(char *)xkb_syms_rtrn,
+							2*sizeof(KeySym));
+	}
+	else if (types_inout[XkbGroup1Index]==types_inout[XkbGroup2Index]) {
+	    memcpy((char *)&xkb_syms_rtrn[nSyms[XkbGroup1Index]],
+	    				(char *)xkb_syms_rtrn,
+					nSyms[XkbGroup1Index]*sizeof(KeySym));
+	}
+    }
+
+    /* step 7: check for all groups identical or all width 1 */
+    if (nGroups>1) {
+	Bool sameType,allOneLevel;
+	allOneLevel= (xkb->map->types[types_inout[0]].num_levels==1);
+	for (i=1,sameType=True;(allOneLevel||sameType)&&(i<nGroups);i++) {
+	    sameType=(sameType&&(types_inout[i]==types_inout[XkbGroup1Index]));
+	    if (allOneLevel)
+		allOneLevel= (xkb->map->types[types_inout[i]].num_levels==1);
+	}
+	if ((sameType)&&
+	    (!(protected&(XkbExplicitKeyTypesMask&~XkbExplicitKeyType1Mask)))){
+	    register int s;
+	    Bool	identical;
+	    for (i=1,identical=True;identical&&(i<nGroups);i++) {
+		KeySym *syms;
+		syms= &xkb_syms_rtrn[XKB_OFFSET(i,0)];
+		for (s=0;identical&&(s<nSyms[i]);s++) {
+		    if (syms[s]!=xkb_syms_rtrn[s])
+			identical= False;
+		}
+	    }
+	    if (identical)
+		nGroups= 1;
+	}
+	if (allOneLevel && (nGroups>1)) {
+	    KeySym *syms;
+	    syms= &xkb_syms_rtrn[nSyms[XkbGroup1Index]];
+	    nSyms[XkbGroup1Index]= 1;
+	    for (i=1;i<nGroups;i++) {
+		xkb_syms_rtrn[i]= syms[0];
+		syms+= nSyms[i];
+		nSyms[i]= 1;
+	    }
+	}
+    }
+    return nGroups;
+}
+
+static XkbSymInterpretPtr
+_XkbFindMatchingInterp(	XkbDescPtr	xkb,
+			KeySym 		sym,
+			unsigned int	real_mods,
+			unsigned int	level)
+{
+register unsigned	 i;
+XkbSymInterpretPtr	 interp,rtrn;
+CARD8			 mods;
+
+    rtrn= NULL;
+    interp= xkb->compat->sym_interpret;
+    for (i=0;i<xkb->compat->num_si;i++,interp++) {
+	if ((interp->sym==NoSymbol)||(sym==interp->sym)) {
+	    int match;
+	    if ((level==0)||((interp->match&XkbSI_LevelOneOnly)==0))
+		 mods= real_mods;
+	    else mods= 0;
+	    switch (interp->match&XkbSI_OpMask) {
+		case XkbSI_NoneOf:
+		    match= ((interp->mods&mods)==0);
+		    break;
+		case XkbSI_AnyOfOrNone:
+		    match= ((mods==0)||((interp->mods&mods)!=0));
+		    break;
+		case XkbSI_AnyOf:
+		    match= ((interp->mods&mods)!=0);
+		    break;
+		case XkbSI_AllOf:
+		    match= ((interp->mods&mods)==interp->mods);
+		    break;
+		case XkbSI_Exactly:
+		    match= (interp->mods==mods);
+		    break;
+		default:
+		    match= 0;
+		    break;
+	    }
+	    if (match) {
+		if (interp->sym!=NoSymbol) {
+		    return interp;
+		}
+		else if (rtrn==NULL) {
+		    rtrn= interp;
+		}
+	    }
+	}
+    }
+    return rtrn;
+}
+
+static void
+_XkbAddKeyChange(KeyCode *pFirst,unsigned char *pNum,KeyCode newKey)
+{
+KeyCode	last;
+
+    last= (*pFirst)+(*pNum);
+    if (newKey<*pFirst) {
+	*pFirst= newKey;
+	*pNum= (last-newKey)+1;
+    }
+    else if (newKey>last) {
+	*pNum= (last-*pFirst)+1;
+    }
+    return;
+}
+
+static void
+_XkbSetActionKeyMods(XkbDescPtr xkb,XkbAction *act,unsigned mods)
+{
+unsigned	tmp;
+
+    switch (act->type) {
+	case XkbSA_SetMods: case XkbSA_LatchMods: case XkbSA_LockMods:
+	    if (act->mods.flags&XkbSA_UseModMapMods)
+		act->mods.real_mods= act->mods.mask= mods;
+	    if ((tmp= XkbModActionVMods(&act->mods))!=0) {
+		XkbVirtualModsToReal(xkb,tmp,&tmp);
+		act->mods.mask|= tmp;
+	    }
+	    break;
+	case XkbSA_ISOLock:
+	    if (act->iso.flags&XkbSA_UseModMapMods)
+		act->iso.real_mods= act->iso.mask= mods;
+	    if ((tmp= XkbModActionVMods(&act->iso))!=0) {
+		XkbVirtualModsToReal(xkb,tmp,&tmp);
+		act->iso.mask|= tmp;
+	    }
+	    break;
+    }
+    return;
+}
+
+#define	IBUF_SIZE	8
+
+Bool
+XkbApplyCompatMapToKey(XkbDescPtr xkb,KeyCode key,XkbChangesPtr changes)
+{
+KeySym *		syms;
+unsigned char 		explicit,mods;
+XkbSymInterpretPtr	*interps,ibuf[IBUF_SIZE]; 
+int			n,nSyms,found;
+unsigned		changed,tmp;
+
+    if ((!xkb)||(!xkb->map)||(!xkb->map->key_sym_map)||
+    			(!xkb->compat)||(!xkb->compat->sym_interpret)||
+			(key<xkb->min_key_code)||(key>xkb->max_key_code)) {
+	return False;
+    }
+    if (((!xkb->server)||(!xkb->server->key_acts))&&
+		(XkbAllocServerMap(xkb,XkbAllServerInfoMask,0)!=Success)) {
+	return False;
+    }
+    changed= 0;	/* keeps track of what has changed in _this_ call */
+    explicit= xkb->server->explicit[key];
+    if (explicit&XkbExplicitInterpretMask) /* nothing to do */
+	return True;
+    mods= (xkb->map->modmap?xkb->map->modmap[key]:0);
+    nSyms= XkbKeyNumSyms(xkb,key);
+    syms= XkbKeySymsPtr(xkb,key);
+    if (nSyms>IBUF_SIZE) {
+	interps= _XkbTypedCalloc(nSyms,XkbSymInterpretPtr);
+	if (interps==NULL) {
+	    interps= ibuf;
+	    nSyms= IBUF_SIZE;
+	}
+    }
+    else {
+	interps= ibuf;
+    }
+    found= 0;
+    for (n=0;n<nSyms;n++) {
+	unsigned level= (n%XkbKeyGroupsWidth(xkb,key));
+	interps[n]= NULL;
+	if (syms[n]!=NoSymbol) {
+	    interps[n]= _XkbFindMatchingInterp(xkb,syms[n],mods,level);
+	    if (interps[n]&&interps[n]->act.type!=XkbSA_NoAction)
+		found++;
+	    else interps[n]= NULL;
+	}
+    }
+    /* 1/28/96 (ef) -- XXX! WORKING HERE */
+    if (!found) {
+	if (xkb->server->key_acts[key]!=0) {
+	    xkb->server->key_acts[key]= 0;
+	    changed|= XkbKeyActionsMask;
+	}
+    }
+    else {
+	XkbAction *pActs;
+	unsigned int	new_vmodmask;
+	changed|= XkbKeyActionsMask;
+	pActs= XkbResizeKeyActions(xkb,key,nSyms);
+	if (!pActs)
+	    return False;
+	new_vmodmask= 0;
+	for (n=0;n<nSyms;n++) {
+	    if (interps[n]) {
+		unsigned effMods;
+
+		pActs[n]= *((XkbAction *)&interps[n]->act);
+		if ((n==0)||((interps[n]->match&XkbSI_LevelOneOnly)==0)) {
+		     effMods= mods;
+		     if (interps[n]->virtual_mod!=XkbNoModifier)
+			new_vmodmask|= (1<<interps[n]->virtual_mod);
+		}
+		else effMods= 0;
+		_XkbSetActionKeyMods(xkb,&pActs[n],effMods);
+	    }
+	    else pActs[n].type= XkbSA_NoAction;
+	}
+	if (((explicit&XkbExplicitVModMapMask)==0)&&
+				(xkb->server->vmodmap[key]!=new_vmodmask)) {
+	    changed|= XkbVirtualModMapMask;
+	    xkb->server->vmodmap[key]= new_vmodmask;
+	}
+	if (interps[0]) {
+	    if ((interps[0]->flags&XkbSI_LockingKey)&&
+				((explicit&XkbExplicitBehaviorMask)==0)) {
+		xkb->server->behaviors[key].type= XkbKB_Lock;
+		changed|= XkbKeyBehaviorsMask;
+	    }
+	    if (((explicit&XkbExplicitAutoRepeatMask)==0)&&(xkb->ctrls)) {
+		CARD8 old;
+		old= xkb->ctrls->per_key_repeat[key/8];
+		if (interps[0]->flags&XkbSI_AutoRepeat)
+		     xkb->ctrls->per_key_repeat[key/8]|= (1<<(key%8));
+		else xkb->ctrls->per_key_repeat[key/8]&= ~(1<<(key%8));
+		if (changes && (old!=xkb->ctrls->per_key_repeat[key/8]))
+		    changes->ctrls.changed_ctrls|= XkbPerKeyRepeatMask;
+	    }
+	}
+    }
+    if ((!found)||(interps[0]==NULL)) {
+	if (((explicit&XkbExplicitAutoRepeatMask)==0)&&(xkb->ctrls)) {
+	    CARD8 old;
+	    old= xkb->ctrls->per_key_repeat[key/8];
+#ifdef RETURN_SHOULD_REPEAT
+	    if (*XkbKeySymsPtr(xkb,key) != XK_Return)
+#endif
+		xkb->ctrls->per_key_repeat[key/8]|= (1<<(key%8));
+	    if (changes && (old!=xkb->ctrls->per_key_repeat[key/8]))
+		changes->ctrls.changed_ctrls|= XkbPerKeyRepeatMask;
+	}
+	if (((explicit&XkbExplicitBehaviorMask)==0)&&
+		(xkb->server->behaviors[key].type==XkbKB_Lock)) {
+		xkb->server->behaviors[key].type= XkbKB_Default;
+		changed|= XkbKeyBehaviorsMask;
+	}
+    }
+    if (changes) {
+	XkbMapChangesPtr	mc;
+	mc= &changes->map;
+	tmp= (changed&mc->changed);
+	if (tmp&XkbKeyActionsMask)
+	    _XkbAddKeyChange(&mc->first_key_act,&mc->num_key_acts,key);
+	else if (changed&XkbKeyActionsMask) {
+	    mc->changed|= XkbKeyActionsMask;
+	    mc->first_key_act= key;
+	    mc->num_key_acts= 1;
+	}
+	if (tmp&XkbKeyBehaviorsMask) {
+	    _XkbAddKeyChange(&mc->first_key_behavior,&mc->num_key_behaviors,
+	    								key);
+	}
+	else if (changed&XkbKeyBehaviorsMask) {
+	    mc->changed|= XkbKeyBehaviorsMask;
+	    mc->first_key_behavior= key;
+	    mc->num_key_behaviors= 1;
+	}
+	if (tmp&XkbVirtualModMapMask)
+	    _XkbAddKeyChange(&mc->first_vmodmap_key,&mc->num_vmodmap_keys,key);
+	else if (changed&XkbVirtualModMapMask) {
+	    mc->changed|= XkbVirtualModMapMask;
+	    mc->first_vmodmap_key= key;
+	    mc->num_vmodmap_keys= 1;
+	}
+	mc->changed|= changed;
+    }
+    if (interps!=ibuf)
+	_XkbFree(interps);
+    return True;
+}
+
+Bool
+XkbUpdateMapFromCore(	XkbDescPtr	xkb,
+			KeyCode		first_key,
+			int		num_keys,
+			int		map_width,
+			KeySym *	core_keysyms,
+			XkbChangesPtr	changes)
+{
+register int	key,last_key;
+KeySym *	syms;
+
+    syms= &core_keysyms[(first_key-xkb->min_key_code)*map_width];
+    if (changes) {
+	if (changes->map.changed&XkbKeySymsMask) {
+	    _XkbAddKeyChange(&changes->map.first_key_sym,
+	    			&changes->map.num_key_syms,first_key);
+	    if (num_keys>1) {
+		_XkbAddKeyChange(&changes->map.first_key_sym,
+						&changes->map.num_key_syms,
+						first_key+num_keys-1);
+	    }
+	}
+	else {
+	    changes->map.changed|= XkbKeySymsMask;
+	    changes->map.first_key_sym= first_key;
+	    changes->map.num_key_syms= num_keys;
+	}
+    }
+    last_key= first_key+num_keys-1;
+    for (key=first_key;key<=last_key;key++,syms+= map_width) {
+	XkbMapChangesPtr	mc;
+	unsigned		explicit;
+	KeySym			tsyms[XkbMaxSymsPerKey];
+	int	 		types[XkbNumKbdGroups];
+	int			nG;
+
+	explicit= xkb->server->explicit[key]&XkbExplicitKeyTypesMask;
+	types[XkbGroup1Index]= XkbKeyKeyTypeIndex(xkb,key,XkbGroup1Index);
+	types[XkbGroup2Index]= XkbKeyKeyTypeIndex(xkb,key,XkbGroup2Index);
+	types[XkbGroup3Index]= XkbKeyKeyTypeIndex(xkb,key,XkbGroup3Index);
+	types[XkbGroup4Index]= XkbKeyKeyTypeIndex(xkb,key,XkbGroup4Index);
+	nG= XkbKeyTypesForCoreSymbols(xkb,map_width,syms,explicit,types,tsyms);
+	if (changes)
+	     mc= &changes->map;
+	else mc= NULL;
+	XkbChangeTypesOfKey(xkb,key,nG,XkbAllGroupsMask,types,mc);
+	memcpy((char *)XkbKeySymsPtr(xkb,key),(char *)tsyms,
+					XkbKeyNumSyms(xkb,key)*sizeof(KeySym));
+	XkbApplyCompatMapToKey(xkb,key,changes);
+    }
+
+    if ((xkb->server->vmods!=NULL)&&(xkb->map->modmap!=NULL)&&(changes)&&
+	(changes->map.changed&(XkbVirtualModMapMask|XkbModifierMapMask))) {
+	unsigned char		newVMods[XkbNumVirtualMods];
+	register  unsigned 	bit,i;
+	unsigned		present;
+
+	bzero(newVMods,XkbNumVirtualMods);
+	present= 0;
+	for (key=xkb->min_key_code;key<=xkb->max_key_code;key++) {
+	    if (xkb->server->vmodmap[key]==0)
+		continue;
+	    for (i=0,bit=1;i<XkbNumVirtualMods;i++,bit<<=1) {
+		if (bit&xkb->server->vmodmap[key]) {
+		    present|= bit;
+		    newVMods[i]|= xkb->map->modmap[key];
+		}
+	    }
+	}
+	for (i=0,bit=1;i<XkbNumVirtualMods;i++,bit<<=1) {
+	    if ((bit&present)&&(newVMods[i]!=xkb->server->vmods[i])) {
+		changes->map.changed|= XkbVirtualModsMask;
+		changes->map.vmods|= bit;
+		xkb->server->vmods[i]= newVMods[i];
+	    }
+	}
+    }
+    if (changes && (changes->map.changed&XkbVirtualModsMask))
+	XkbApplyVirtualModChanges(xkb,changes->map.vmods,changes);
+    return True;
+}
+
+Status
+XkbChangeTypesOfKey(	XkbDescPtr		 xkb,
+			int		 	 key,
+			int			 nGroups,
+			unsigned	 	 groups,
+			int	* 	 	 newTypesIn,
+			XkbMapChangesPtr	 changes)
+{
+XkbKeyTypePtr	pOldType,pNewType;
+register int	i;
+int		width,nOldGroups,oldWidth,newTypes[XkbNumKbdGroups];
+
+    if ((!xkb) || (!XkbKeycodeInRange(xkb,key)) || (!xkb->map) ||
+	(!xkb->map->types)||((groups&XkbAllGroupsMask)==0)||
+	(nGroups>XkbNumKbdGroups)) {
+	return BadMatch;
+    }
+    if (nGroups==0) {
+	for (i=0;i<XkbNumKbdGroups;i++) {
+	    xkb->map->key_sym_map[key].kt_index[i]= XkbOneLevelIndex;
+	}
+	i= xkb->map->key_sym_map[key].group_info;
+	i= XkbSetNumGroups(i,0);
+	xkb->map->key_sym_map[key].group_info= i;
+	XkbResizeKeySyms(xkb,key,0);
+	return Success;
+    }
+
+    nOldGroups= XkbKeyNumGroups(xkb,key);
+    oldWidth= XkbKeyGroupsWidth(xkb,key);
+    for (width=i=0;i<nGroups;i++) {
+	if (groups&(1<<i))
+	     newTypes[i]=  newTypesIn[i];
+	else if (i<nOldGroups)
+	     newTypes[i]= XkbKeyKeyTypeIndex(xkb,key,i);
+	else if (nOldGroups>0)
+	     newTypes[i]= XkbKeyKeyTypeIndex(xkb,key,XkbGroup1Index);
+	else newTypes[i]= XkbTwoLevelIndex;
+	if (newTypes[i]>xkb->map->num_types)
+	    return BadMatch;
+	pNewType= &xkb->map->types[newTypes[i]];
+	if (pNewType->num_levels>width)
+	    width= pNewType->num_levels;
+    }
+    if ((xkb->ctrls)&&(nGroups>xkb->ctrls->num_groups))
+	xkb->ctrls->num_groups= nGroups;
+    if ((width!=oldWidth)||(nGroups!=nOldGroups)) {
+	KeySym		oldSyms[XkbMaxSymsPerKey],*pSyms;
+	int		nCopy;
+
+	if (nOldGroups==0) {
+	    pSyms= XkbResizeKeySyms(xkb,key,width*nGroups);
+	    if (pSyms!=NULL) {
+		i= xkb->map->key_sym_map[key].group_info;
+		i= XkbSetNumGroups(i,nGroups);
+		xkb->map->key_sym_map[key].group_info= i;
+		xkb->map->key_sym_map[key].width= width;
+		for (i=0;i<nGroups;i++) {
+		    xkb->map->key_sym_map[key].kt_index[i]= newTypes[i];
+		}
+		return Success;
+	    }
+	    return BadAlloc;
+	}
+	pSyms= XkbKeySymsPtr(xkb,key);
+	memcpy(oldSyms,pSyms,XkbKeyNumSyms(xkb,key)*sizeof(KeySym));
+	pSyms= XkbResizeKeySyms(xkb,key,width*nGroups);
+	if (pSyms==NULL)
+	    return BadAlloc;
+	bzero(pSyms,width*nGroups*sizeof(KeySym));
+	for (i=0;(i<nGroups)&&(i<nOldGroups);i++) {
+	    pOldType= XkbKeyKeyType(xkb,key,i);
+	    pNewType= &xkb->map->types[newTypes[i]];
+	    if (pNewType->num_levels>pOldType->num_levels)
+		 nCopy= pOldType->num_levels;
+	    else nCopy= pNewType->num_levels;
+	    memcpy(&pSyms[i*width],&oldSyms[i*oldWidth],nCopy*sizeof(KeySym));
+	}
+	if (XkbKeyHasActions(xkb,key)) {
+	    XkbAction	oldActs[XkbMaxSymsPerKey],*pActs;
+	    pActs= XkbKeyActionsPtr(xkb,key);
+	    memcpy(oldActs,pActs,XkbKeyNumSyms(xkb,key)*sizeof(XkbAction));
+	    pActs= XkbResizeKeyActions(xkb,key,width*nGroups);
+	    if (pActs==NULL)
+		return BadAlloc;
+	    bzero(pActs,width*nGroups*sizeof(XkbAction));
+	    for (i=0;(i<nGroups)&&(i<nOldGroups);i++) {
+		pOldType= XkbKeyKeyType(xkb,key,i);
+		pNewType= &xkb->map->types[newTypes[i]];
+		if (pNewType->num_levels>pOldType->num_levels)
+		     nCopy= pOldType->num_levels;
+		else nCopy= pNewType->num_levels;
+		memcpy(&pActs[i*width],&oldActs[i*oldWidth],
+						nCopy*sizeof(XkbAction));
+	    }
+	}
+	i= xkb->map->key_sym_map[key].group_info;
+	i= XkbSetNumGroups(i,nGroups);
+	xkb->map->key_sym_map[key].group_info= i;
+	xkb->map->key_sym_map[key].width= width;
+    }
+    width= 0;
+    for (i=0;i<nGroups;i++) {
+	xkb->map->key_sym_map[key].kt_index[i]= newTypes[i];
+	if (xkb->map->types[newTypes[i]].num_levels>width)
+	    width= xkb->map->types[newTypes[i]].num_levels;
+    }
+    xkb->map->key_sym_map[key].width= width;
+    if (changes!=NULL) {
+	if (changes->changed&XkbKeySymsMask) {
+	    _XkbAddKeyChange(&changes->first_key_sym,&changes->num_key_syms,
+	    								key);
+	}
+	else {
+	    changes->changed|= XkbKeySymsMask;
+	    changes->first_key_sym= key;
+	    changes->num_key_syms= 1;
+	}
+    }
+    return Success;
+}
+
+/***====================================================================***/
+
+Bool
+XkbVirtualModsToReal(XkbDescPtr xkb,unsigned virtual_mask,unsigned *mask_rtrn)
+{
+register int i,bit;
+register unsigned mask;
+
+    if (xkb==NULL)
+	return False;
+    if (virtual_mask==0) {
+	*mask_rtrn= 0;
+	return True;
+    }
+    if (xkb->server==NULL)
+	return False;
+    for (i=mask=0,bit=1;i<XkbNumVirtualMods;i++,bit<<=1) {
+	if (virtual_mask&bit)
+	    mask|= xkb->server->vmods[i];
+    }
+    *mask_rtrn= mask;
+    return True;
+}
+
+/***====================================================================***/
+
+Bool
+XkbUpdateActionVirtualMods(XkbDescPtr xkb,XkbAction *act,unsigned changed)
+{
+unsigned int	tmp;
+
+    switch (act->type) {
+	case XkbSA_SetMods: case XkbSA_LatchMods: case XkbSA_LockMods:
+	    if (((tmp= XkbModActionVMods(&act->mods))&changed)!=0) {
+		XkbVirtualModsToReal(xkb,tmp,&tmp);
+		act->mods.mask= act->mods.real_mods;
+		act->mods.mask|= tmp;
+		return True;
+	    }
+	    break;
+	case XkbSA_ISOLock:
+	    if ((((tmp= XkbModActionVMods(&act->iso))!=0)&changed)!=0) {
+		XkbVirtualModsToReal(xkb,tmp,&tmp);
+		act->iso.mask= act->iso.real_mods;
+		act->iso.mask|= tmp;
+		return True;
+	    }
+	    break;
+    }
+    return False;
+}
+
+void
+XkbUpdateKeyTypeVirtualMods(	XkbDescPtr	xkb,
+				XkbKeyTypePtr	type,
+				unsigned int	changed,
+				XkbChangesPtr 	changes)
+{
+register unsigned int	i;
+unsigned int		mask = 0;
+
+    XkbVirtualModsToReal(xkb,type->mods.vmods,&mask);
+    type->mods.mask= type->mods.real_mods|mask;
+    if ((type->map_count>0)&&(type->mods.vmods!=0)) {
+	XkbKTMapEntryPtr entry;
+	for (i=0,entry=type->map;i<type->map_count;i++,entry++) {
+	    if (entry->mods.vmods!=0) {
+		XkbVirtualModsToReal(xkb,entry->mods.vmods,&mask);
+		entry->mods.mask=entry->mods.real_mods|mask;
+		/* entry is active if vmods are bound*/
+	    	entry->active= (mask!=0);
+	    }
+	    else entry->active= 1;
+	}
+    }
+    if (changes) {
+	int	type_ndx;
+	type_ndx= type-xkb->map->types;
+	if ((type_ndx<0)||(type_ndx>xkb->map->num_types))
+	    return;
+	if (changes->map.changed&XkbKeyTypesMask) {
+	    int last;
+	    last= changes->map.first_type+changes->map.num_types-1;
+	    if (type_ndx<changes->map.first_type) {
+		changes->map.first_type= type_ndx;
+		changes->map.num_types= (last-type_ndx)+1;
+	    }
+	    else if (type_ndx>last) {
+		changes->map.num_types= (type_ndx-changes->map.first_type)+1;
+	    }
+	}
+	else {
+	    changes->map.changed|= XkbKeyTypesMask;
+	    changes->map.first_type= type_ndx;
+	    changes->map.num_types= 1;
+	}
+    }
+    return;
+}
+
+Bool
+XkbApplyVirtualModChanges(XkbDescPtr xkb,unsigned changed,XkbChangesPtr changes)
+{
+register int	i;
+unsigned int	checkState = 0;
+
+    if ((!xkb) || (!xkb->map) || (changed==0))
+	return False;
+    for (i=0;i<xkb->map->num_types;i++) {
+	if (xkb->map->types[i].mods.vmods & changed)
+	XkbUpdateKeyTypeVirtualMods(xkb,&xkb->map->types[i],changed,changes);
+    }
+    if (changed&xkb->ctrls->internal.vmods) {
+	unsigned int	newMask = 0;
+	XkbVirtualModsToReal(xkb,xkb->ctrls->internal.vmods,&newMask);
+	newMask|= xkb->ctrls->internal.real_mods;
+	if (xkb->ctrls->internal.mask!=newMask) {
+	    xkb->ctrls->internal.mask= newMask;
+	    if (changes) {
+		changes->ctrls.changed_ctrls|= XkbInternalModsMask;
+		checkState= True;
+	    }
+	}
+    }
+    if (changed&xkb->ctrls->ignore_lock.vmods) {
+	unsigned int	newMask = 0;
+	XkbVirtualModsToReal(xkb,xkb->ctrls->ignore_lock.vmods,&newMask);
+	newMask|= xkb->ctrls->ignore_lock.real_mods;
+	if (xkb->ctrls->ignore_lock.mask!=newMask) {
+	    xkb->ctrls->ignore_lock.mask= newMask;
+	    if (changes) {
+		changes->ctrls.changed_ctrls|= XkbIgnoreLockModsMask;
+		checkState= True;
+	    }
+	}
+    }
+    if (xkb->indicators!=NULL) {
+	XkbIndicatorMapPtr map;
+	map= &xkb->indicators->maps[0];
+	for (i=0;i<XkbNumIndicators;i++,map++) {
+	    if (map->mods.vmods&changed) {
+		unsigned int newMask = 0;
+		XkbVirtualModsToReal(xkb,map->mods.vmods,&newMask);
+		newMask|= map->mods.real_mods;
+		if (newMask!=map->mods.mask) {
+		    map->mods.mask= newMask;
+		    if (changes) {
+			changes->indicators.map_changes|= (1<<i);
+			checkState= True;
+		    }
+		}
+	    }
+	}
+    }
+    if (xkb->compat!=NULL) {
+	XkbCompatMapPtr	compat;
+	compat= xkb->compat;
+	for (i=0;i<XkbNumKbdGroups;i++) {
+	    unsigned int newMask = 0;
+	    XkbVirtualModsToReal(xkb,compat->groups[i].vmods,&newMask);
+	    newMask|= compat->groups[i].real_mods;
+	    if (compat->groups[i].mask!=newMask) {
+		compat->groups[i].mask= newMask;
+		if (changes) {
+		    changes->compat.changed_groups|= (1<<i);
+		    checkState= True;
+		}
+	    }
+	}
+    }
+    if (xkb->map && xkb->server) {
+	int highChange = 0, lowChange = -1;
+	for (i=xkb->min_key_code;i<=xkb->max_key_code;i++) {
+	    if (XkbKeyHasActions(xkb,i)) {
+		register XkbAction *pAct;
+		register int n;
+
+		pAct= XkbKeyActionsPtr(xkb,i);
+		for (n=XkbKeyNumActions(xkb,i);n>0;n--,pAct++) {
+		    if ((pAct->type!=XkbSA_NoAction)&&
+			XkbUpdateActionVirtualMods(xkb,pAct,changed)) {
+			if (lowChange<0)
+			    lowChange= i;
+			highChange= i;
+		    }
+		}
+	    }
+	}
+	if (changes && (lowChange>0)) { /* something changed */
+	    if (changes->map.changed&XkbKeyActionsMask) {
+		int last;
+		if (changes->map.first_key_act<lowChange)
+		    lowChange= changes->map.first_key_act;
+		last= changes->map.first_key_act+changes->map.num_key_acts-1;
+		if (last>highChange)
+		    highChange= last;
+	    }
+	    changes->map.changed|= 	XkbKeyActionsMask;
+	    changes->map.first_key_act=	lowChange;
+	    changes->map.num_key_acts=	(highChange-lowChange)+1;
+	}
+    }
+    return checkState;
+}

--- a/nx-X11/programs/Xserver/xkb/ddxBeep.c
+++ b/nx-X11/programs/Xserver/xkb/ddxBeep.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 #if (defined(__osf__) && defined(__alpha))

--- a/nx-X11/programs/Xserver/xkb/ddxConfig.c
+++ b/nx-X11/programs/Xserver/xkb/ddxConfig.c
@@ -37,7 +37,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "windowstr.h"
 #include "os.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBconfig.h>
 
 Bool

--- a/nx-X11/programs/Xserver/xkb/ddxConfig.c
+++ b/nx-X11/programs/Xserver/xkb/ddxConfig.c
@@ -36,7 +36,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "scrnintstr.h"
 #include "windowstr.h"
 #include "os.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XKBconfig.h>
 

--- a/nx-X11/programs/Xserver/xkb/ddxCtrls.c
+++ b/nx-X11/programs/Xserver/xkb/ddxCtrls.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 void

--- a/nx-X11/programs/Xserver/xkb/ddxDevBtn.c
+++ b/nx-X11/programs/Xserver/xkb/ddxDevBtn.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 #include <nx-X11/extensions/XIproto.h>
 

--- a/nx-X11/programs/Xserver/xkb/ddxFakeBtn.c
+++ b/nx-X11/programs/Xserver/xkb/ddxFakeBtn.c
@@ -36,7 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 void

--- a/nx-X11/programs/Xserver/xkb/ddxFakeMtn.c
+++ b/nx-X11/programs/Xserver/xkb/ddxFakeMtn.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 #ifdef PANORAMIX

--- a/nx-X11/programs/Xserver/xkb/ddxInit.c
+++ b/nx-X11/programs/Xserver/xkb/ddxInit.c
@@ -36,7 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 int

--- a/nx-X11/programs/Xserver/xkb/ddxKeyClick.c
+++ b/nx-X11/programs/Xserver/xkb/ddxKeyClick.c
@@ -36,7 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 void

--- a/nx-X11/programs/Xserver/xkb/ddxKillSrv.c
+++ b/nx-X11/programs/Xserver/xkb/ddxKillSrv.c
@@ -39,7 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 #ifdef XF86DDXACTIONS

--- a/nx-X11/programs/Xserver/xkb/ddxLEDs.c
+++ b/nx-X11/programs/Xserver/xkb/ddxLEDs.c
@@ -36,7 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 void

--- a/nx-X11/programs/Xserver/xkb/ddxList.c
+++ b/nx-X11/programs/Xserver/xkb/ddxList.c
@@ -39,7 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "scrnintstr.h"
 #include "windowstr.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 #ifndef PATH_MAX

--- a/nx-X11/programs/Xserver/xkb/ddxList.c
+++ b/nx-X11/programs/Xserver/xkb/ddxList.c
@@ -38,7 +38,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 

--- a/nx-X11/programs/Xserver/xkb/ddxLoad.c
+++ b/nx-X11/programs/Xserver/xkb/ddxLoad.c
@@ -50,7 +50,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "scrnintstr.h"
 #include "windowstr.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 #include "xkb.h"
 

--- a/nx-X11/programs/Xserver/xkb/ddxLoad.c
+++ b/nx-X11/programs/Xserver/xkb/ddxLoad.c
@@ -49,7 +49,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/ddxPrivate.c
+++ b/nx-X11/programs/Xserver/xkb/ddxPrivate.c
@@ -11,7 +11,7 @@
 #include <nx-X11/X.h>
 #include "windowstr.h"
 #define XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #ifdef XF86DDXACTIONS
 #include "xf86.h"

--- a/nx-X11/programs/Xserver/xkb/ddxPrivate.c
+++ b/nx-X11/programs/Xserver/xkb/ddxPrivate.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <nx-X11/X.h>
 #include "windowstr.h"
-#define XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
 #ifdef XF86DDXACTIONS

--- a/nx-X11/programs/Xserver/xkb/ddxVT.c
+++ b/nx-X11/programs/Xserver/xkb/ddxVT.c
@@ -39,7 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "scrnintstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XI.h>
 
 #ifdef XF86DDXACTIONS

--- a/nx-X11/programs/Xserver/xkb/maprules.c
+++ b/nx-X11/programs/Xserver/xkb/maprules.c
@@ -65,7 +65,7 @@
 #include "dix.h"
 #include <nx-X11/extensions/XKBstr.h>
 #define XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #endif
 

--- a/nx-X11/programs/Xserver/xkb/maprules.c
+++ b/nx-X11/programs/Xserver/xkb/maprules.c
@@ -47,7 +47,7 @@
 #include <nx-X11/Xatom.h>
 #include <nx-X11/keysym.h>
 #include <nx-X11/XKBlib.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "XKMformat.h"
 #include "XKBfileInt.h"
 #include "XKBrules.h"

--- a/nx-X11/programs/Xserver/xkb/maprules.c
+++ b/nx-X11/programs/Xserver/xkb/maprules.c
@@ -49,7 +49,6 @@
 #include "inputstr.h"
 #include "dix.h"
 #include "xkbstr.h"
-#define XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
 

--- a/nx-X11/programs/Xserver/xkb/maprules.c
+++ b/nx-X11/programs/Xserver/xkb/maprules.c
@@ -38,21 +38,6 @@
 #define XOS_USE_NO_LOCKING
 #include <nx-X11/Xos_r.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <nx-X11/Xproto.h>
-#include <nx-X11/Xlib.h>
-#include <nx-X11/Xos.h>
-#include <nx-X11/Xfuncs.h>
-#include <nx-X11/Xatom.h>
-#include <nx-X11/keysym.h>
-#include <nx-X11/XKBlib.h>
-#include "xkbgeom.h"
-#include "XKMformat.h"
-#include "XKBfileInt.h"
-#include "XKBrules.h"
-
-#else
 
 #include <nx-X11/Xproto.h>
 #include <nx-X11/X.h>
@@ -67,7 +52,6 @@
 #define XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
-#endif
 
 #ifdef DEBUG
 #define PR_DEBUG(s)		fprintf(stderr,s)
@@ -1349,131 +1333,3 @@ XkbRF_GroupPtr	group;
     return;
 }
 
-#ifndef XKB_IN_SERVER
-
-Bool 
-XkbRF_GetNamesProp(Display *dpy,char **rf_rtrn,XkbRF_VarDefsPtr vd_rtrn)
-{
-Atom		rules_atom,actual_type;
-int		fmt;
-unsigned long	nitems,bytes_after;
-char            *data,*out;
-Status		rtrn;
-
-    rules_atom= XInternAtom(dpy,_XKB_RF_NAMES_PROP_ATOM,True);
-    if (rules_atom==None)	/* property cannot exist */
-	return False; 
-    rtrn= XGetWindowProperty(dpy,DefaultRootWindow(dpy),rules_atom,
-                                0L,_XKB_RF_NAMES_PROP_MAXLEN,False,
-                                XA_STRING,&actual_type,
-                                &fmt,&nitems,&bytes_after,
-                                (unsigned char **)&data);
-    if (rtrn!=Success)
-	return False;
-    if (rf_rtrn)
-	*rf_rtrn= NULL;
-    (void)bzero((char *)vd_rtrn,sizeof(XkbRF_VarDefsRec));
-    if ((bytes_after>0)||(actual_type!=XA_STRING)||(fmt!=8)) {
-	if (data) XFree(data);
-	return (fmt==0?True:False);
-    }
-
-    out= data;
-    if (out && (*out) && rf_rtrn)
-	 *rf_rtrn= _XkbDupString(out);
-    out+=strlen(out)+1;
-
-    if ((out-data)<nitems) {
-	if (*out)
-	    vd_rtrn->model= _XkbDupString(out);
-	out+=strlen(out)+1;
-    }
-
-    if ((out-data)<nitems) {
-	if (*out)
-	    vd_rtrn->layout= _XkbDupString(out);
-	out+=strlen(out)+1;
-    }
-
-    if ((out-data)<nitems) {
-	if (*out)
-	    vd_rtrn->variant= _XkbDupString(out);
-	out+=strlen(out)+1;
-    }
-
-
-    if ((out-data)<nitems) {
-	if (*out)
-	    vd_rtrn->options= _XkbDupString(out);
-	out+=strlen(out)+1;
-    }
-    XFree(data);
-    return True;
-}
-
-Bool 
-XkbRF_SetNamesProp(Display *dpy,char *rules_file,XkbRF_VarDefsPtr var_defs)
-{
-int	len,out;
-Atom	name;
-char *	pval;
-
-    len= (rules_file?strlen(rules_file):0);
-    len+= (var_defs->model?strlen(var_defs->model):0);
-    len+= (var_defs->layout?strlen(var_defs->layout):0);
-    len+= (var_defs->variant?strlen(var_defs->variant):0);
-    len+= (var_defs->options?strlen(var_defs->options):0);
-    if (len<1)
-        return True;
-
-    len+= 5; /* trailing NULs */
-
-    name= XInternAtom(dpy,_XKB_RF_NAMES_PROP_ATOM,False);
-    if (name==None)  { /* should never happen */
-	_XkbLibError(_XkbErrXReqFailure,"XkbRF_SetNamesProp",X_InternAtom);
-        return False;
-    }
-    pval= (char *)_XkbAlloc(len);
-    if (!pval) {
-	_XkbLibError(_XkbErrBadAlloc,"XkbRF_SetNamesProp",len);
-        return False;
-    }
-    out= 0;
-    if (rules_file) {
-        strcpy(&pval[out],rules_file);
-        out+= strlen(rules_file);
-    }
-    pval[out++]= '\0';
-    if (var_defs->model) {
-        strcpy(&pval[out],var_defs->model);
-        out+= strlen(var_defs->model);
-    }
-    pval[out++]= '\0';
-    if (var_defs->layout) {
-        strcpy(&pval[out],var_defs->layout);
-        out+= strlen(var_defs->layout);
-    }
-    pval[out++]= '\0';
-    if (var_defs->variant) {
-        strcpy(&pval[out],var_defs->variant);
-        out+= strlen(var_defs->variant);
-    }
-    pval[out++]= '\0';
-    if (var_defs->options) {
-        strcpy(&pval[out],var_defs->options);
-        out+= strlen(var_defs->options);
-    }
-    pval[out++]= '\0';
-    if (out!=len) {
-	_XkbLibError(_XkbErrBadLength,"XkbRF_SetNamesProp",out);
-	_XkbFree(pval);
-	return False;
-    }
-
-    XChangeProperty(dpy,DefaultRootWindow(dpy),name,XA_STRING,8,PropModeReplace,
-                                                (unsigned char *)pval,len);
-    _XkbFree(pval);
-    return True;
-}
-
-#endif

--- a/nx-X11/programs/Xserver/xkb/maprules.c
+++ b/nx-X11/programs/Xserver/xkb/maprules.c
@@ -63,7 +63,7 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "dix.h"
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -3880,7 +3880,7 @@ ProcXkbSetNames(ClientPtr client)
 
 /***====================================================================***/
 
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #define	XkbSizeCountedString(s)  ((s)?((((2+strlen(s))+3)/4)*4):4)
 

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -33,7 +33,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "inputstr.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include "extnsionst.h"
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -34,7 +34,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include "extnsionst.h"
 #include "xkb.h"
 #include "protocol-versions.h"

--- a/nx-X11/programs/Xserver/xkb/xkb.h
+++ b/nx-X11/programs/Xserver/xkb/xkb.h
@@ -1,7 +1,5 @@
 /* $XFree86$ */
 
-/* #include "XKBfile.h" */
-
 extern int ProcXkbUseExtension(ClientPtr client);
 extern int ProcXkbSelectEvents(ClientPtr client);
 extern int ProcXkbBell(ClientPtr client);

--- a/nx-X11/programs/Xserver/xkb/xkbAccessX.c
+++ b/nx-X11/programs/Xserver/xkb/xkbAccessX.c
@@ -37,7 +37,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/Xproto.h>
 #include <nx-X11/keysym.h>
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #if !defined(WIN32) && !defined(Lynx)
 #include <sys/time.h>
 #endif

--- a/nx-X11/programs/Xserver/xkb/xkbActions.c
+++ b/nx-X11/programs/Xserver/xkb/xkbActions.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/keysym.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include "xkb.h"
 #include <ctype.h>
 

--- a/nx-X11/programs/Xserver/xkb/xkbDflts.h
+++ b/nx-X11/programs/Xserver/xkb/xkbDflts.h
@@ -7,13 +7,8 @@
 #ifndef DEFAULT_H
 #define DEFAULT_H 1
 
-#ifndef XKB_IN_SERVER
-#define GET_ATOM(d,s)	XInternAtom(d,s,0)
-#define DPYTYPE	Display *
-#else
 #define GET_ATOM(d,s)	MakeAtom(s,strlen(s),1)
 #define DPYTYPE	char *
-#endif
 #define NUM_KEYS	1
 
 #define	vmod_NumLock	0

--- a/nx-X11/programs/Xserver/xkb/xkbEvents.c
+++ b/nx-X11/programs/Xserver/xkb/xkbEvents.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/extensions/XI.h>
 #include "inputstr.h"
 #include "windowstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include "xkb.h"
 
 /***====================================================================***/

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -46,7 +46,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "opaque.h"
 #include "property.h"
 #include "scrnintstr.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 #include <nx-X11/extensions/XKMformat.h>

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -50,7 +50,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 #include <nx-X11/extensions/XKMformat.h>
-#include <nx-X11/extensions/XKBfile.h>
+#include "xkbfile.h"
 #include "xkb.h"
 
 #define	CREATE_ATOM(s)	MakeAtom(s,sizeof(s)-1,1)

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -48,7 +48,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "scrnintstr.h"
 #define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include <nx-X11/extensions/XKMformat.h>
 #include "xkbfile.h"
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -47,7 +47,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "property.h"
 #include "scrnintstr.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 #include <nx-X11/extensions/XKMformat.h>
 #include <nx-X11/extensions/XKBfile.h>

--- a/nx-X11/programs/Xserver/xkb/xkbLEDs.c
+++ b/nx-X11/programs/Xserver/xkb/xkbLEDs.c
@@ -37,7 +37,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 
 #include <nx-X11/extensions/XI.h>
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include "xkb.h"
 
 /***====================================================================***/

--- a/nx-X11/programs/Xserver/xkb/xkbPrKeyEv.c
+++ b/nx-X11/programs/Xserver/xkb/xkbPrKeyEv.c
@@ -35,7 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/keysym.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <ctype.h>
 
 

--- a/nx-X11/programs/Xserver/xkb/xkbPrOtherEv.c
+++ b/nx-X11/programs/Xserver/xkb/xkbPrOtherEv.c
@@ -36,7 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/keysym.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #include <nx-X11/extensions/XI.h>
 #include <nx-X11/extensions/XIproto.h>

--- a/nx-X11/programs/Xserver/xkb/xkbSwap.c
+++ b/nx-X11/programs/Xserver/xkb/xkbSwap.c
@@ -34,7 +34,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #include "extnsionst.h"
 #include "xkb.h"
 

--- a/nx-X11/programs/Xserver/xkb/xkbSwap.c
+++ b/nx-X11/programs/Xserver/xkb/xkbSwap.c
@@ -33,7 +33,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBstr.h>
 #include "extnsionst.h"
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/xkbUtils.c
+++ b/nx-X11/programs/Xserver/xkb/xkbUtils.c
@@ -40,7 +40,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "xkb.h"
 
 #ifdef MODE_SWITCH

--- a/nx-X11/programs/Xserver/xkb/xkbUtils.c
+++ b/nx-X11/programs/Xserver/xkb/xkbUtils.c
@@ -39,7 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 #include "xkb.h"
 

--- a/nx-X11/programs/Xserver/xkb/xkbUtils.c
+++ b/nx-X11/programs/Xserver/xkb/xkbUtils.c
@@ -38,7 +38,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/xkbconfig.c
+++ b/nx-X11/programs/Xserver/xkb/xkbconfig.c
@@ -55,7 +55,7 @@
 #include "inputstr.h"
 #include "dix.h"
 #define	XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #endif
 
 #include <nx-X11/extensions/XKBconfig.h>

--- a/nx-X11/programs/Xserver/xkb/xkbconfig.c
+++ b/nx-X11/programs/Xserver/xkb/xkbconfig.c
@@ -45,7 +45,6 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "dix.h"
-#define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 
 #include <nx-X11/extensions/XKBconfig.h>

--- a/nx-X11/programs/Xserver/xkb/xkbconfig.c
+++ b/nx-X11/programs/Xserver/xkb/xkbconfig.c
@@ -38,15 +38,6 @@
 
 #include <nx-X11/Xfuncs.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <nx-X11/Xos.h>
-#include <nx-X11/Xlib.h>
-#include <nx-X11/keysym.h>
-#include <nx-X11/XKBlib.h>
-#include "XKBfileInt.h"
-
-#else
 
 #include <nx-X11/X.h>
 #include <nx-X11/keysym.h>
@@ -56,7 +47,6 @@
 #include "dix.h"
 #define	XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
-#endif
 
 #include <nx-X11/extensions/XKBconfig.h>
 
@@ -1339,14 +1329,8 @@ char *	msg;
 	default:
 	    msg= "unknown error on line %d"; break;
     }
-#ifndef XKB_IN_SERVER
-    fprintf(file,msg,line);
-    if (name)	fprintf(file," of %s\n",name);
-    else	fprintf(file,"\n");
-#else
     ErrorF(msg,line);
     if (name)	ErrorF(" of %s\n",name);
     else	ErrorF("\n");
-#endif
     return;
 }

--- a/nx-X11/programs/Xserver/xkb/xkbfmisc.c
+++ b/nx-X11/programs/Xserver/xkb/xkbfmisc.c
@@ -54,7 +54,7 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "dix.h"
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>

--- a/nx-X11/programs/Xserver/xkb/xkbfmisc.c
+++ b/nx-X11/programs/Xserver/xkb/xkbfmisc.c
@@ -37,16 +37,6 @@
 #include <nx-X11/Xos.h>
 #include <nx-X11/Xfuncs.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <nx-X11/Xlib.h>
-#include <nx-X11/keysym.h>
-#include <nx-X11/XKBlib.h>
-#include "xkbgeom.h"
-#include "XKMformat.h"
-#include "XKBfileInt.h"
-
-#else
 
 #include <nx-X11/X.h>
 #include <nx-X11/keysym.h>
@@ -60,7 +50,6 @@
 #include "xkbgeom.h"
 #include "xkb.h"
 
-#endif
 
 unsigned
 _XkbKSCheckCase(KeySym ks)

--- a/nx-X11/programs/Xserver/xkb/xkbfmisc.c
+++ b/nx-X11/programs/Xserver/xkb/xkbfmisc.c
@@ -56,7 +56,7 @@
 #include "dix.h"
 #include <nx-X11/extensions/XKBstr.h>
 #define XKBSRV_NEED_FILE_FUNCS	1
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 #include "xkb.h"
 

--- a/nx-X11/programs/Xserver/xkb/xkbfmisc.c
+++ b/nx-X11/programs/Xserver/xkb/xkbfmisc.c
@@ -42,7 +42,7 @@
 #include <nx-X11/Xlib.h>
 #include <nx-X11/keysym.h>
 #include <nx-X11/XKBlib.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "XKMformat.h"
 #include "XKBfileInt.h"
 
@@ -57,7 +57,7 @@
 #include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "xkb.h"
 
 #endif

--- a/nx-X11/programs/Xserver/xkb/xkbfmisc.c
+++ b/nx-X11/programs/Xserver/xkb/xkbfmisc.c
@@ -45,7 +45,6 @@
 #include "inputstr.h"
 #include "dix.h"
 #include "xkbstr.h"
-#define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 #include "xkb.h"

--- a/nx-X11/programs/Xserver/xkb/xkbgeom.h
+++ b/nx-X11/programs/Xserver/xkb/xkbgeom.h
@@ -1,0 +1,655 @@
+/************************************************************
+Copyright (c) 1993 by Silicon Graphics Computer Systems, Inc.
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation, and that the name of Silicon Graphics not be 
+used in advertising or publicity pertaining to distribution 
+of the software without specific prior written permission.
+Silicon Graphics makes no representation about the suitability 
+of this software for any purpose. It is provided "as is"
+without any express or implied warranty.
+
+SILICON GRAPHICS DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS 
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY 
+AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL SILICON
+GRAPHICS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL 
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, 
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
+THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+********************************************************/
+
+#ifndef _XKBGEOM_H_
+#define	_XKBGEOM_H_
+
+#include "xkbstr.h"
+
+#define XkbAddGeomKeyAlias 		SrvXkbAddGeomKeyAlias
+#define XkbAddGeomColor 		SrvXkbAddGeomColor
+#define XkbAddGeomDoodad		SrvXkbAddGeomDoodad
+#define XkbAddGeomKey			SrvXkbAddGeomKey
+#define XkbAddGeomOutline		SrvXkbAddGeomOutline
+#define XkbAddGeomOverlay		SrvXkbAddGeomOverlay
+#define XkbAddGeomOverlayRow		SrvXkbAddGeomOverlayRow
+#define	XkbAddGeomOverlayKey		SrvXkbAddGeomOverlayKey
+#define XkbAddGeomProperty		SrvXkbAddGeomProperty
+#define XkbAddGeomRow			SrvXkbAddGeomRow
+#define XkbAddGeomSection		SrvXkbAddGeomSection
+#define XkbAddGeomShape			SrvXkbAddGeomShape
+#define XkbAllocGeomKeyAliases		SrvXkbAllocGeomKeyAliases
+#define XkbAllocGeomColors		SrvXkbAllocGeomColors
+#define XkbAllocGeomDoodads		SrvXkbAllocGeomDoodads
+#define XkbAllocGeomKeys		SrvXkbAllocGeomKeys
+#define XkbAllocGeomOutlines		SrvXkbAllocGeomOutlines
+#define XkbAllocGeomPoints		SrvXkbAllocGeomPoints
+#define XkbAllocGeomProps		SrvXkbAllocGeomProps
+#define XkbAllocGeomRows		SrvXkbAllocGeomRows
+#define XkbAllocGeomSectionDoodads	SrvXkbAllocGeomSectionDoodads
+#define XkbAllocGeomSections		SrvXkbAllocGeomSections
+#define	XkbAllocGeomOverlays		SrvXkbAllocGeomOverlays
+#define	XkbAllocGeomOverlayRows		SrvXkbAllocGeomOverlayRows
+#define	XkbAllocGeomOverlayKeys		SrvXkbAllocGeomOverlayKeys
+#define XkbAllocGeomShapes		SrvXkbAllocGeomShapes
+#define XkbAllocGeometry		SrvXkbAllocGeometry
+#define XkbFreeGeomKeyAliases		SrvXkbFreeGeomKeyAliases
+#define XkbFreeGeomColors		SrvXkbFreeGeomColors
+#define XkbFreeGeomDoodads		SrvXkbFreeGeomDoodads
+#define XkbFreeGeomProperties		SrvXkbFreeGeomProperties
+#define	XkbFreeGeomOverlayKeys		SrvXkbFreeGeomOverlayKeys
+#define	XkbFreeGeomOverlayRows		SrvXkbFreeGeomOverlayRows
+#define	XkbFreeGeomOverlays		SrvXkbFreeGeomOverlays
+#define	XkbFreeGeomKeys			SrvXkbFreeGeomKeys
+#define	XkbFreeGeomRows			SrvXkbFreeGeomRows
+#define XkbFreeGeomSections		SrvXkbFreeGeomSections
+#define	XkbFreeGeomPoints		SrvXkbFreeGeomPoints
+#define	XkbFreeGeomOutlines		SrvXkbFreeGeomOutlines
+#define XkbFreeGeomShapes		SrvXkbFreeGeomShapes
+#define XkbFreeGeometry			SrvXkbFreeGeometry
+
+typedef	struct _XkbProperty {
+	char	*name;
+	char	*value;
+} XkbPropertyRec,*XkbPropertyPtr;
+
+typedef struct _XkbColor {
+	unsigned int 	pixel;
+	char *		spec;
+} XkbColorRec,*XkbColorPtr;
+
+typedef	struct _XkbPoint {
+	short	x;
+	short	y;
+} XkbPointRec, *XkbPointPtr;
+
+typedef struct	_XkbBounds {
+	short	x1,y1;
+	short	x2,y2;
+} XkbBoundsRec, *XkbBoundsPtr;
+#define	XkbBoundsWidth(b)	(((b)->x2)-((b)->x1))
+#define	XkbBoundsHeight(b)	(((b)->y2)-((b)->y1))
+
+typedef struct _XkbOutline {
+	unsigned short	num_points;
+	unsigned short	sz_points;
+	unsigned short	corner_radius;
+	XkbPointPtr	points;
+} XkbOutlineRec, *XkbOutlinePtr;
+
+typedef struct _XkbShape {
+	Atom	 	 name;
+	unsigned short	 num_outlines;
+	unsigned short	 sz_outlines;
+	XkbOutlinePtr	 outlines;
+	XkbOutlinePtr	 approx;
+	XkbOutlinePtr	 primary;
+	XkbBoundsRec	 bounds;
+} XkbShapeRec, *XkbShapePtr;
+#define	XkbOutlineIndex(s,o)	((int)((o)-&(s)->outlines[0]))
+
+typedef struct _XkbShapeDoodad {
+	Atom		 name;
+	unsigned char	 type;
+	unsigned char	 priority;
+	short		 top;
+	short		 left;
+	short	 	 angle;
+	unsigned short	 color_ndx;
+	unsigned short	 shape_ndx;
+} XkbShapeDoodadRec, *XkbShapeDoodadPtr;
+#define	XkbShapeDoodadColor(g,d)	(&(g)->colors[(d)->color_ndx])
+#define	XkbShapeDoodadShape(g,d)	(&(g)->shapes[(d)->shape_ndx])
+#define	XkbSetShapeDoodadColor(g,d,c)	((d)->color_ndx= (c)-&(g)->colors[0])
+#define	XkbSetShapeDoodadShape(g,d,s)	((d)->shape_ndx= (s)-&(g)->shapes[0])
+
+typedef struct _XkbTextDoodad {
+	Atom		 name;
+	unsigned char	 type;
+	unsigned char	 priority;
+	short	 	 top;
+	short	 	 left;
+	short	 	 angle;
+	short	 	 width;
+	short		 height;
+	unsigned short	 color_ndx;
+	char *		 text;
+	char *		 font;
+} XkbTextDoodadRec, *XkbTextDoodadPtr;
+#define	XkbTextDoodadColor(g,d)	(&(g)->colors[(d)->color_ndx])
+#define	XkbSetTextDoodadColor(g,d,c)	((d)->color_ndx= (c)-&(g)->colors[0])
+
+typedef struct _XkbIndicatorDoodad {
+	Atom		 name;
+	unsigned char	 type;
+	unsigned char	 priority;
+	short	 	 top;
+	short	 	 left;
+	short		 angle;
+	unsigned short	 shape_ndx;
+	unsigned short	 on_color_ndx;
+	unsigned short	 off_color_ndx;
+} XkbIndicatorDoodadRec, *XkbIndicatorDoodadPtr;
+#define	XkbIndicatorDoodadShape(g,d)	(&(g)->shapes[(d)->shape_ndx])
+#define	XkbIndicatorDoodadOnColor(g,d)	(&(g)->colors[(d)->on_color_ndx])
+#define	XkbIndicatorDoodadOffColor(g,d)	(&(g)->colors[(d)->off_color_ndx])
+#define	XkbSetIndicatorDoodadOnColor(g,d,c) \
+				((d)->on_color_ndx= (c)-&(g)->colors[0])
+#define	XkbSetIndicatorDoodadOffColor(g,d,c) \
+				((d)->off_color_ndx= (c)-&(g)->colors[0])
+#define	XkbSetIndicatorDoodadShape(g,d,s) \
+				((d)->shape_ndx= (s)-&(g)->shapes[0])
+
+typedef struct _XkbLogoDoodad {
+	Atom		 name;
+	unsigned char	 type;
+	unsigned char	 priority;
+	short		 top;
+	short		 left;
+	short	 	 angle;
+	unsigned short	 color_ndx;
+	unsigned short	 shape_ndx;
+	char *		 logo_name;
+} XkbLogoDoodadRec, *XkbLogoDoodadPtr;
+#define	XkbLogoDoodadColor(g,d)		(&(g)->colors[(d)->color_ndx])
+#define	XkbLogoDoodadShape(g,d)		(&(g)->shapes[(d)->shape_ndx])
+#define	XkbSetLogoDoodadColor(g,d,c)	((d)->color_ndx= (c)-&(g)->colors[0])
+#define	XkbSetLogoDoodadShape(g,d,s)	((d)->shape_ndx= (s)-&(g)->shapes[0])
+
+typedef struct _XkbAnyDoodad {
+	Atom		 name;
+	unsigned char	 type;
+	unsigned char	 priority;
+	short	 	 top;
+	short	 	 left;
+	short		 angle;
+} XkbAnyDoodadRec, *XkbAnyDoodadPtr;
+
+typedef union _XkbDoodad {
+	XkbAnyDoodadRec		any;
+	XkbShapeDoodadRec	shape;
+	XkbTextDoodadRec	text;
+	XkbIndicatorDoodadRec	indicator;
+	XkbLogoDoodadRec	logo;
+} XkbDoodadRec, *XkbDoodadPtr;
+
+#define	XkbUnknownDoodad	0
+#define	XkbOutlineDoodad	1
+#define	XkbSolidDoodad		2
+#define	XkbTextDoodad		3
+#define	XkbIndicatorDoodad	4
+#define	XkbLogoDoodad		5
+
+typedef struct _XkbKey {
+	XkbKeyNameRec	 name;
+	short		 gap;
+	unsigned char	 shape_ndx;
+	unsigned char	 color_ndx;
+} XkbKeyRec, *XkbKeyPtr;
+#define	XkbKeyShape(g,k)	(&(g)->shapes[(k)->shape_ndx])
+#define	XkbKeyColor(g,k)	(&(g)->colors[(k)->color_ndx])
+#define	XkbSetKeyShape(g,k,s)	((k)->shape_ndx= (s)-&(g)->shapes[0])
+#define	XkbSetKeyColor(g,k,c)	((k)->color_ndx= (c)-&(g)->colors[0])
+
+typedef struct _XkbRow {
+	short	 	top;
+	short	 	left;
+	unsigned short	num_keys;
+	unsigned short	sz_keys;
+	int		vertical;
+	XkbKeyPtr	keys;
+	XkbBoundsRec	bounds;
+} XkbRowRec, *XkbRowPtr;
+
+typedef struct _XkbSection {
+	Atom		 name;
+	unsigned char	 priority;
+	short	 	 top;
+	short	 	 left;
+	unsigned short	 width;
+	unsigned short	 height;
+	short	 	 angle;
+	unsigned short	 num_rows;
+	unsigned short	 num_doodads;
+	unsigned short	 num_overlays;
+	unsigned short	 sz_rows;
+	unsigned short	 sz_doodads;
+	unsigned short	 sz_overlays;
+	XkbRowPtr	 rows;
+	XkbDoodadPtr	 doodads;
+	XkbBoundsRec	 bounds;
+	struct _XkbOverlay *overlays;
+} XkbSectionRec, *XkbSectionPtr;
+
+typedef	struct _XkbOverlayKey {
+	XkbKeyNameRec	over;
+	XkbKeyNameRec	under;
+} XkbOverlayKeyRec,*XkbOverlayKeyPtr;
+
+typedef struct _XkbOverlayRow {
+	unsigned short		row_under;
+	unsigned short		num_keys;
+	unsigned short		sz_keys;
+	XkbOverlayKeyPtr	keys;
+} XkbOverlayRowRec,*XkbOverlayRowPtr;
+
+typedef struct _XkbOverlay {
+	Atom			name;
+	XkbSectionPtr		section_under;
+	unsigned short		num_rows;
+	unsigned short		sz_rows;
+	XkbOverlayRowPtr	rows;
+	XkbBoundsPtr		bounds;
+} XkbOverlayRec,*XkbOverlayPtr;
+
+typedef struct _XkbGeometry {
+	Atom		 name;
+	unsigned short	 width_mm;
+	unsigned short	 height_mm;
+	char *		 label_font;
+	XkbColorPtr	 label_color;
+	XkbColorPtr	 base_color;
+	unsigned short	 sz_properties;
+	unsigned short	 sz_colors;
+	unsigned short	 sz_shapes;
+	unsigned short   sz_sections;
+	unsigned short	 sz_doodads;
+	unsigned short	 sz_key_aliases;
+	unsigned short	 num_properties;
+	unsigned short	 num_colors;
+	unsigned short	 num_shapes;
+	unsigned short	 num_sections;
+	unsigned short	 num_doodads;
+	unsigned short	 num_key_aliases;
+	XkbPropertyPtr	 properties;
+	XkbColorPtr	 colors;
+	XkbShapePtr	 shapes;
+	XkbSectionPtr	 sections;
+	XkbDoodadPtr	 doodads;
+	XkbKeyAliasPtr	 key_aliases;
+} XkbGeometryRec;
+#define	XkbGeomColorIndex(g,c)	((int)((c)-&(g)->colors[0]))
+
+#define	XkbGeomPropertiesMask	(1<<0)
+#define	XkbGeomColorsMask	(1<<1)
+#define	XkbGeomShapesMask	(1<<2)
+#define	XkbGeomSectionsMask	(1<<3)
+#define	XkbGeomDoodadsMask	(1<<4)
+#define	XkbGeomKeyAliasesMask	(1<<5)
+#define	XkbGeomAllMask		(0x3f)
+
+typedef struct _XkbGeometrySizes {
+	unsigned int	which;
+	unsigned short	num_properties;
+	unsigned short	num_colors;
+	unsigned short	num_shapes;
+	unsigned short	num_sections;
+	unsigned short	num_doodads;
+	unsigned short	num_key_aliases;
+} XkbGeometrySizesRec,*XkbGeometrySizesPtr;
+
+_XFUNCPROTOBEGIN
+
+extern	XkbPropertyPtr
+XkbAddGeomProperty(
+    XkbGeometryPtr	/* geom */,
+    char *		/* name */,
+    char *		/* value */
+);
+
+extern	XkbKeyAliasPtr
+XkbAddGeomKeyAlias(
+    XkbGeometryPtr	/* geom */,
+    char *		/* alias */,
+    char *		/* real */
+);
+
+extern	XkbColorPtr
+XkbAddGeomColor(
+    XkbGeometryPtr	/* geom */,
+    char *		/* spec */,
+    unsigned int	/* pixel */
+);
+
+extern	XkbOutlinePtr
+XkbAddGeomOutline(
+    XkbShapePtr		/* shape */,
+    int			/* sz_points */
+);
+
+extern XkbShapePtr
+XkbAddGeomShape(
+    XkbGeometryPtr	/* geom */,
+    Atom		/* name */,
+    int			/* sz_outlines */
+);
+
+extern XkbKeyPtr
+XkbAddGeomKey(
+    XkbRowPtr		/* row */
+);
+
+extern XkbRowPtr
+XkbAddGeomRow(
+    XkbSectionPtr	/* section */,
+    int			/* sz_keys */
+);
+
+extern XkbSectionPtr
+XkbAddGeomSection(
+    XkbGeometryPtr	/* geom */,
+    Atom		/* name */,
+    int			/* sz_rows */,
+    int			/* sz_doodads */,
+    int			/* sz_overlays */
+);
+
+extern XkbOverlayPtr
+XkbAddGeomOverlay(
+    XkbSectionPtr	/* section */,
+    Atom		/* name */,
+    int			/* sz_rows */
+);
+
+extern XkbOverlayRowPtr
+XkbAddGeomOverlayRow(
+    XkbOverlayPtr	/* overlay */,
+    int			/* row_under */,
+    int			/* sz_keys */
+);
+
+extern XkbOverlayKeyPtr
+XkbAddGeomOverlayKey(
+    XkbOverlayPtr	/* overlay */,
+    XkbOverlayRowPtr	/* row */,
+    char *		/* over */,
+    char *		/* under */
+);
+
+extern XkbDoodadPtr
+XkbAddGeomDoodad(
+    XkbGeometryPtr	/* geom */,
+    XkbSectionPtr	/* section */,
+    Atom		/* name */
+);
+
+
+extern void
+XkbFreeGeomKeyAliases(
+    XkbGeometryPtr	/* geom */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomColors(
+    XkbGeometryPtr	/* geom */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomDoodads(
+    XkbDoodadPtr	/* doodads */,
+    int			/* nDoodads */,
+    Bool		/* freeAll */
+);
+
+
+extern void
+XkbFreeGeomProperties(
+    XkbGeometryPtr	/* geom */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomOverlayKeys(
+    XkbOverlayRowPtr	/* row */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomOverlayRows(
+    XkbOverlayPtr	/* overlay */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomOverlays(
+    XkbSectionPtr	/* section */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomKeys(
+    XkbRowPtr		/* row */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomRows(
+    XkbSectionPtr	/* section */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomSections(
+    XkbGeometryPtr	/* geom */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+
+extern void
+XkbFreeGeomPoints(
+    XkbOutlinePtr	/* outline */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomOutlines(
+    XkbShapePtr		/* shape */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeomShapes(
+    XkbGeometryPtr	/* geom */,
+    int			/* first */,
+    int			/* count */,
+    Bool		/* freeAll */
+);
+
+extern void
+XkbFreeGeometry(
+    XkbGeometryPtr	/* geom */,
+    unsigned int	/* which */,
+    Bool		/* freeMap */
+);
+
+extern Status
+XkbAllocGeomProps(
+    XkbGeometryPtr	/* geom */,
+    int			/* nProps */
+);
+
+extern Status
+XkbAllocGeomKeyAliases(
+    XkbGeometryPtr	/* geom */,
+    int			/* nAliases */
+);
+
+extern Status
+XkbAllocGeomColors(
+    XkbGeometryPtr	/* geom */,
+    int			/* nColors */
+);
+
+extern Status
+XkbAllocGeomShapes(
+    XkbGeometryPtr	/* geom */,
+    int			/* nShapes */
+);
+
+extern Status
+XkbAllocGeomSections(
+    XkbGeometryPtr	/* geom */,
+    int			/* nSections */
+);
+
+extern Status
+XkbAllocGeomOverlays(
+    XkbSectionPtr	/* section */,
+    int			/* num_needed */
+);
+
+extern Status
+XkbAllocGeomOverlayRows(
+    XkbOverlayPtr	/* overlay */,
+    int			/* num_needed */
+);
+
+extern Status
+XkbAllocGeomOverlayKeys(
+    XkbOverlayRowPtr	/* row */,
+    int			/* num_needed */
+);
+
+extern Status
+XkbAllocGeomDoodads(
+    XkbGeometryPtr	/* geom */,
+    int			/* nDoodads */
+);
+
+extern Status
+XkbAllocGeomSectionDoodads(
+    XkbSectionPtr	/* section */,
+    int			/* nDoodads */
+);
+
+extern Status
+XkbAllocGeomOutlines(
+    XkbShapePtr		/* shape */,
+    int			/* nOL */
+);
+
+extern Status
+XkbAllocGeomRows(
+    XkbSectionPtr	/* section */,
+    int			/* nRows */
+);
+
+extern Status
+XkbAllocGeomPoints(
+    XkbOutlinePtr	/* ol */,
+    int			/* nPts */
+);
+
+extern Status
+XkbAllocGeomKeys(
+    XkbRowPtr		/* row */,
+    int			/* nKeys */
+);
+
+extern	Status
+XkbAllocGeometry(
+	XkbDescPtr		/* xkb */,
+	XkbGeometrySizesPtr	/* sizes */
+);
+
+extern	Status
+XkbSetGeometry(
+	Display *		/* dpy */,
+	unsigned		/* deviceSpec */,
+	XkbGeometryPtr		/* geom */
+);
+
+extern	Bool
+XkbComputeShapeTop(
+	XkbShapePtr		/* shape */,
+	XkbBoundsPtr		/* bounds */
+);
+
+extern	Bool
+XkbComputeShapeBounds(
+	XkbShapePtr		/* shape */
+);
+
+extern	Bool
+XkbComputeRowBounds(
+	XkbGeometryPtr		/* geom */,
+	XkbSectionPtr		/* section */,
+	XkbRowPtr		/* row */
+);
+
+extern	Bool
+XkbComputeSectionBounds(
+	XkbGeometryPtr		/* geom */,
+	XkbSectionPtr		/* section */
+);
+
+extern	char *
+XkbFindOverlayForKey(
+	XkbGeometryPtr		/* geom */,
+	XkbSectionPtr		/* wanted */,
+	char *			/* under */
+);
+
+extern	Status
+XkbGetGeometry(
+    Display *			/* dpy */,
+    XkbDescPtr			/* xkb */
+);
+
+extern	Status
+XkbGetNamedGeometry(
+    Display *			/* dpy */,
+    XkbDescPtr			/* xkb */,
+    Atom			/* name */
+);
+
+_XFUNCPROTOEND
+
+#endif /* _XKBSTR_H_ */

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -57,7 +57,7 @@
 #include <xkbsrv.h>
 
 #include <nx-X11/extensions/XKBgeom.h>
-#include <nx-X11/extensions/XKBfile.h>
+#include "xkbfile.h"
 
 #endif
 

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -43,7 +43,6 @@
 #include "inputstr.h"
 #include "dix.h"
 #include "xkbstr.h"
-#define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 
 #include "xkbgeom.h"

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -52,7 +52,7 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "dix.h"
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -54,7 +54,7 @@
 #include "dix.h"
 #include <nx-X11/extensions/XKBstr.h>
 #define XKBSRV_NEED_FILE_FUNCS	1
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 
 #include <nx-X11/extensions/XKBgeom.h>
 #include <nx-X11/extensions/XKBfile.h>

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -39,7 +39,7 @@
 
 #include <nx-X11/Xlib.h>
 #include <nx-X11/XKBlib.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #include "XKMformat.h"
 #include "XKBfileInt.h"
@@ -56,7 +56,7 @@
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "xkbfile.h"
 
 #endif

--- a/nx-X11/programs/Xserver/xkb/xkbout.c
+++ b/nx-X11/programs/Xserver/xkb/xkbout.c
@@ -35,16 +35,6 @@
 #include <stdlib.h>
 #include <nx-X11/Xfuncs.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <nx-X11/Xlib.h>
-#include <nx-X11/XKBlib.h>
-#include "xkbgeom.h"
-
-#include "XKMformat.h"
-#include "XKBfileInt.h"
-
-#else
 
 #include <nx-X11/X.h>
 #include <nx-X11/keysym.h>
@@ -59,7 +49,6 @@
 #include "xkbgeom.h"
 #include "xkbfile.h"
 
-#endif
 
 #define	VMOD_HIDE_VALUE	0
 #define	VMOD_SHOW_VALUE	1

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -40,7 +40,7 @@
 
 #include <nx-X11/Xlib.h>
 #include <nx-X11/XKBlib.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #include "XKMformat.h"
 #include "XKBfileInt.h"
@@ -55,7 +55,7 @@
 #include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 #endif
 

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -54,7 +54,7 @@
 #include "dix.h"
 #include <nx-X11/extensions/XKBstr.h>
 #define XKBSRV_NEED_FILE_FUNCS	1
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 
 #endif

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -43,7 +43,6 @@
 #include "inputstr.h"
 #include "dix.h"
 #include "xkbstr.h"
-#define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -52,7 +52,7 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "dix.h"
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #define XKBSRV_NEED_FILE_FUNCS	1
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -36,16 +36,6 @@
 
 #include <nx-X11/Xos.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <nx-X11/Xlib.h>
-#include <nx-X11/XKBlib.h>
-#include "xkbgeom.h"
-
-#include "XKMformat.h"
-#include "XKBfileInt.h"
-
-#else
 
 #include <nx-X11/X.h>
 #include <nx-X11/Xproto.h>
@@ -57,7 +47,6 @@
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 
-#endif
 
 /***====================================================================***/
 
@@ -348,22 +337,10 @@ XkbKeysymText(KeySym sym,unsigned format)
 {
 static char buf[32],*rtrn;
 
-#ifndef XKB_IN_SERVER
-    if (sym==NoSymbol)
-	strcpy(rtrn=buf,"NoSymbol");
-    else if ((rtrn=XKeysymToString(sym))==NULL)
-	sprintf(rtrn=buf, "0x%lx", (long)sym);
-    else if (format==XkbCFile) {
-	sprintf(buf,"XK_%s",rtrn);
-	rtrn= buf;
-    }
-    return rtrn;
-#else /* def XKB_IN_SERVER */
     if (sym==NoSymbol)
 	 strcpy(rtrn=buf,"NoSymbol");
     else sprintf(rtrn=buf, "0x%lx", (long)sym);
     return rtrn;
-#endif /* XKB_IN_SERVER */
 }
 
 char *
@@ -1348,90 +1325,3 @@ register int i;
     return buf;
 }
 
-#ifndef XKB_IN_SERVER
-
-/***====================================================================***/
-
-#define	PIXEL_MAX	65535
-
-Bool
-XkbLookupCanonicalRGBColor(char *def,XColor *color)
-{
-int     tmp;
-
-    if (_XkbStrCaseEqual(def,"black")) {
-	color->red= color->green= color->blue= 0;
-	return True;
-    }
-    else if (_XkbStrCaseEqual(def,"white")) {
-	color->red= color->green= color->blue= PIXEL_MAX;
-	return True;
-    }
-    else if ((sscanf(def,"grey%d",&tmp)==1)||
-        (sscanf(def,"gray%d",&tmp)==1)||
-        (sscanf(def,"Grey%d",&tmp)==1)||
-        (sscanf(def,"Gray%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->red= color->green= color->blue= tmp;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"red")*100))||
-             (sscanf(def,"red%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->red= tmp;
-	    color->green= color->blue= 0;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"green")*100))||
-             (sscanf(def,"green%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->green= tmp;
-	    color->red= color->blue= 0;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"blue")*100))||
-             (sscanf(def,"blue%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->blue= tmp;
-	    color->red= color->green= 0;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"magenta")*100))||
-             (sscanf(def,"magenta%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->green= 0;
-	    color->red= color->blue= tmp;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"cyan")*100))||
-             (sscanf(def,"cyan%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->red= 0;
-	    color->green= color->blue= tmp;
-	    return True;
-	}
-    }
-    else if ((tmp=(_XkbStrCaseEqual(def,"yellow")*100))||
-             (sscanf(def,"yellow%d",&tmp)==1)) {
-	if ((tmp>0)&&(tmp<=100)) {
-	    tmp= (PIXEL_MAX*tmp)/100;
-	    color->blue= 0;
-	    color->red= color->green= tmp;
-	    return True;
-	}
-    }
-    return False;
-}
-
-#endif

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -42,7 +42,6 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "xkbstr.h"
-#define	 XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include "xkbgeom.h"
 

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -42,7 +42,7 @@
 #include "misc.h"
 #include "inputstr.h"
 #include "xkbstr.h"
-#include <xkbsrv.h>
+#include "xkbsrv.h"
 #include "xkbgeom.h"
 
 Atom

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -35,19 +35,6 @@
 #include <nx-X11/Xos.h>
 #include <nx-X11/Xfuncs.h>
 
-#ifndef XKB_IN_SERVER
-
-#include <stdlib.h>
-#include <nx-X11/Xlib.h>
-#include <nx-X11/keysym.h>
-
-#include <nx-X11/XKBlib.h>
-
-#include "xkbgeom.h"
-#include "XKMformat.h"
-#include "XKBfileInt.h"
-
-#else
 
 #include <nx-X11/X.h>
 #include <nx-X11/Xproto.h>
@@ -67,7 +54,6 @@ XkbInternAtom(Display *dpy,char *str,Bool only_if_exists)
     return MakeAtom(str,strlen(str),!only_if_exists);
 }
 
-#endif
 
 #ifndef SEEK_SET
 #define	SEEK_SET 0

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -56,7 +56,7 @@
 #include "inputstr.h"
 #include <nx-X11/extensions/XKBstr.h>
 #define	 XKBSRV_NEED_FILE_FUNCS
-#include <nx-X11/extensions/XKBsrv.h>
+#include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>
 
 Atom

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -43,7 +43,7 @@
 
 #include <nx-X11/XKBlib.h>
 
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 #include "XKMformat.h"
 #include "XKBfileInt.h"
 
@@ -57,7 +57,7 @@
 #include "xkbstr.h"
 #define	 XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
-#include <nx-X11/extensions/XKBgeom.h>
+#include "xkbgeom.h"
 
 Atom
 XkbInternAtom(Display *dpy,char *str,Bool only_if_exists)

--- a/nx-X11/programs/Xserver/xkb/xkmread.c
+++ b/nx-X11/programs/Xserver/xkb/xkmread.c
@@ -54,7 +54,7 @@
 #include <nx-X11/keysym.h>
 #include "misc.h"
 #include "inputstr.h"
-#include <nx-X11/extensions/XKBstr.h>
+#include "xkbstr.h"
 #define	 XKBSRV_NEED_FILE_FUNCS
 #include <xkbsrv.h>
 #include <nx-X11/extensions/XKBgeom.h>


### PR DESCRIPTION
- Use own copies of xkb headers just as upstream does.
- refer to Xtrans via header file xstrans.c instead of softlinking in the makefile
- backport fixes for some compiler warnings that became obvious after the xstrans switch. These happened to be CVEs...
