### PR TITLE
testscripts: Use non-NoMachine file headers for our testscripts.

### DIFF
--- a/testscripts/run-nxproxy2nxagent-on-localhost
+++ b/testscripts/run-nxproxy2nxagent-on-localhost
@@ -6,15 +6,18 @@
 #/* Copyright (c) 2015-2016 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>*/
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/run-nxproxy2nxagent-over-network
+++ b/testscripts/run-nxproxy2nxagent-over-network
@@ -6,15 +6,18 @@
 #/* Copyright (c) 2015-2016 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>*/
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/run-nxproxy2nxagent-over-sockets
+++ b/testscripts/run-nxproxy2nxagent-over-sockets
@@ -6,15 +6,18 @@
 #/* Copyright (c) 2015-2016 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>*/
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/run-nxproxy2nxproxy
+++ b/testscripts/run-nxproxy2nxproxy
@@ -8,15 +8,18 @@ set -e
 #/* Copyright (c) 2015-2016 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>*/
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/run-nxproxy2nxproxy-over-sockets
+++ b/testscripts/run-nxproxy2nxproxy-over-sockets
@@ -8,15 +8,18 @@ set -ex
 #/* Copyright (c) 2015-2016 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>*/
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/slave-agent
+++ b/testscripts/slave-agent
@@ -4,15 +4,18 @@
 #/* Copyright (c) 2015-2016 Qindel Group (http://www.qindel.com)           */
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
+#/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
 #/*                                                                        */
 #/**************************************************************************/
 

--- a/testscripts/slave-client
+++ b/testscripts/slave-client
@@ -4,18 +4,20 @@
 #/* Copyright (c) 2015-2016 Qindel Group (http://www.qindel.com)           */
 #/*                                                                        */
 #/* NXSCRIPTS, NX protocol compression and NX extensions to this software  */
-#/* are copyright of NoMachine. Redistribution and use of the present      */
-#/* software is allowed according to terms specified in the file LICENSE   */
-#/* which comes in the source distribution.                                */
+#/* are copyright of the aforementioned persons and companies.             */
 #/*                                                                        */
-#/* Check http://www.nomachine.com/licensing.html for applicability.       */
-#/*                                                                        */
-#/* NX and NoMachine are trademarks of Medialogic S.p.A.                   */
+#/* Redistribution and use of the present software is allowed according    */
+#/* to terms specified in the file LICENSE.nxcomp which comes in the       */
+#/* source distribution.                                                   */
 #/*                                                                        */
 #/* All rights reserved.                                                   */
 #/*                                                                        */
+#/* NOTE: This software has received contributions from various other      */
+#/* contributors, only the core maintainers and supporters are listed as   */
+#/* copyright holders. Please contact us, if you feel you should be listed */
+#/* as copyright holder, as well.                                          */
+#/*                                                                        */
 #/**************************************************************************/
-#
 
 use strict;
 use Getopt::Long;


### PR DESCRIPTION
@Ionic: @uli42: @vatral: please check if you are ok with changing file headers in our testscripts to the headers that we use for all other files.

Esp. I wonder if we should leave the trademark information for the NX name in the headers... Ideas?