### PR TITLE
Support built-in fonts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends:
  libxmltok1-dev,
  libxml2-dev,
  libxpm-dev,
- libxfont1-dev | libxfont-dev,
+ libxfont1-dev | libxfont-dev (>= 1.4.2),
  libxdmcp-dev,
  libxdamage-dev,
  libxext-dev,

--- a/debian/nx-x11-common.dirs
+++ b/debian/nx-x11-common.dirs
@@ -1,0 +1,2 @@
+# we symlink to this dir, so make sure it exists
+usr/share/fonts/X11

--- a/debian/nx-x11-common.links
+++ b/debian/nx-x11-common.links
@@ -1,0 +1,1 @@
+usr/share/fonts/X11 usr/share/nx/fonts

--- a/nx-X11/config/cf/X11.tmpl
+++ b/nx-X11/config/cf/X11.tmpl
@@ -856,10 +856,10 @@ FCHOWN_DEFINES = -DHAS_FCHOWN
 #define DocPdfDir $(DOCDIR)/PDF
 #endif
 #ifndef FontDir
-#define FontDir $(LIBDIR)/fonts
+#define FontDir $(USRDATADIR)/fonts
 #endif
 #ifndef FontEncDir
-#define FontEncDir $(LIBDIR)/fonts/encodings
+#define FontEncDir $(USRDATADIR)/fonts/encodings
 #endif
 #ifndef AdmDir
 #define AdmDir /usr/adm

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -1925,7 +1925,11 @@ InitFonts ()
 {
     patternCache = MakeFontPatternCache();
 
+#if defined(BUILTIN_FONTS) || defined(NXAGENT_SERVER)
+    BuiltinRegisterFpeFunctions();
+#else
     register_fpe_functions();
+#endif
 }
 
 int

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -1953,11 +1953,7 @@ InitFonts ()
 {
     patternCache = MakeFontPatternCache();
 
-#if defined(BUILTIN_FONTS) || defined(NXAGENT_SERVER)
-    BuiltinRegisterFpeFunctions();
-#else
     register_fpe_functions();
-#endif
 }
 
 int

--- a/nx-X11/programs/Xserver/dix/main.c
+++ b/nx-X11/programs/Xserver/dix/main.c
@@ -388,7 +388,7 @@ main(int argc, char *argv[], char *envp[])
 	    SetFontPath(0, 0, (unsigned char *)defaultFontPath, &error);
 	} else {
 	    if (SetDefaultFontPath(defaultFontPath) != Success)
-		ErrorF("failed to set default font path '%s'",
+		ErrorF("failed to set default font path '%s'\n",
 			defaultFontPath);
 	}
 	if (!SetDefaultFont(defaultTextFont))

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -77,26 +77,22 @@ is" without express or implied warranty.
 #define NXAGENT_DEFAULT_FONT_PATH  \
 "/usr/share/nx/fonts/misc/,/usr/share/nx/fonts/Speedo/,\
 /usr/share/nx/fonts/Type1/,/usr/share/nx/fonts/75dpi/,\
-/usr/share/nx/fonts/100dpi/,/usr/share/nx/fonts/TTF/,\
-/usr/NX/share/fonts/base"
+/usr/share/nx/fonts/100dpi/,/usr/share/nx/fonts/TTF/"
 
 #define NXAGENT_ALTERNATE_FONT_PATH  \
 "/usr/share/X11/fonts/misc/,/usr/share/X11/fonts/Speedo/,\
 /usr/share/X11/fonts/Type1/,/usr/share/X11/fonts/75dpi/,\
-/usr/share/X11/fonts/100dpi/,/usr/share/X11/fonts/TTF/,\
-/usr/NX/share/fonts/base"
+/usr/share/X11/fonts/100dpi/,/usr/share/X11/fonts/TTF/"
 
 #define NXAGENT_ALTERNATE_FONT_PATH_2  \
 "/usr/share/fonts/X11/misc/,/usr/share/fonts/X11/Speedo/,\
 /usr/share/fonts/X11/Type1/,/usr/share/fonts/X11/75dpi/,\
-/usr/share/fonts/X11/100dpi/,/usr/share/fonts/X11/TTF/,\
-/usr/NX/share/fonts/base"
+/usr/share/fonts/X11/100dpi/,/usr/share/fonts/X11/TTF/"
 
 #define NXAGENT_ALTERNATE_FONT_PATH_3  \
 "/usr/X11R6/lib/X11/fonts/misc/,/usr/X11R6/lib/X11/fonts/Speedo/,\
 /usr/X11R6/lib/X11/fonts/Type1/,/usr/X11R6/lib/X11/fonts/75dpi/,\
-/usr/X11R6/lib/X11/fonts/100dpi/,/usr/X11R6/lib/X11/fonts/TTF/,\
-/usr/NX/share/fonts/base"
+/usr/X11R6/lib/X11/fonts/100dpi/,/usr/X11R6/lib/X11/fonts/TTF/"
 
 #undef NXAGENT_FONTCACHE_DEBUG
 #undef NXAGENT_RECONNECT_FONT_DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -73,7 +73,6 @@ is" without express or implied warranty.
 #define NXAGENT_ALTERNATE_FONT_DIR    "/usr/share/X11/fonts"
 #define NXAGENT_ALTERNATE_FONT_DIR_2  "/usr/share/fonts/X11"
 #define NXAGENT_ALTERNATE_FONT_DIR_3  "/usr/share/fonts"
-#define NXAGENT_ALTERNATE_FONT_DIR_4  "/usr/NX/share/fonts"
 
 #define NXAGENT_DEFAULT_FONT_PATH  \
 "/usr/X11R6/lib/X11/fonts/misc/,/usr/X11R6/lib/X11/fonts/Speedo/,\
@@ -98,9 +97,6 @@ is" without express or implied warranty.
 /usr/share/fonts/Type1/,/usr/share/fonts/75dpi/,\
 /usr/share/fonts/100dpi/,/usr/share/fonts/TTF/,\
 /usr/NX/share/fonts/base"
-
-#define NXAGENT_ALTERNATE_FONT_PATH_4  \
-"/usr/NX/share/fonts/base"
 
 #undef NXAGENT_FONTCACHE_DEBUG
 #undef NXAGENT_RECONNECT_FONT_DEBUG
@@ -1574,32 +1570,6 @@ void nxagentVerifyDefaultFontPath(void)
 
     strcat(fontPath, NXAGENT_ALTERNATE_FONT_PATH_3);
   }
-
-  if (stat(NXAGENT_ALTERNATE_FONT_DIR_4, &dirStat) == 0 &&
-          S_ISDIR(dirStat.st_mode) != 0)
-  {
-    /*
-     * Let's use the "/usr/NX/share/fonts" path.
-     */
-
-    #ifdef TEST
-    fprintf(stderr, "nxagentVerifyDefaultFontPath: Assuming fonts in directory [%s].\n",
-                validateString(NXAGENT_ALTERNATE_FONT_DIR_4));
-    #endif
-
-    if (*fontPath != '\0')
-    {
-      fontPath = realloc(fontPath, strlen(fontPath) + strlen(NXAGENT_ALTERNATE_FONT_PATH_4) + 2);
-      strcat(fontPath, ",");
-    }
-    else
-    {
-      fontPath = realloc(fontPath, strlen(fontPath) + strlen(NXAGENT_ALTERNATE_FONT_PATH_4) + 1);
-    }
-
-    strcat(fontPath, NXAGENT_ALTERNATE_FONT_PATH_4);
-  }
-
   if (*fontPath == '\0') 
   {
     #ifdef WARNING

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -69,15 +69,15 @@ is" without express or implied warranty.
 #undef  TEST
 #undef  DEBUG
 
-#define NXAGENT_DEFAULT_FONT_DIR      "/usr/X11R6/lib/X11/fonts"
+#define NXAGENT_DEFAULT_FONT_DIR      "/usr/share/nx/fonts"
 #define NXAGENT_ALTERNATE_FONT_DIR    "/usr/share/X11/fonts"
 #define NXAGENT_ALTERNATE_FONT_DIR_2  "/usr/share/fonts/X11"
-#define NXAGENT_ALTERNATE_FONT_DIR_3  "/usr/share/fonts"
+#define NXAGENT_ALTERNATE_FONT_DIR_3  "/usr/X11R6/lib/X11/fonts"
 
 #define NXAGENT_DEFAULT_FONT_PATH  \
-"/usr/X11R6/lib/X11/fonts/misc/,/usr/X11R6/lib/X11/fonts/Speedo/,\
-/usr/X11R6/lib/X11/fonts/Type1/,/usr/X11R6/lib/X11/fonts/75dpi/,\
-/usr/X11R6/lib/X11/fonts/100dpi/,/usr/X11R6/lib/X11/fonts/TTF/,\
+"/usr/share/nx/fonts/misc/,/usr/share/nx/fonts/Speedo/,\
+/usr/share/nx/fonts/Type1/,/usr/share/nx/fonts/75dpi/,\
+/usr/share/nx/fonts/100dpi/,/usr/share/nx/fonts/TTF/,\
 /usr/NX/share/fonts/base"
 
 #define NXAGENT_ALTERNATE_FONT_PATH  \
@@ -93,9 +93,9 @@ is" without express or implied warranty.
 /usr/NX/share/fonts/base"
 
 #define NXAGENT_ALTERNATE_FONT_PATH_3  \
-"/usr/share/fonts/misc/,/usr/share/fonts/Speedo/,\
-/usr/share/fonts/Type1/,/usr/share/fonts/75dpi/,\
-/usr/share/fonts/100dpi/,/usr/share/fonts/TTF/,\
+"/usr/X11R6/lib/X11/fonts/misc/,/usr/X11R6/lib/X11/fonts/Speedo/,\
+/usr/X11R6/lib/X11/fonts/Type1/,/usr/X11R6/lib/X11/fonts/75dpi/,\
+/usr/X11R6/lib/X11/fonts/100dpi/,/usr/X11R6/lib/X11/fonts/TTF/,\
 /usr/NX/share/fonts/base"
 
 #undef NXAGENT_FONTCACHE_DEBUG
@@ -1475,7 +1475,7 @@ void nxagentVerifyDefaultFontPath(void)
           S_ISDIR(dirStat.st_mode) != 0)
   {
     /*
-     * Let's use the old "/usr/X11R6/lib/X11/fonts" style.
+     * Let's use the old "/usr/share/nx/fonts" style.
      */
 
     #ifdef TEST
@@ -1550,7 +1550,7 @@ void nxagentVerifyDefaultFontPath(void)
           S_ISDIR(dirStat.st_mode) != 0)
   {
     /*
-     * Let's use the "/usr/share/fonts" path.
+     * Let's use the "/usr/X11R6/lib/X11/fonts" path.
      */
 
     #ifdef TEST

--- a/nx-X11/programs/Xserver/include/dixfont.h
+++ b/nx-X11/programs/Xserver/include/dixfont.h
@@ -150,9 +150,6 @@ extern void InitGlyphCaching(void);
 
 extern void SetGlyphCachingMode(int /*newmode*/);
 
-/*
- * libXfont/src/builtins/builtin.h
- */
-extern _X_EXPORT void BuiltinRegisterFpeFunctions(void);
+extern void register_fpe_functions(void);
 
 #endif				/* DIXFONT_H */

--- a/nx-X11/programs/Xserver/include/dixfont.h
+++ b/nx-X11/programs/Xserver/include/dixfont.h
@@ -150,4 +150,9 @@ extern void InitGlyphCaching(void);
 
 extern void SetGlyphCachingMode(int /*newmode*/);
 
+/*
+ * libXfont/src/builtins/builtin.h
+ */
+extern _X_EXPORT void BuiltinRegisterFpeFunctions(void);
+
 #endif				/* DIXFONT_H */

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -272,8 +272,9 @@ Obsoletes:      nx < 3.5.0-19
 Provides:       nx = %{version}-%{release}
 Provides:       nx%{?_isa} = %{version}-%{release}
 Obsoletes:      nxauth < 3.5.99.1
-%if 0%{?suse_version}
-Requires:       xorg-x11-fonts-core
+%if 0%{?fedora} || 0%{?rhel}
+# For /usr/share/X11/fonts
+Requires: xorg-x11-font-utils
 %endif
 
 %description -n nxagent
@@ -356,6 +357,13 @@ make install \
         INSTALL_DIR="install -dm0755" \
         INSTALL_FILE="install -pm0644" \
         INSTALL_PROGRAM="install -pm0755"
+
+# this needs to be adapted distribution-wise...
+%if 0%{?suse_version}
+ln -s ../fonts %{buildroot}%{_datadir}/nx/fonts
+%elif 0%{?fedora} || 0%{?rhel}
+ln -s ../X11/fonts %{buildroot}%{_datadir}/nx/fonts
+%endif
 
 # Remove static libs (they don't exist on SLES, so using -f here)
 rm -f %{buildroot}%{_libdir}/*.a
@@ -520,6 +528,7 @@ rm -r %{buildroot}%{_includedir}/nx-X11/Xtrans
 %dir %{_datadir}/nx
 %{_datadir}/nx/VERSION.nxagent
 %{_datadir}/man/man1/nxagent.1*
+%{_datadir}/nx/fonts
 
 %files -n nxproxy
 %defattr(-,root,root)

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -26,6 +26,10 @@ BuildRequires:  gpg-offline
 %endif
 %if 0%{?suse_version}
 BuildRequires:  fdupes
+
+# This is what provides /usr/share/fonts on SUSE systems...
+BuildRequires: filesystem
+
 %if 0%{?suse_version} >= 1130
 BuildRequires:  pkgconfig(expat)
 BuildRequires:  pkgconfig(libpng)

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -78,6 +78,7 @@ BuildRequires:  libXrandr-devel
 BuildRequires:  libXfixes-devel
 BuildRequires:  libXtst-devel
 BuildRequires:  libXinerama-devel
+BuildRequires:  xorg-x11-font-utils
 %endif
 
 # For imake

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -34,7 +34,7 @@ BuildRequires:  pkgconfig(pixman-1) >= 0.13.2
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xext)
 BuildRequires:  pkgconfig(xpm)
-BuildRequires:  pkgconfig(xfont)
+BuildRequires:  pkgconfig(xfont) >= 1.4.2
 BuildRequires:  pkgconfig(xdmcp)
 BuildRequires:  pkgconfig(xdamage)
 BuildRequires:  pkgconfig(xcomposite)
@@ -50,7 +50,7 @@ BuildRequires:  pixman-devel >= 0.13.2
 BuildRequires:  xorg-x11-libX11-devel
 BuildRequires:  xorg-x11-libXext-devel
 BuildRequires:  xorg-x11-libXpm-devel
-BuildRequires:  xorg-x11-libXfont-devel
+BuildRequires:  xorg-x11-libXfont-devel >= 1.4.2
 BuildRequires:  xorg-x11-libXdmcp-devel
 BuildRequires:  xorg-x11-libXdamage-devel
 BuildRequires:  xorg-x11-libXcomposite-devel
@@ -70,7 +70,7 @@ BuildRequires:  pixman-devel >= 0.13.2
 BuildRequires:  libX11-devel
 BuildRequires:  libXext-devel
 BuildRequires:  libXpm-devel
-BuildRequires:  libXfont-devel
+BuildRequires:  libXfont-devel >= 1.4.2
 BuildRequires:  libXdmcp-devel
 BuildRequires:  libXdamage-devel
 BuildRequires:  libXcomposite-devel


### PR DESCRIPTION
This PR, once and for all, fixes the "Could not open default font 'fixed'" issue in nxagent.

Important for distribution maintainers:

  symlink /usr/share/nx/fonts -> <your-distro's-X11-fonts-dir>
  drop hard dependency on xfonts-base, xorg-x11-fonts-misc (not required anymore as a must)