### PR TITLE
Make nxagent only bind to loopback when requested

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -6692,11 +6692,15 @@ int WaitForRemote(ChannelEndPoint &socketAddress)
       strcpy(hostLabel, "any host");
     }
 
-    if (loopbackBind)
+    long bindPort;
+    if (socketAddress.getTCPHostAndPort(NULL, &bindPort))
     {
-      long bindPort;
-      if (socketAddress.getTCPHostAndPort(NULL, &bindPort))
-          socketAddress.setSpec("localhost", bindPort);
+      socketAddress.setSpec(loopbackBind ? "localhost" : "*", bindPort);
+    }
+    else
+    {
+      // This should never happen
+      cerr << "Error" << ": Unable to change bind host\n";
     }
   }
   else if (socketAddress.isUnixSocket())


### PR DESCRIPTION
The current code always binds to localhost, though by default binding to localhost is disabled.

This was breaking QVD.