### PR TITLE
Fix reversed logic in acceptHost setting

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -6685,11 +6685,11 @@ int WaitForRemote(ChannelEndPoint &socketAddress)
 
         goto WaitForRemoteError;
       }
-      strcpy(hostLabel, "any host");
+      snprintf(hostLabel, sizeof(hostLabel), "'%s'", acceptHost);
     }
     else
     {
-      snprintf(hostLabel, sizeof(hostLabel), "'%s'", acceptHost);
+      strcpy(hostLabel, "any host");
     }
 
     if (loopbackBind)


### PR DESCRIPTION
The messages seem to be backwards with the logic