### PR TITLE
Xserver/randr/rrinfo.c: Don't call RRScanOldConfig() from RANDR_10_INTERFACE. CRTC and OUTPUT setup happens in nxagent's Screen.c file.

### DIFF
--- a/nx-X11/programs/Xserver/randr/rrinfo.c
+++ b/nx-X11/programs/Xserver/randr/rrinfo.c
@@ -201,7 +201,7 @@ RRGetInfo(ScreenPtr pScreen, Bool force_query)
     if (!(*pScrPriv->rrGetInfo) (pScreen, &rotations))
         return FALSE;
 
-#if RANDR_10_INTERFACE
+#if defined(RANDR_10_INTERFACE) && !defined(NXAGENT_SERVER)
     if (pScrPriv->nSizes)
         RRScanOldConfig(pScreen, rotations);
 #endif


### PR DESCRIPTION
 Fixes ArcticaProject/nx-libs#293.