### PR TITLE
nxproxy: Support communication over stdin. Allows nxcl to use standard ssh instead of nxssh.

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -13940,7 +13940,7 @@ void PrintProcessInfo()
   //
 
   cerr << "Info: Proxy running in "
-       << (control -> ProxyMode == proxy_client ? "server" : "client")
+       << (control -> ProxyMode == proxy_client ? "client" : "server")
        << " mode with pid '" << getpid() << "'.\n";
 
   if (agent == NULL)

--- a/nxproxy/Main.c
+++ b/nxproxy/Main.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
+#include <limits.h>
 
 #include "NX.h"
 
@@ -26,6 +28,8 @@
 #define WARNING
 #undef  TEST
 #undef  DEBUG
+
+extern const char *__progname;
 
 /*
  * Entry point when running nxproxy stand-alone.
@@ -37,27 +41,74 @@ int main(int argc, const char **argv)
 
   char *options = NULL;
 
+  char *nx_commfd_str = NULL;
+
   options = getenv("NX_DISPLAY");
 
-  if (NXTransParseCommandLine(argc, argv) < 0)
+  if ((nx_commfd_str = getenv("NX_COMMFD")) != NULL)
   {
-    NXTransCleanup();
-  }
+    errno = 0;
+    unsigned long int nx_commfd = strtoul(nx_commfd_str, NULL, 10);
 
-  if (NXTransParseEnvironment(options, 0) < 0)
+    if ((errno) && (0 == nx_commfd))
+    {
+      fprintf(stderr, "%s: NX_COMMFD environment variable's value [%s] is not a file descriptor number. "
+                      "Aborting...\n",
+                      __progname, nx_commfd_str
+                      );
+      NXTransCleanup();
+    }
+    else if ((unsigned long int) INT_MAX < nx_commfd)
+    {
+      fprintf(stderr, "%s: NX_COMMFD environment variable's value [%lu] is out of range for a file descriptor number. "
+                      "Aborting...\n",
+                      __progname, nx_commfd);
+      NXTransCleanup();
+    }
+    else {
+      result = NXTransCreate(nx_commfd, NX_MODE_SERVER, options);
+
+      if (result != 1)
+      {
+        fprintf(stderr, "%s: NXTransCreate failed for FD#%lu\n"
+                        "Aborting...",
+                        __progname, nx_commfd);
+        NXTransCleanup();
+      }
+
+    }
+
+    // go into endless loop
+
+    if (result == 1)
+    {
+      while (NXTransRunning(NX_FD_ANY))
+        result = NXTransContinue(NULL);
+    }
+  }
+  else
   {
-    NXTransCleanup();
+
+    if (NXTransParseCommandLine(argc, argv) < 0)
+    {
+      NXTransCleanup();
+    }
+
+    if (NXTransParseEnvironment(options, 0) < 0)
+    {
+      NXTransCleanup();
+    }
+
+    /*
+     * This should not return...
+     */
+
+    #ifdef TEST
+    fprintf(stderr, "%s: Yielding control to NX entry point.\n", __progname);
+    #endif
+
+    result = NXTransProxy(NX_FD_ANY, NX_MODE_ANY, NX_DISPLAY_ANY);
   }
-
-  /*
-   * This should not return...
-   */
-
-  #ifdef TEST
-  fprintf(stderr, "Main: Yielding control to NX entry point.\n");
-  #endif
-
-  result = NXTransProxy(NX_FD_ANY, NX_MODE_ANY, NX_DISPLAY_ANY);
 
   /*
    * ...So these should not be called.


### PR DESCRIPTION
Patch from Gentoo. Ported 1:1.