### PR TITLE
Slave channel implementation

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -359,7 +359,7 @@ static void RestoreSignal(int signal);
 
 static int HandleChildren();
 
-static int HandleChild(int child);
+int HandleChild(int child);
 static int CheckChild(int pid, int status);
 static int WaitChild(int child, const char *label, int force);
 
@@ -6249,6 +6249,8 @@ int HandleChildren()
 
     return 1;
   }
+
+  proxy->checkSlaves();
 
   //
   // This can actually happen either because we

--- a/nxcomp/Misc.cpp
+++ b/nxcomp/Misc.cpp
@@ -358,6 +358,13 @@ tolerancechecks=s\n\
                ory compared to the other programs, to make easier\n\
                for the user to execute the program from the shell.\n\
 \n\
+  NX_SLAVE_CMD The full path to the slave channel handler. When the\n\
+               slave channel is enabled, the agent will listen on a\n\
+               port and forward the connection to the NX_SLAVE_CMD\n\
+               program. This can be used to implement agent/proxy\n\
+               communication for applications such as serial port and\n\
+               USB forwarding.\n\
+\n\
   Shell environment:\n\
 \n\
   HOME         The variable is checked in the case NX_HOME is not\n\

--- a/nxcomp/Proxy.h
+++ b/nxcomp/Proxy.h
@@ -302,6 +302,8 @@ class Proxy
 
   int handleNewSlaveConnectionFromProxy(int channelId);
 
+  void checkSlaves();
+
   //
   // Force closure of channels.
   //
@@ -1268,6 +1270,7 @@ class Proxy
 
   int channelMap_[CONNECTIONS_LIMIT];
   int fdMap_[CONNECTIONS_LIMIT];
+  int slavePidMap_[CONNECTIONS_LIMIT];
 };
 
 #endif /* Proxy_H */

--- a/nxproxy/man/nxproxy.1
+++ b/nxproxy/man/nxproxy.1
@@ -339,6 +339,13 @@ where <nxclient> is located in a different directory compared to the
 other programs, to make easier for the user to execute the program from
 the shell.
 
+.TP 8
+.B  NX_SLAVE_CMD
+The full path to the slave channel handler. When the slave channel is
+enabled, the agent will listen on a port and forward the connection to
+the NX_SLAVE_CMD program. This can be used to implement agent/proxy
+communication for applications such as serial port and USB forwarding.
+
 .SH SHELL ENVIRONMENT VARIABLES
 
 .TP 8


### PR DESCRIPTION
This is the slave channel implementation we use at QVD. 

When the channel is enabled, and the NX_SLAVE_CMD environment variable is set to a command, the agent or the proxy listens on a port, and the connection is directed to the opposite side, where the command is invoked and a bidirectional channel is created to it.
