### PR TITLE
use rpath for nxagent (instead of LD_LIBRARY_PATH hack)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,14 +186,14 @@ uninstall-lite:
 	$(RM_DIR) $(DESTDIR)$(NXLIBDIR)/bin/
 	$(RM_FILE) $(DESTDIR)$(PREFIX)/share/man/man1/*.1
 	$(RM_FILE) $(DESTDIR)$(PREFIX)/share/nx/VERSION.nxproxy
-	$(RM_DIR) $(DESTDIR)$(NXLIBDIR)/share/nx/
+	$(RM_DIR) $(DESTDIR)$(PREFIX)/share/nx/
 
 uninstall-full:
 	for f in nxagent; do \
 	    $(RM_FILE) $(DESTDIR)$(BINDIR)/$$f; done
 
 	$(RM_FILE) $(DESTDIR)$(PREFIX)/share/nx/VERSION.nxagent
-	$(RM_DIR) $(DESTDIR)$(NXLIBDIR)/share/nx/
+	$(RM_DIR) $(DESTDIR)$(PREFIX)/share/nx/
 
 	if test -d nx-X11; then \
 	    if test -f nxcompshad/Makefile; then ${MAKE} -C nxcompshad $@; fi; \

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ COPY_DEREFERENCED=cp -RH
 RM_FILE=rm -f
 RM_DIR=rmdir -p --ignore-fail-on-non-empty
 
-ETCDIR_NX   ?= /etc/nxagent
-PREFIX      ?= /usr/local
-BINDIR      ?= $(PREFIX)/bin
-LIBDIR      ?= $(PREFIX)/lib
-SHLIBDIR    ?= $(LIBDIR)
-NXLIBDIR    ?= $(SHLIBDIR)/nx
-USRLIBDIR   ?= $(NXLIBDIR)/X11
-INCLUDEDIR  ?= $(PREFIX)/include
-CONFIGURE   ?= ./configure
+ETCDIR_NX       ?= /etc/nxagent
+PREFIX          ?= /usr/local
+BINDIR          ?= $(PREFIX)/bin
+LIBDIR          ?= $(PREFIX)/lib
+SHLIBDIR        ?= $(LIBDIR)
+NXLIBDIR        ?= $(SHLIBDIR)/nx
+USRLIBDIR       ?= $(NXLIBDIR)/X11
+INCLUDEDIR      ?= $(PREFIX)/include
+CONFIGURE       ?= ./configure
 
 NX_VERSION_MAJOR=$(shell ./version.sh 1)
 NX_VERSION_MINOR=$(shell ./version.sh 2)

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ ETCDIR_NX   ?= /etc/nxagent
 PREFIX      ?= /usr/local
 BINDIR      ?= $(PREFIX)/bin
 LIBDIR      ?= $(PREFIX)/lib
-USRLIBDIR   ?= $(LIBDIR)
+SHLIBDIR    ?= $(LIBDIR)
+NXLIBDIR    ?= $(SHLIBDIR)/nx
+USRLIBDIR   ?= $(NXLIBDIR)/X11
 INCLUDEDIR  ?= $(PREFIX)/include
-NXLIBDIR    ?= $(LIBDIR)/nx
 CONFIGURE   ?= ./configure
 
 NX_VERSION_MAJOR=$(shell ./version.sh 1)
@@ -143,13 +144,13 @@ install-full:
 	    cp -a "$$(string_rep "$$libpath" "$$libfile" "$$link")" "$$(string_rep "$$libdir" exports .build-exports)"; \
 	done;
 
+	$(INSTALL_DIR) $(DESTDIR)$(SHLIBDIR)
+	$(COPY_SYMLINK) nx-X11/.build-exports/lib/libNX_X11.so $(DESTDIR)$(SHLIBDIR)/
+	$(COPY_SYMLINK) nx-X11/.build-exports/lib/libNX_X11.so.6 $(DESTDIR)$(SHLIBDIR)/
+	$(COPY_DEREFERENCED) nx-X11/.build-exports/lib/libNX_X11.so.6.2 $(DESTDIR)$(SHLIBDIR)/
 	$(INSTALL_DIR) $(DESTDIR)$(USRLIBDIR)
-	$(COPY_SYMLINK) nx-X11/.build-exports/lib/libNX_X11.so $(DESTDIR)$(USRLIBDIR)/
-	$(COPY_SYMLINK) nx-X11/.build-exports/lib/libNX_X11.so.6 $(DESTDIR)$(USRLIBDIR)/
-	$(COPY_DEREFERENCED) nx-X11/.build-exports/lib/libNX_X11.so.6.2 $(DESTDIR)$(USRLIBDIR)/
-	$(INSTALL_DIR) $(DESTDIR)$(USRLIBDIR)/nx-X11
-	$(INSTALL_SYMLINK) ../libNX_X11.so.6 $(DESTDIR)$(USRLIBDIR)/nx-X11/libX11.so.6
-	$(INSTALL_SYMLINK) ../libNX_X11.so.6.2 $(DESTDIR)$(USRLIBDIR)/nx-X11/libX11.so.6.2
+	$(INSTALL_SYMLINK) ../../libNX_X11.so.6 $(DESTDIR)$(USRLIBDIR)/libX11.so.6
+	$(INSTALL_SYMLINK) ../../libNX_X11.so.6.2 $(DESTDIR)$(USRLIBDIR)/libX11.so.6.2
 
 	. replace.sh; set -x; find nx-X11/.build-exports/include/{nx*,GL} -type d | \
 	    while read dirname; do \

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build-full:
 
 	cd nxcompshad && autoconf && (${CONFIGURE}) && ${MAKE}
 
-	cd nx-X11 && ${MAKE} World
+	cd nx-X11 && ${MAKE} World USRLIBDIR=$(USRLIBDIR) SHLIBDIR=$(SHLIBDIR)
 
 	cd nxproxy && autoconf && (${CONFIGURE}) && ${MAKE}
 

--- a/bin/nxagent.in
+++ b/bin/nxagent.in
@@ -20,6 +20,5 @@ NX_LIBDIR=@@NXLIBDIR@@
 # make sure nxagent starts properly with pam_tmpdir.so being in use
 NX_TEMP=${NX_TEMP:-/tmp}
 export NX_TEMP
-export LD_LIBRARY_PATH=@@NX_LIBDIR@@/X11/
 
 exec $NX_LIBDIR/bin/${NXAPP:-"nxagent"} "$@"

--- a/bin/nxagent.in
+++ b/bin/nxagent.in
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
-NX_LIBS=@@NXLIBDIR@@
+NX_LIBDIR=@@NXLIBDIR@@
 
 # make sure nxagent starts properly with pam_tmpdir.so being in use
 NX_TEMP=${NX_TEMP:-/tmp}
 export NX_TEMP
-export LD_LIBRARY_PATH=@@NXLIBDIR@@-X11/
+export LD_LIBRARY_PATH=@@NX_LIBDIR@@/X11/
 
-exec $NX_LIBS/bin/${NXAPP:-"nxagent"} "$@"
+exec $NX_LIBDIR/bin/${NXAPP:-"nxagent"} "$@"

--- a/bin/nxproxy.in
+++ b/bin/nxproxy.in
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
-NX_LIBS=@@NXLIBDIR@@
+NX_LIBDIR=@@NXLIBDIR@@
 
 # make sure nxagent starts properly with pam_tmpdir.so being in use
 NX_TEMP=${NX_TEMP:-/tmp}
 export NX_TEMP
 
-exec $NX_LIBS/bin/${NXAPP:="nxproxy"} "$@"
+exec $NX_LIBDIR/bin/${NXAPP:="nxproxy"} "$@"

--- a/debian/nxagent.install
+++ b/debian/nxagent.install
@@ -4,7 +4,7 @@ usr/share/nx/rgb
 usr/share/nx/VERSION.nxagent
 usr/share/man/man1/nxagent.1*
 usr/lib/*/nx/bin/nxagent
-usr/lib/*/nx-X11/
+usr/lib/*/nx/X11/
 usr/bin/nxagent
 usr/share/pixmaps/nxagent.xpm
 etc/nxagent/nxagent.keyboard

--- a/debian/patches/016_nx-X11_install-location.debian.patch
+++ b/debian/patches/016_nx-X11_install-location.debian.patch
@@ -6,16 +6,16 @@ Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
 Last-Update: 2012-12-31
 --- a/nx-X11/config/cf/Imake.tmpl
 +++ b/nx-X11/config/cf/Imake.tmpl
-@@ -749,7 +749,7 @@
+@@ -730,7 +730,7 @@
  #define AlternateUsrLibDir YES
  #endif
  #else
--#define UsrLibDir Concat4(/usr/local,/,LibDirName,/nx)
-+#define UsrLibDir Concat4(/usr,/,LibDirName,/nx)
+-#define UsrLibDir Concat4(/usr/local,/,LibDirName,/nx/X11)
++#define UsrLibDir Concat4(/usr,/,LibDirName,/nx/X11)
  #ifndef AlternateUsrLibDir
  #define AlternateUsrLibDir NO
  #endif
-@@ -767,7 +767,7 @@
+@@ -748,7 +748,7 @@
  #define AlternateUsrDataDir YES
  #endif
  #else
@@ -26,7 +26,7 @@ Last-Update: 2012-12-31
  #endif
 --- a/nx-X11/config/cf/site.def
 +++ b/nx-X11/config/cf/site.def
-@@ -72,7 +72,7 @@
+@@ -69,7 +69,7 @@
  #ifdef AfterVendorCF
  
  #ifndef ProjectRoot

--- a/debian/patches/016_nx-X11_install-location.debian.patch
+++ b/debian/patches/016_nx-X11_install-location.debian.patch
@@ -1,9 +1,17 @@
 Description: FHS adaptation for Debian packaging
- On Debian, NX libraries and binaries are installed to
- /usr/lib/nx.
+Abstract:
+ On Debian, binaries are installed to /usr/<lib>/nx.
+ .
+ Also, a fake-libX11 library symlink is placed into
+ /usr/<lib>/nx/X11.
+ .
+ The given paths will be overridden by the Debian packaging
+ and modified into multi-arch paths.
+
 Forwarded: not-needed
 Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
-Last-Update: 2012-12-31
+Last-Update: 2017-02-08
+
 --- a/nx-X11/config/cf/Imake.tmpl
 +++ b/nx-X11/config/cf/Imake.tmpl
 @@ -730,7 +730,7 @@

--- a/debian/rules
+++ b/debian/rules
@@ -51,7 +51,7 @@ override_dh_auto_install:
 
 override_dh_auto_build:
 
-	PREFIX=/usr dh_auto_build --parallel -- CDEBUGFLAGS="$(CPPFLAGS) $(CFLAGS)" LOCAL_LDFLAGS="$(LDFLAGS)" SHLIBGLOBALSFLAGS='$(filter-out -pie,$(LDFLAGS))' SHLIBDIR="$(LIBDIR)"
+	PREFIX=/usr dh_auto_build --parallel -- CDEBUGFLAGS="$(CPPFLAGS) $(CFLAGS)" LOCAL_LDFLAGS="$(LDFLAGS)" SHLIBGLOBALSFLAGS='$(filter-out -pie,$(LDFLAGS))'
 
 override_dh_strip:
 	dh_strip -plibnx-x11-6 --dbg-package=libnx-x11-6-dbg

--- a/nx-X11/config/cf/Imake.tmpl
+++ b/nx-X11/config/cf/Imake.tmpl
@@ -723,12 +723,12 @@ TCLIBDIR = TclLibDir
 
 #ifndef UsrLibDir
 #ifdef ProjectRoot
-#define UsrLibDir Concat4(ProjectRoot,/,LibDirName,/nx)
+#define UsrLibDir Concat4(ProjectRoot,/,LibDirName,/nx/X11)
 #ifndef AlternateUsrLibDir
 #define AlternateUsrLibDir YES
 #endif
 #else
-#define UsrLibDir Concat4(/usr/local,/,LibDirName,/nx)
+#define UsrLibDir Concat4(/usr/local,/,LibDirName,/nx/X11)
 #ifndef AlternateUsrLibDir
 #define AlternateUsrLibDir NO
 #endif

--- a/nx-X11/config/cf/X11.rules
+++ b/nx-X11/config/cf/X11.rules
@@ -39,9 +39,9 @@
 #endif
 
 #ifdef X11ProjectRoot
-# define XUsrLibDirPath	$(USRLIBDIR)/nx:$(XPROJECTROOT)
+# define XUsrLibDirPath	$(USRLIBDIR):$(XPROJECTROOT)
 #else
-# define XUsrLibDirPath	$(USRLIBDIR)/nx
+# define XUsrLibDirPath	$(USRLIBDIR)
 #endif
 #ifdef UsrLibDirPath
 # undef UsrLibDirPath

--- a/nx-X11/config/cf/lnxLib.rules
+++ b/nx-X11/config/cf/lnxLib.rules
@@ -9,7 +9,7 @@
 #endif
 
 #ifndef UseRpath
-#define UseRpath NO
+#define UseRpath YES
 #endif
 
 #if UseElfFormat

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -515,8 +515,8 @@ rm -r %{buildroot}%{_includedir}/nx-X11/Xtrans
 %{_bindir}/nxagent
 %dir %{_libdir}/nx/bin
 %{_libdir}/nx/bin/nxagent
-%dir %{_libdir}/nx-X11
-%{_libdir}/nx-X11/libX11.so*
+%dir %{_libdir}/nx/X11
+%{_libdir}/nx/X11/libX11.so*
 %{_datadir}/pixmaps/nxagent.xpm
 %dir %{_datadir}/nx
 %{_datadir}/nx/rgb

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -346,7 +346,7 @@ chmod a+x my_configure;
 export SHLIBGLOBALSFLAGS="%{__global_ldflags}"
 export LOCAL_LDFLAGS="%{__global_ldflags}"
 export CDEBUGFLAGS="%{__global_cppflags} %{__global_cflags}"
-make %{?_smp_mflags} CONFIGURE="$PWD/my_configure" PREFIX=%{_prefix} LIBDIR=%{_libdir} SHLIBDIR=%{_libdir}
+make %{?_smp_mflags} CONFIGURE="$PWD/my_configure" PREFIX=%{_prefix} LIBDIR=%{_libdir}
 
 %install
 make install \


### PR DESCRIPTION
Along with @uli42's suggestion, here comes a PR that makes the LD_LIBRARY_PATH in the /usr/bin/nxagent wrapper script obsolete.

@Ionic: can you please review this PR as paid work. Thanks.