### PR TITLE
Imake.rules: Make BuildIncludes{,Top}() more robust in case people at…

### DIFF
--- a/nx-X11/config/cf/Imake.rules
+++ b/nx-X11/config/cf/Imake.rules
@@ -569,7 +569,7 @@ install::								@@\
 includes:: srclist							@@\
 	MakeDir($(BUILDINCDIR))						@@\
 	@(set -x; cd $(BUILDINCDIR) && for i in srclist; do \		@@\
-		RemoveFile($$i); \					@@\
+		RemoveFile(`basename $$i`); \				@@\
 		$(LN) $(BUILDINCTOP)/$(CURRENT_DIR)/$$i .; \		@@\
 	done)
 #endif /* BuildIncludesTop */
@@ -579,7 +579,7 @@ includes:: srclist							@@\
 includes:: srclist							@@\
 	MakeDir($(BUILDINCDIR)/dstsubdir)				@@\
 	@(set -x; cd $(BUILDINCDIR)/dstsubdir && for i in srclist; do \	@@\
-		RemoveFile($$i); \					@@\
+		RemoveFile(`basename $$i`); \				@@\
 		$(LN) $(BUILDINCTOP)/dstupdir/$(CURRENT_DIR)/$$i .; \	@@\
 	done)
 #endif /* BuildIncludes */


### PR DESCRIPTION
…tempt providing path names instead of file names via srclist.

Fixes ArcticaProject/nx-libs#223.
Fixes ArcticaProject/nx-libs#244.
