### PR TITLE
nx-X11/config/cf/X11.tmpl: Fix DefaultRGBDatabase path to $(USRDATADIR)

### DIFF
--- a/nx-X11/config/cf/X11.tmpl
+++ b/nx-X11/config/cf/X11.tmpl
@@ -313,7 +313,7 @@ XORGRELSTRING = XorgManVersionString
 # define DefaultFSFontPath DefaultFontPath
 #endif
 #ifndef DefaultRGBDatabase
-#define DefaultRGBDatabase $(LIBDIR)/rgb
+#define DefaultRGBDatabase $(USRDATADIR)/rgb
 #endif
 #ifndef UseRgbTxt
 #define UseRgbTxt		NO	/* default is to compile with dbm */


### PR DESCRIPTION
... (not $(LIBDIR)/rgb).

Random flaw discovery while working on the default font paths fixes.