### PR TITLE
Naming change: Security*Access -> Dix*Access

### DIFF
--- a/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
@@ -89,7 +89,7 @@ int PanoramiXCreateWindow(ClientPtr client)
         return BadLength;
 
     if (!(parent = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->parent, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->parent, XRT_WINDOW, DixWriteAccess)))
         return BadWindow;
 
     if(stuff->class == CopyFromParent)
@@ -103,7 +103,7 @@ int PanoramiXCreateWindow(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + pback_offset);
 	if ((tmp != None) && (tmp != ParentRelative)) {
 	   if(!(backPix = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -112,7 +112,7 @@ int PanoramiXCreateWindow(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + pbord_offset);
 	if (tmp != CopyFromParent) {
 	   if(!(bordPix = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -121,7 +121,7 @@ int PanoramiXCreateWindow(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + cmap_offset);
 	if ((tmp != CopyFromParent) && (tmp != None)) {
 	   if(!(cmap = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_COLORMAP, SecurityReadAccess)))
+		client, tmp, XRT_COLORMAP, DixReadAccess)))
 	      return BadColor;
 	}
     }
@@ -190,7 +190,7 @@ int PanoramiXChangeWindowAttributes(ClientPtr client)
         return BadLength;
 
     if (!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, XRT_WINDOW, DixWriteAccess)))
         return BadWindow;
 
     if((win->u.win.class == InputOnly) && 
@@ -202,7 +202,7 @@ int PanoramiXChangeWindowAttributes(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + pback_offset);
 	if ((tmp != None) && (tmp != ParentRelative)) {
 	   if(!(backPix = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -211,7 +211,7 @@ int PanoramiXChangeWindowAttributes(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + pbord_offset);
 	if (tmp != CopyFromParent) {
 	   if(!(bordPix = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -220,7 +220,7 @@ int PanoramiXChangeWindowAttributes(ClientPtr client)
 	tmp = *((CARD32 *) &stuff[1] + cmap_offset);
 	if ((tmp != CopyFromParent) && (tmp != None)) {
 	   if(!(cmap = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_COLORMAP, SecurityReadAccess)))
+		client, tmp, XRT_COLORMAP, DixReadAccess)))
 	      return BadColor;
 	}
     }
@@ -249,7 +249,7 @@ int PanoramiXDestroyWindow(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityDestroyAccess)))
+		client, stuff->id, XRT_WINDOW, DixDestroyAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -274,7 +274,7 @@ int PanoramiXDestroySubwindows(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityDestroyAccess)))
+		client, stuff->id, XRT_WINDOW, DixDestroyAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -299,7 +299,7 @@ int PanoramiXChangeSaveSet(ClientPtr client)
     REQUEST_SIZE_MATCH(xChangeSaveSetReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->window, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -323,11 +323,11 @@ int PanoramiXReparentWindow(ClientPtr client)
     REQUEST_SIZE_MATCH(xReparentWindowReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     if(!(parent = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->parent, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->parent, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     x = stuff->x;
@@ -358,7 +358,7 @@ int PanoramiXMapWindow(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->id, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_FORWARD(j) {
@@ -380,7 +380,7 @@ int PanoramiXMapSubwindows(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->id, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_FORWARD(j) {
@@ -402,7 +402,7 @@ int PanoramiXUnmapWindow(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->id, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_FORWARD(j) {
@@ -424,7 +424,7 @@ int PanoramiXUnmapSubwindows(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->id, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_FORWARD(j) {
@@ -455,11 +455,11 @@ int PanoramiXConfigureWindow(ClientPtr client)
 
     /* because we need the parent */
     if (!(pWin = (WindowPtr)SecurityLookupIDByType(
-		client, stuff->window, RT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, RT_WINDOW, DixWriteAccess)))
         return BadWindow;
 
     if (!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, XRT_WINDOW, DixWriteAccess)))
         return BadWindow;
 
     if ((Mask)stuff->mask & CWSibling) {
@@ -467,7 +467,7 @@ int PanoramiXConfigureWindow(ClientPtr client)
 	sib_offset = Ones((Mask)stuff->mask & (CWSibling - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + sib_offset))) {
 	   if(!(sib = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_WINDOW, SecurityReadAccess)))
+		client, tmp, XRT_WINDOW, DixReadAccess)))
 	      return BadWindow;
 	}
     }
@@ -512,7 +512,7 @@ int PanoramiXCirculateWindow(ClientPtr client)
     REQUEST_SIZE_MATCH(xCirculateWindowReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     FOR_NSCREENS_FORWARD(j) {
@@ -577,11 +577,11 @@ int PanoramiXTranslateCoords(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xTranslateCoordsReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->srcWid, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     pDst = (WindowPtr)SecurityLookupWindow(stuff->dstWid, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pDst)
         return(BadWindow);
     rep.type = X_Reply;
@@ -653,7 +653,7 @@ int PanoramiXCreatePixmap(ClientPtr client)
     client->errorValue = stuff->pid;
 
     if(!(refDraw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityReadAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixReadAccess)))
 	return BadDrawable;
 
     if(!(newPix = (PanoramiXRes *) malloc(sizeof(PanoramiXRes))))
@@ -692,7 +692,7 @@ int PanoramiXFreePixmap(ClientPtr client)
     client->errorValue = stuff->id;
 
     if(!(pix = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_PIXMAP, SecurityDestroyAccess)))
+		client, stuff->id, XRT_PIXMAP, DixDestroyAccess)))
 	return BadPixmap;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -728,14 +728,14 @@ int PanoramiXCreateGC(ClientPtr client)
         return BadLength;
 
     if (!(refDraw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityReadAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixReadAccess)))
         return BadDrawable;
 
     if ((Mask)stuff->mask & GCTile) {
 	tile_offset = Ones((Mask)stuff->mask & (GCTile - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + tile_offset))) {
 	   if(!(tile = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -743,7 +743,7 @@ int PanoramiXCreateGC(ClientPtr client)
 	stip_offset = Ones((Mask)stuff->mask & (GCStipple - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + stip_offset))) {
 	   if(!(stip = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -751,7 +751,7 @@ int PanoramiXCreateGC(ClientPtr client)
 	clip_offset = Ones((Mask)stuff->mask & (GCClipMask - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + clip_offset))) {
 	   if(!(clip = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -803,14 +803,14 @@ int PanoramiXChangeGC(ClientPtr client)
         return BadLength;
 
     if (!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;
 
     if ((Mask)stuff->mask & GCTile) {
 	tile_offset = Ones((Mask)stuff->mask & (GCTile - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + tile_offset))) {
 	   if(!(tile = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -818,7 +818,7 @@ int PanoramiXChangeGC(ClientPtr client)
 	stip_offset = Ones((Mask)stuff->mask & (GCStipple - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + stip_offset))) {
 	   if(!(stip = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -826,7 +826,7 @@ int PanoramiXChangeGC(ClientPtr client)
 	clip_offset = Ones((Mask)stuff->mask & (GCClipMask - 1));
 	if ((tmp = *((CARD32 *) &stuff[1] + clip_offset))) {
 	   if(!(clip = (PanoramiXRes*) SecurityLookupIDByType(
-		client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+		client, tmp, XRT_PIXMAP, DixReadAccess)))
 	      return BadPixmap;
 	}
     }
@@ -857,11 +857,11 @@ int PanoramiXCopyGC(ClientPtr client)
     REQUEST_SIZE_MATCH(xCopyGCReq);
 
     if(!(srcGC = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->srcGC, XRT_GC, SecurityReadAccess)))
+		client, stuff->srcGC, XRT_GC, DixReadAccess)))
 	return BadGC;
 
     if(!(dstGC = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->dstGC, XRT_GC, SecurityWriteAccess)))
+		client, stuff->dstGC, XRT_GC, DixWriteAccess)))
 	return BadGC;
 
     FOR_NSCREENS(j) {
@@ -884,7 +884,7 @@ int PanoramiXSetDashes(ClientPtr client)
     REQUEST_FIXED_SIZE(xSetDashesReq, stuff->nDashes);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityWriteAccess)))
+		client, stuff->gc, XRT_GC, DixWriteAccess)))
 	return BadGC;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -906,7 +906,7 @@ int PanoramiXSetClipRectangles(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xSetClipRectanglesReq);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityWriteAccess)))
+		client, stuff->gc, XRT_GC, DixWriteAccess)))
 	return BadGC;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -928,7 +928,7 @@ int PanoramiXFreeGC(ClientPtr client)
     REQUEST_SIZE_MATCH(xResourceReq);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->id, XRT_GC, SecurityDestroyAccess)))
+		client, stuff->id, XRT_GC, DixDestroyAccess)))
 	return BadGC;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -954,7 +954,7 @@ int PanoramiXClearToBackground(ClientPtr client)
     REQUEST_SIZE_MATCH(xClearAreaReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->window, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     x = stuff->x;
@@ -996,13 +996,13 @@ int PanoramiXCopyArea(ClientPtr client)
     REQUEST_SIZE_MATCH(xCopyAreaReq);
 
     if(!(src = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->srcDrawable, XRC_DRAWABLE, SecurityReadAccess)))
+		client, stuff->srcDrawable, XRC_DRAWABLE, DixReadAccess)))
 	return BadDrawable;
 
     srcShared = IS_SHARED_PIXMAP(src);
 
     if(!(dst = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->dstDrawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->dstDrawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     dstShared = IS_SHARED_PIXMAP(dst);
@@ -1011,7 +1011,7 @@ int PanoramiXCopyArea(ClientPtr client)
 	return (* SavedProcVector[X_CopyArea])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;
 
     if((dst->type == XRT_WINDOW) && dst->u.win.root)
@@ -1080,7 +1080,7 @@ int PanoramiXCopyArea(ClientPtr client)
 	    VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pDst, pGC, client); 
 	    if (stuff->dstDrawable != stuff->srcDrawable) {
 		SECURITY_VERIFY_DRAWABLE(pSrc, stuff->srcDrawable, client,
-                                 SecurityReadAccess);
+                                 DixReadAccess);
 		if ((pDst->pScreen != pSrc->pScreen) || 
 		    (pDst->depth != pSrc->depth)) {
 			client->errorValue = stuff->dstDrawable;
@@ -1144,13 +1144,13 @@ int PanoramiXCopyPlane(ClientPtr client)
     REQUEST_SIZE_MATCH(xCopyPlaneReq);
 
     if(!(src = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->srcDrawable, XRC_DRAWABLE, SecurityReadAccess)))
+		client, stuff->srcDrawable, XRC_DRAWABLE, DixReadAccess)))
 	return BadDrawable;    
 
     srcShared = IS_SHARED_PIXMAP(src);
 
     if(!(dst = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->dstDrawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->dstDrawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     dstShared = IS_SHARED_PIXMAP(dst);
@@ -1159,7 +1159,7 @@ int PanoramiXCopyPlane(ClientPtr client)
 	return (* SavedProcVector[X_CopyPlane])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;
 
     if((dst->type == XRT_WINDOW) && dst->u.win.root)
@@ -1186,7 +1186,7 @@ int PanoramiXCopyPlane(ClientPtr client)
 	VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pdstDraw, pGC, client);
 	if (stuff->dstDrawable != stuff->srcDrawable) {
 	    SECURITY_VERIFY_DRAWABLE(psrcDraw, stuff->srcDrawable, client,
-                                 SecurityReadAccess);
+                                 DixReadAccess);
             if (pdstDraw->pScreen != psrcDraw->pScreen) {
 		client->errorValue = stuff->dstDrawable;
 		return (BadMatch);
@@ -1244,14 +1244,14 @@ int PanoramiXPolyPoint(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyPointReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyPoint])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1302,14 +1302,14 @@ int PanoramiXPolyLine(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyLineReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyLine])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1360,14 +1360,14 @@ int PanoramiXPolySegment(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolySegmentReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolySegment])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1422,14 +1422,14 @@ int PanoramiXPolyRectangle(ClientPtr client)
 
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyRectangle])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1482,14 +1482,14 @@ int PanoramiXPolyArc(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyArcReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyArc])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1540,14 +1540,14 @@ int PanoramiXFillPoly(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xFillPolyReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_FillPoly])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1599,14 +1599,14 @@ int PanoramiXPolyFillRectangle(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyFillRectangleReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyFillRectangle])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1658,14 +1658,14 @@ int PanoramiXPolyFillArc(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyFillArcReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyFillArc])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1716,14 +1716,14 @@ int PanoramiXPutImage(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPutImageReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PutImage])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1767,7 +1767,7 @@ int PanoramiXGetImage(ClientPtr client)
     }
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     if(draw->type == XRT_PIXMAP)
@@ -1907,14 +1907,14 @@ PanoramiXPolyText8(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyTextReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyText8])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1946,14 +1946,14 @@ PanoramiXPolyText16(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xPolyTextReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_PolyText16])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1985,14 +1985,14 @@ int PanoramiXImageText8(ClientPtr client)
     REQUEST_FIXED_SIZE(xImageTextReq, stuff->nChars);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_ImageText8])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -2024,14 +2024,14 @@ int PanoramiXImageText16(ClientPtr client)
     REQUEST_FIXED_SIZE(xImageTextReq, stuff->nChars << 1);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;    
 
     if(IS_SHARED_PIXMAP(draw))
 	return (*SavedProcVector[X_ImageText16])(client);
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->gc, XRT_GC, SecurityReadAccess)))
+		client, stuff->gc, XRT_GC, DixReadAccess)))
 	return BadGC;    
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -2062,7 +2062,7 @@ int PanoramiXCreateColormap(ClientPtr client)
     REQUEST_SIZE_MATCH(xCreateColormapReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->window, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->window, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;    
 
     if(!stuff->visual || (stuff->visual > 255)) 
@@ -2105,7 +2105,7 @@ int PanoramiXFreeColormap(ClientPtr client)
     client->errorValue = stuff->id;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->id, XRT_COLORMAP, SecurityDestroyAccess)))
+                client, stuff->id, XRT_COLORMAP, DixDestroyAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -2134,7 +2134,7 @@ PanoramiXCopyColormapAndFree(ClientPtr client)
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
                 client, stuff->srcCmap, XRT_COLORMAP, 
-		SecurityReadAccess | SecurityWriteAccess)))
+		DixReadAccess | DixWriteAccess)))
         return BadColor;
 
     if(!(newCmap = (PanoramiXRes *) malloc(sizeof(PanoramiXRes))))
@@ -2172,7 +2172,7 @@ int PanoramiXInstallColormap(ClientPtr client)
     client->errorValue = stuff->id;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->id, XRT_COLORMAP, SecurityReadAccess)))
+                client, stuff->id, XRT_COLORMAP, DixReadAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j){
@@ -2195,7 +2195,7 @@ int PanoramiXUninstallColormap(ClientPtr client)
     client->errorValue = stuff->id;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->id, XRT_COLORMAP, SecurityReadAccess)))
+                client, stuff->id, XRT_COLORMAP, DixReadAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -2218,7 +2218,7 @@ int PanoramiXAllocColor(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
 	return BadColor;
 
     FOR_NSCREENS_BACKWARD(j){
@@ -2241,7 +2241,7 @@ int PanoramiXAllocNamedColor(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j){
@@ -2264,7 +2264,7 @@ int PanoramiXAllocColorCells(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
 	return BadColor;
 	
     FOR_NSCREENS_BACKWARD(j){
@@ -2287,7 +2287,7 @@ int PanoramiXAllocColorPlanes(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
 	return BadColor;
 	
     FOR_NSCREENS_BACKWARD(j){
@@ -2311,7 +2311,7 @@ int PanoramiXFreeColors(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j) {
@@ -2333,7 +2333,7 @@ int PanoramiXStoreColors(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j){
@@ -2356,7 +2356,7 @@ int PanoramiXStoreNamedColor(ClientPtr client)
     client->errorValue = stuff->cmap;
 
     if(!(cmap = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->cmap, XRT_COLORMAP, SecurityWriteAccess)))
+                client, stuff->cmap, XRT_COLORMAP, DixWriteAccess)))
         return BadColor;
 
     FOR_NSCREENS_BACKWARD(j){

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -1199,7 +1199,7 @@ ProcScreenSaverSetAttributes (ClientPtr client)
        REQUEST_AT_LEAST_SIZE (xScreenSaverSetAttributesReq);
 
        if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                   client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                   client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
            return BadDrawable;
 
        len = stuff->length -  (sizeof(xScreenSaverSetAttributesReq) >> 2);
@@ -1211,7 +1211,7 @@ ProcScreenSaverSetAttributes (ClientPtr client)
           tmp = *((CARD32 *) &stuff[1] + pback_offset);
           if ((tmp != None) && (tmp != ParentRelative)) {
              if(!(backPix = (PanoramiXRes*) SecurityLookupIDByType(
-                  client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+                  client, tmp, XRT_PIXMAP, DixReadAccess)))
                 return BadPixmap;
           }
        }
@@ -1221,7 +1221,7 @@ ProcScreenSaverSetAttributes (ClientPtr client)
           tmp = *((CARD32 *) &stuff[1] + pbord_offset);
           if (tmp != CopyFromParent) {
              if(!(bordPix = (PanoramiXRes*) SecurityLookupIDByType(
-                  client, tmp, XRT_PIXMAP, SecurityReadAccess)))
+                  client, tmp, XRT_PIXMAP, DixReadAccess)))
                 return BadPixmap;
           }
        }
@@ -1231,7 +1231,7 @@ ProcScreenSaverSetAttributes (ClientPtr client)
            tmp = *((CARD32 *) &stuff[1] + cmap_offset);
            if ((tmp != CopyFromParent) && (tmp != None)) {
              if(!(cmap = (PanoramiXRes*) SecurityLookupIDByType(
-                  client, tmp, XRT_COLORMAP, SecurityReadAccess)))
+                  client, tmp, XRT_COLORMAP, DixReadAccess)))
                  return BadColor;
            }
        }
@@ -1271,7 +1271,7 @@ ProcScreenSaverUnsetAttributes (ClientPtr client)
        int i;
 
        if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                   client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                   client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
            return BadDrawable;
 
        for(i = PanoramiXNumScreens - 1; i > 0; i--) {

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -750,7 +750,7 @@ ProcSecurityRevokeAuthorization(
     REQUEST_SIZE_MATCH(xSecurityRevokeAuthorizationReq);
 
     pAuth = (SecurityAuthorizationPtr)SecurityLookupIDByType(client,
-	stuff->authId, SecurityAuthorizationResType, SecurityDestroyAccess);
+	stuff->authId, SecurityAuthorizationResType, DixDestroyAccess);
     if (!pAuth)
 	return SecurityErrorBase + XSecurityBadAuthorization;
 
@@ -1115,7 +1115,7 @@ SecurityCheckResourceIDAccess(
     int cid = CLIENT_ID(id);
     int reqtype = ((xReq *)client->requestBuffer)->reqType;
 
-    if (SecurityUnknownAccess == access_mode)
+    if (DixUnknownAccess == access_mode)
 	return rval;  /* for compatibility, we have to allow access */
 
     switch (reqtype)
@@ -2051,11 +2051,11 @@ SecurityCheckPropertyAccess(client, pWin, propertyName, access_mode)
 	     * executed a continue, which will skip the follwing code.
 	     */
 	    action = SecurityAllowOperation;
-	    if (access_mode & SecurityReadAccess)
+	    if (access_mode & DixReadAccess)
 		action = max(action, pacl->readAction);
-	    if (access_mode & SecurityWriteAccess)
+	    if (access_mode & DixWriteAccess)
 		action = max(action, pacl->writeAction);
-	    if (access_mode & SecurityDestroyAccess)
+	    if (access_mode & DixDestroyAccess)
 		action = max(action, pacl->destroyAction);
 	    break;
 	} /* end for each pacl */

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -385,7 +385,7 @@ ProcPanoramiXShapeRectangles(
     REQUEST_AT_LEAST_SIZE (xShapeRectanglesReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->dest, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->dest, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     FOR_NSCREENS(j) {
@@ -417,7 +417,7 @@ ProcShapeMask (client)
 
     REQUEST_SIZE_MATCH (xShapeMaskReq);
     UpdateCurrentTime();
-    pWin = SecurityLookupWindow (stuff->dest, client, SecurityWriteAccess);
+    pWin = SecurityLookupWindow (stuff->dest, client, DixWriteAccess);
     if (!pWin)
 	return BadWindow;
     switch (stuff->destKind) {
@@ -439,7 +439,7 @@ ProcShapeMask (client)
 	srcRgn = 0;
     else {
         pPixmap = (PixmapPtr) SecurityLookupIDByType(client, stuff->src,
-						RT_PIXMAP, SecurityReadAccess);
+						RT_PIXMAP, DixReadAccess);
         if (!pPixmap)
 	    return BadPixmap;
 	if (pPixmap->drawable.pScreen != pScreen ||
@@ -483,12 +483,12 @@ ProcPanoramiXShapeMask(
     REQUEST_SIZE_MATCH (xShapeMaskReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->dest, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->dest, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     if(stuff->src != None) {
 	if(!(pmap = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->src, XRT_PIXMAP, SecurityReadAccess)))
+		client, stuff->src, XRT_PIXMAP, DixReadAccess)))
 	    return BadPixmap;
     } else
 	pmap = NULL;
@@ -611,11 +611,11 @@ ProcPanoramiXShapeCombine(
     REQUEST_AT_LEAST_SIZE (xShapeCombineReq);
 
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->dest, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->dest, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     if(!(win2 = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->src, XRT_WINDOW, SecurityReadAccess)))
+		client, stuff->src, XRT_WINDOW, DixReadAccess)))
 	return BadWindow;
 
     FOR_NSCREENS(j) {
@@ -683,7 +683,7 @@ ProcPanoramiXShapeOffset(
     REQUEST_AT_LEAST_SIZE (xShapeOffsetReq);
    
     if(!(win = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->dest, XRT_WINDOW, SecurityWriteAccess)))
+		client, stuff->dest, XRT_WINDOW, DixWriteAccess)))
 	return BadWindow;
 
     FOR_NSCREENS(j) {
@@ -817,11 +817,11 @@ ProcShapeSelectInput (client)
     XID			clientResource;
 
     REQUEST_SIZE_MATCH (xShapeSelectInputReq);
-    pWin = SecurityLookupWindow (stuff->window, client, SecurityWriteAccess);
+    pWin = SecurityLookupWindow (stuff->window, client, DixWriteAccess);
     if (!pWin)
 	return BadWindow;
     pHead = (ShapeEventPtr *)SecurityLookupIDByType(client,
-			pWin->drawable.id, EventType, SecurityWriteAccess);
+			pWin->drawable.id, EventType, DixWriteAccess);
     switch (stuff->enable) {
     case xTrue:
 	if (pHead) {
@@ -988,7 +988,7 @@ ProcShapeInputSelected (client)
     if (!pWin)
 	return BadWindow;
     pHead = (ShapeEventPtr *) SecurityLookupIDByType(client,
-			pWin->drawable.id, EventType, SecurityReadAccess);
+			pWin->drawable.id, EventType, DixReadAccess);
     enabled = xFalse;
     if (pHead) {
     	for (pShapeEvent = *pHead;

--- a/nx-X11/programs/Xserver/Xext/shm.c
+++ b/nx-X11/programs/Xserver/Xext/shm.c
@@ -568,11 +568,11 @@ ProcPanoramiXShmPutImage(register ClientPtr client)
     REQUEST_SIZE_MATCH(xShmPutImageReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->gc, XRT_GC, SecurityReadAccess)))
+                client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -618,7 +618,7 @@ ProcPanoramiXShmGetImage(ClientPtr client)
     }
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
 
     if (draw->type == XRT_PIXMAP)

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -425,7 +425,7 @@ SyncInitTrigger(client, pTrigger, counter, changes)
 	if (counter == None)
 	    pCounter = NULL;
 	else if (!(pCounter = (SyncCounter *)SecurityLookupIDByType(
-			client, counter, RTCounter, SecurityReadAccess)))
+			client, counter, RTCounter, DixReadAccess)))
 	{
 	    client->errorValue = counter;
 	    return SyncErrorBase + XSyncBadCounter;
@@ -1527,7 +1527,7 @@ ProcSyncSetCounter(client)
     REQUEST_SIZE_MATCH(xSyncSetCounterReq);
 
     pCounter = (SyncCounter *)SecurityLookupIDByType(client, stuff->cid,
-					   RTCounter, SecurityWriteAccess);
+					   RTCounter, DixWriteAccess);
     if (pCounter == NULL)
     {
 	client->errorValue = stuff->cid;
@@ -1560,7 +1560,7 @@ ProcSyncChangeCounter(client)
     REQUEST_SIZE_MATCH(xSyncChangeCounterReq);
 
     pCounter = (SyncCounter *) SecurityLookupIDByType(client, stuff->cid,
-					    RTCounter, SecurityWriteAccess);
+					    RTCounter, DixWriteAccess);
     if (pCounter == NULL)
     {
 	client->errorValue = stuff->cid;
@@ -1598,7 +1598,7 @@ ProcSyncDestroyCounter(client)
     REQUEST_SIZE_MATCH(xSyncDestroyCounterReq);
 
     pCounter = (SyncCounter *)SecurityLookupIDByType(client, stuff->counter,
-					   RTCounter, SecurityDestroyAccess);
+					   RTCounter, DixDestroyAccess);
     if (pCounter == NULL)
     {
 	client->errorValue = stuff->counter;
@@ -1744,7 +1744,7 @@ ProcSyncQueryCounter(client)
     REQUEST_SIZE_MATCH(xSyncQueryCounterReq);
 
     pCounter = (SyncCounter *)SecurityLookupIDByType(client, stuff->counter,
-					    RTCounter, SecurityReadAccess);
+					    RTCounter, DixReadAccess);
     if (pCounter == NULL)
     {
 	client->errorValue = stuff->counter;
@@ -1872,7 +1872,7 @@ ProcSyncChangeAlarm(client)
     REQUEST_AT_LEAST_SIZE(xSyncChangeAlarmReq);
 
     if (!(pAlarm = (SyncAlarm *)SecurityLookupIDByType(client, stuff->alarm,
-					      RTAlarm, SecurityWriteAccess)))
+					      RTAlarm, DixWriteAccess)))
     {
 	client->errorValue = stuff->alarm;
 	return SyncErrorBase + XSyncBadAlarm;
@@ -1913,7 +1913,7 @@ ProcSyncQueryAlarm(client)
     REQUEST_SIZE_MATCH(xSyncQueryAlarmReq);
 
     pAlarm = (SyncAlarm *)SecurityLookupIDByType(client, stuff->alarm,
-						RTAlarm, SecurityReadAccess);
+						RTAlarm, DixReadAccess);
     if (!pAlarm)
     {
 	client->errorValue = stuff->alarm;
@@ -1972,7 +1972,7 @@ ProcSyncDestroyAlarm(client)
     REQUEST_SIZE_MATCH(xSyncDestroyAlarmReq);
 
     if (!((SyncAlarm *)SecurityLookupIDByType(client, stuff->alarm,
-					      RTAlarm, SecurityDestroyAccess)))
+					      RTAlarm, DixDestroyAccess)))
     {
 	client->errorValue = stuff->alarm;
 	return SyncErrorBase + XSyncBadAlarm;

--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
@@ -443,11 +443,11 @@ ProcXF86BigfontQueryFont(
 #endif
     client->errorValue = stuff->id;		/* EITHER font or gc */
     pFont = (FontPtr)SecurityLookupIDByType(client, stuff->id, RT_FONT,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pFont) {
 	/* can't use VERIFY_GC because it might return BadGC */
 	GC *pGC = (GC *) SecurityLookupIDByType(client, stuff->id, RT_GC,
-						SecurityReadAccess);
+						DixReadAccess);
         if (!pGC) {
 	    client->errorValue = stuff->id;
             return BadFont;    /* procotol spec says only error is BadFont */

--- a/nx-X11/programs/Xserver/Xext/xvdisp.c
+++ b/nx-X11/programs/Xserver/Xext/xvdisp.c
@@ -1854,11 +1854,11 @@ XineramaXvStopVideo(ClientPtr client)
    REQUEST_SIZE_MATCH(xvStopVideoReq);
 
    if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
    if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->port, XvXRTPort, SecurityReadAccess)))
+                client, stuff->port, XvXRTPort, DixReadAccess)))
         return _XvBadPort;
 
    FOR_NSCREENS_BACKWARD(i) {
@@ -1882,7 +1882,7 @@ XineramaXvSetPortAttribute(ClientPtr client)
     REQUEST_SIZE_MATCH(xvSetPortAttributeReq);
 
     if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->port, XvXRTPort, SecurityReadAccess)))
+                client, stuff->port, XvXRTPort, DixReadAccess)))
         return _XvBadPort;
 
     FOR_NSCREENS_BACKWARD(i) {
@@ -1908,15 +1908,15 @@ XineramaXvShmPutImage(ClientPtr client)
     REQUEST_SIZE_MATCH(xvShmPutImageReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->gc, XRT_GC, SecurityReadAccess)))
+                client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;    
 
     if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->port, XvXRTPort, SecurityReadAccess)))
+                client, stuff->port, XvXRTPort, DixReadAccess)))
         return _XvBadPort;
  
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -1955,15 +1955,15 @@ XineramaXvPutImage(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xvPutImageReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->gc, XRT_GC, SecurityReadAccess)))
+                client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;    
 
     if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-		client, stuff->port, XvXRTPort, SecurityReadAccess)))
+		client, stuff->port, XvXRTPort, DixReadAccess)))
 	return _XvBadPort;
  
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -2000,15 +2000,15 @@ XineramaXvPutVideo(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xvPutVideoReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->gc, XRT_GC, SecurityReadAccess)))
+                client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;
 
     if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->port, XvXRTPort, SecurityReadAccess)))
+                client, stuff->port, XvXRTPort, DixReadAccess)))
         return _XvBadPort;
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
@@ -2045,15 +2045,15 @@ XineramaXvPutStill(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xvPutImageReq);
 
     if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
-                client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+                client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
         return BadDrawable;
 
     if(!(gc = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->gc, XRT_GC, SecurityReadAccess)))
+                client, stuff->gc, XRT_GC, DixReadAccess)))
         return BadGC;
 
     if(!(port = (PanoramiXRes *)SecurityLookupIDByType(
-                client, stuff->port, XvXRTPort, SecurityReadAccess)))
+                client, stuff->port, XvXRTPort, DixReadAccess)))
         return _XvBadPort;
 
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;

--- a/nx-X11/programs/Xserver/composite/compwindow.c
+++ b/nx-X11/programs/Xserver/composite/compwindow.c
@@ -83,7 +83,7 @@ compRepaintBorder (ClientPtr pClient, void * closure)
         dixLookupWindow(&pWindow, (XID) (intptr_t) closure, pClient,
                         DixWriteAccess);
 #else
-    pWindow = SecurityLookupWindow((XID) (intptr_t) closure, pClient, SecurityWriteAccess);
+    pWindow = SecurityLookupWindow((XID) (intptr_t) closure, pClient, DixWriteAccess);
     int rc = pWindow ? Success : BadWindow;
 #endif
 

--- a/nx-X11/programs/Xserver/damageext/damageext.c
+++ b/nx-X11/programs/Xserver/damageext/damageext.c
@@ -175,7 +175,7 @@ ProcDamageCreate (ClientPtr client)
     REQUEST_SIZE_MATCH(xDamageCreateReq);
     LEGAL_NEW_RESOURCE(stuff->damage, client);
     SECURITY_VERIFY_DRAWABLE (pDrawable, stuff->drawable, client,
-			      SecurityReadAccess);
+			      DixReadAccess);
     switch (stuff->level) {
     case XDamageReportRawRectangles:
 	level = DamageReportRawRegion;
@@ -233,7 +233,7 @@ ProcDamageDestroy (ClientPtr client)
     DamageExtPtr    pDamageExt;
 
     REQUEST_SIZE_MATCH(xDamageDestroyReq);
-    VERIFY_DAMAGEEXT(pDamageExt, stuff->damage, client, SecurityWriteAccess);
+    VERIFY_DAMAGEEXT(pDamageExt, stuff->damage, client, DixWriteAccess);
     FreeResource (stuff->damage, RT_NONE);
     return (client->noClientException);
 }
@@ -247,9 +247,9 @@ ProcDamageSubtract (ClientPtr client)
     RegionPtr	    pParts;
 
     REQUEST_SIZE_MATCH(xDamageSubtractReq);
-    VERIFY_DAMAGEEXT(pDamageExt, stuff->damage, client, SecurityWriteAccess);
-    VERIFY_REGION_OR_NONE(pRepair, stuff->repair, client, SecurityWriteAccess);
-    VERIFY_REGION_OR_NONE(pParts, stuff->parts, client, SecurityWriteAccess);
+    VERIFY_DAMAGEEXT(pDamageExt, stuff->damage, client, DixWriteAccess);
+    VERIFY_REGION_OR_NONE(pRepair, stuff->repair, client, DixWriteAccess);
+    VERIFY_REGION_OR_NONE(pParts, stuff->parts, client, DixWriteAccess);
 
     if (pDamageExt->level != DamageReportRawRegion)
     {

--- a/nx-X11/programs/Xserver/dbe/dbe.c
+++ b/nx-X11/programs/Xserver/dbe/dbe.c
@@ -420,7 +420,7 @@ ProcDbeAllocateBackBufferName(client)
 
     /* The window must be valid. */
     if (!(pWin = SecurityLookupWindow(stuff->window, client,
-				      SecurityWriteAccess)))
+				      DixWriteAccess)))
     {
 	return(BadWindow);
     }
@@ -648,9 +648,9 @@ ProcDbeDeallocateBackBufferName(client)
 
     /* Buffer name must be valid */
     if (!(pDbeWindowPriv = (DbeWindowPrivPtr)SecurityLookupIDByType(client,
-		stuff->buffer, dbeWindowPrivResType, SecurityDestroyAccess)) ||
+		stuff->buffer, dbeWindowPrivResType, DixDestroyAccess)) ||
         !(SecurityLookupIDByType(client, stuff->buffer, dbeDrawableResType,
-				 SecurityDestroyAccess)))
+				 DixDestroyAccess)))
     {
         client->errorValue = stuff->buffer;
         return(dbeErrorBase + DbeBadBuffer);
@@ -751,7 +751,7 @@ ProcDbeSwapBuffers(client)
 
         /* Each window must be a valid window - BadWindow. */
         if (!(pWin = SecurityLookupWindow(dbeSwapInfo[i].window, client,
-					  SecurityWriteAccess)))
+					  DixWriteAccess)))
         {
             free(swapInfo);
 	    return(BadWindow);
@@ -916,7 +916,7 @@ ProcDbeGetVisualInfo(client)
         for (i = 0; i < stuff->n; i++)
         {
             if (!(pDrawables[i] = (DrawablePtr)SecurityLookupDrawable(
-				drawables[i], client, SecurityReadAccess)))
+				drawables[i], client, DixReadAccess)))
             {
                 free(pDrawables);
                 return(BadDrawable);
@@ -1072,7 +1072,7 @@ ProcDbeGetBackBufferAttributes(client)
     REQUEST_SIZE_MATCH(xDbeGetBackBufferAttributesReq);
 
     if (!(pDbeWindowPriv = (DbeWindowPrivPtr)SecurityLookupIDByType(client,
-		stuff->buffer, dbeWindowPrivResType, SecurityReadAccess)))
+		stuff->buffer, dbeWindowPrivResType, DixReadAccess)))
     {
         rep.attributes = None;
     }

--- a/nx-X11/programs/Xserver/dix/colormap.c
+++ b/nx-X11/programs/Xserver/dix/colormap.c
@@ -892,7 +892,7 @@ AllocColor (ColormapPtr pmap,
 	{
 	    ColormapPtr prootmap = (ColormapPtr)
 		SecurityLookupIDByType (clients[client], pmap->pScreen->defColormap,
-					 RT_COLORMAP, SecurityReadAccess);
+					 RT_COLORMAP, DixReadAccess);
 
 	    if (pmap->class == prootmap->class)
 		FindColorInRootCmap (prootmap, prootmap->red, entries, &rgb, 
@@ -909,7 +909,7 @@ AllocColor (ColormapPtr pmap,
 	{
 	    ColormapPtr prootmap = (ColormapPtr)
 		SecurityLookupIDByType (clients[client], pmap->pScreen->defColormap,
-					 RT_COLORMAP, SecurityReadAccess);
+					 RT_COLORMAP, DixReadAccess);
 
 	    if (pmap->class == prootmap->class)
 	    {

--- a/nx-X11/programs/Xserver/dix/cursor.c
+++ b/nx-X11/programs/Xserver/dix/cursor.c
@@ -262,9 +262,9 @@ AllocGlyphCursor(Font source, unsigned sourceChar, Font mask, unsigned maskChar,
     GlyphSharePtr pShare;
 
     sourcefont = (FontPtr) SecurityLookupIDByType(client, source, RT_FONT,
-						  SecurityReadAccess);
+						  DixReadAccess);
     maskfont = (FontPtr) SecurityLookupIDByType(client, mask, RT_FONT,
-						SecurityReadAccess);
+						DixReadAccess);
 
     if (!sourcefont)
     {

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -491,7 +491,7 @@ ProcCreateWindow(ClientPtr client)
     
     LEGAL_NEW_RESOURCE(stuff->wid, client);
     if (!(pParent = (WindowPtr)SecurityLookupWindow(stuff->parent, client,
-						    SecurityWriteAccess)))
+						    DixWriteAccess)))
         return BadWindow;
     len = client->req_len - (sizeof(xCreateWindowReq) >> 2);
     if (Ones(stuff->mask) != len)
@@ -532,7 +532,7 @@ ProcChangeWindowAttributes(register ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xChangeWindowAttributesReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     len = client->req_len - (sizeof(xChangeWindowAttributesReq) >> 2);
@@ -557,7 +557,7 @@ ProcGetWindowAttributes(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     memset(&wa, 0, sizeof(xGetWindowAttributesReply));
@@ -574,7 +574,7 @@ ProcDestroyWindow(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityDestroyAccess);
+					   DixDestroyAccess);
     if (!pWin)
         return(BadWindow);
     if (pWin->parent)
@@ -590,7 +590,7 @@ ProcDestroySubwindows(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityDestroyAccess);
+					   DixDestroyAccess);
     if (!pWin)
         return(BadWindow);
     DestroySubwindows(pWin, client);
@@ -606,7 +606,7 @@ ProcChangeSaveSet(register ClientPtr client)
 		  
     REQUEST_SIZE_MATCH(xChangeSaveSetReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     if (client->clientAsMask == (CLIENT_BITS(pWin->drawable.id)))
@@ -636,11 +636,11 @@ ProcReparentWindow(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xReparentWindowReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     pParent = (WindowPtr)SecurityLookupWindow(stuff->parent, client,
-					      SecurityWriteAccess);
+					      DixWriteAccess);
     if (!pParent)
         return(BadWindow);
     if (SAME_SCREENS(pWin->drawable, pParent->drawable))
@@ -671,7 +671,7 @@ ProcMapWindow(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     MapWindow(pWin, client);
@@ -687,7 +687,7 @@ ProcMapSubwindows(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow( stuff->id, client,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pWin)
         return(BadWindow);
     MapSubwindows(pWin, client);
@@ -703,7 +703,7 @@ ProcUnmapWindow(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow( stuff->id, client,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pWin)
         return(BadWindow);
     UnmapWindow(pWin, FALSE);
@@ -719,7 +719,7 @@ ProcUnmapSubwindows(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow( stuff->id, client,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pWin)
         return(BadWindow);
     UnmapSubwindows(pWin);
@@ -736,7 +736,7 @@ ProcConfigureWindow(register ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xConfigureWindowReq);
     pWin = (WindowPtr)SecurityLookupWindow( stuff->window, client,
-					    SecurityWriteAccess);
+					    DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     len = client->req_len - (sizeof(xConfigureWindowReq) >> 2);
@@ -764,7 +764,7 @@ ProcCirculateWindow(register ClientPtr client)
         return BadValue;
     }
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     CirculateWindow(pWin, (int)stuff->direction, client);
@@ -778,7 +778,7 @@ GetGeometry(register ClientPtr client, xGetGeometryReply *rep)
     REQUEST(xResourceReq);
 
     REQUEST_SIZE_MATCH(xResourceReq);
-    SECURITY_VERIFY_GEOMETRABLE (pDraw, stuff->id, client, SecurityReadAccess);
+    SECURITY_VERIFY_GEOMETRABLE (pDraw, stuff->id, client, DixReadAccess);
     memset(rep, 0, sizeof(xGetGeometryReply));
     rep->type = X_Reply;
     rep->length = 0;
@@ -839,7 +839,7 @@ ProcQueryTree(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     memset(&reply, 0, sizeof(xQueryTreeReply));
@@ -957,7 +957,7 @@ ProcSetSelectionOwner(register ClientPtr client)
     if (stuff->window != None)
     {
         pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					       SecurityReadAccess);
+					       DixReadAccess);
         if (!pWin)
             return(BadWindow);
     }
@@ -1079,7 +1079,7 @@ ProcConvertSelection(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xConvertSelectionReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->requestor, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
 
@@ -1098,7 +1098,7 @@ ProcConvertSelection(register ClientPtr client)
 #ifdef XCSECURITY
 	    && (!client->CheckAccess ||
 		(* client->CheckAccess)(client, CurrentSelections[i].window,
-					RT_WINDOW, SecurityReadAccess,
+					RT_WINDOW, DixReadAccess,
 					CurrentSelections[i].pWin))
 #endif
 	    )
@@ -1208,11 +1208,11 @@ ProcTranslateCoords(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xTranslateCoordsReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->srcWid, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     pDst = (WindowPtr)SecurityLookupWindow(stuff->dstWid, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pDst)
         return(BadWindow);
     memset(&rep, 0, sizeof(xTranslateCoordsReply));
@@ -1305,7 +1305,7 @@ ProcCloseFont(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pFont = (FontPtr)SecurityLookupIDByType(client, stuff->id, RT_FONT,
-					    SecurityDestroyAccess);
+					    DixDestroyAccess);
     if ( pFont != (FontPtr)NULL)	/* id was valid */
     {
         FreeResource(stuff->id, RT_NONE);
@@ -1331,12 +1331,12 @@ ProcQueryFont(register ClientPtr client)
     client->errorValue = stuff->id;		/* EITHER font or gc */
 
     pFont = (FontPtr)SecurityLookupIDByType(client, stuff->id, RT_FONT,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pFont)
     {
 	  /* can't use VERIFY_GC because it might return BadGC */
 	pGC = (GC *) SecurityLookupIDByType(client, stuff->id, RT_GC,
-					    SecurityReadAccess);
+					    DixReadAccess);
         if (!pGC)
 	{
 	    client->errorValue = stuff->id;
@@ -1394,11 +1394,11 @@ ProcQueryTextExtents(register ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xQueryTextExtentsReq);
         
     pFont = (FontPtr)SecurityLookupIDByType(client, stuff->fid, RT_FONT,
-					    SecurityReadAccess);
+					    DixReadAccess);
     if (!pFont)
     {
         pGC = (GC *)SecurityLookupIDByType(client, stuff->fid, RT_GC,
-					   SecurityReadAccess);
+					   DixReadAccess);
         if (!pGC)
 	{
 	    client->errorValue = stuff->fid;
@@ -1479,7 +1479,7 @@ ProcCreatePixmap(register ClientPtr client)
     client->errorValue = stuff->pid;
     LEGAL_NEW_RESOURCE(stuff->pid, client);
     SECURITY_VERIFY_GEOMETRABLE (pDraw, stuff->drawable, client,
-				 SecurityReadAccess);
+				 DixReadAccess);
     if (!stuff->width || !stuff->height)
     {
 	client->errorValue = 0;
@@ -1535,7 +1535,7 @@ ProcFreePixmap(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pMap = (PixmapPtr)SecurityLookupIDByType(client, stuff->id, RT_PIXMAP,
-					     SecurityDestroyAccess);
+					     DixDestroyAccess);
     if (pMap) 
     {
 	FreeResource(stuff->id, RT_NONE);
@@ -1562,7 +1562,7 @@ ProcCreateGC(register ClientPtr client)
     client->errorValue = stuff->gc;
     LEGAL_NEW_RESOURCE(stuff->gc, client);
     SECURITY_VERIFY_DRAWABLE (pDraw, stuff->drawable, client,
-			      SecurityReadAccess);
+			      DixReadAccess);
     len = client->req_len -  (sizeof(xCreateGCReq) >> 2);
     if (len != Ones(stuff->mask))
         return BadLength;
@@ -1584,7 +1584,7 @@ ProcChangeGC(register ClientPtr client)
     unsigned len;
 		
     REQUEST_AT_LEAST_SIZE(xChangeGCReq);
-    SECURITY_VERIFY_GC(pGC, stuff->gc, client, SecurityWriteAccess);
+    SECURITY_VERIFY_GC(pGC, stuff->gc, client, DixWriteAccess);
     len = client->req_len -  (sizeof(xChangeGCReq) >> 2);
     if (len != Ones(stuff->mask))
         return BadLength;
@@ -1608,8 +1608,8 @@ ProcCopyGC(register ClientPtr client)
     REQUEST(xCopyGCReq);
 
     REQUEST_SIZE_MATCH(xCopyGCReq);
-    SECURITY_VERIFY_GC( pGC, stuff->srcGC, client, SecurityReadAccess);
-    SECURITY_VERIFY_GC( dstGC, stuff->dstGC, client, SecurityWriteAccess);
+    SECURITY_VERIFY_GC( pGC, stuff->srcGC, client, DixReadAccess);
+    SECURITY_VERIFY_GC( dstGC, stuff->dstGC, client, DixWriteAccess);
     if ((dstGC->pScreen != pGC->pScreen) || (dstGC->depth != pGC->depth))
         return (BadMatch);    
     result = CopyGC(pGC, dstGC, stuff->mask);
@@ -1636,7 +1636,7 @@ ProcSetDashes(register ClientPtr client)
          return BadValue;
     }
 
-    SECURITY_VERIFY_GC(pGC,stuff->gc, client, SecurityWriteAccess);
+    SECURITY_VERIFY_GC(pGC,stuff->gc, client, DixWriteAccess);
 
     result = SetDashes(pGC, stuff->dashOffset, stuff->nDashes,
 		       (unsigned char *)&stuff[1]);
@@ -1664,7 +1664,7 @@ ProcSetClipRectangles(register ClientPtr client)
 	client->errorValue = stuff->ordering;
         return BadValue;
     }
-    SECURITY_VERIFY_GC(pGC,stuff->gc, client, SecurityWriteAccess);
+    SECURITY_VERIFY_GC(pGC,stuff->gc, client, DixWriteAccess);
 		 
     nr = (client->req_len << 2) - sizeof(xSetClipRectanglesReq);
     if (nr & 4)
@@ -1685,7 +1685,7 @@ ProcFreeGC(register ClientPtr client)
     REQUEST(xResourceReq);
 
     REQUEST_SIZE_MATCH(xResourceReq);
-    SECURITY_VERIFY_GC(pGC, stuff->id, client, SecurityDestroyAccess);
+    SECURITY_VERIFY_GC(pGC, stuff->id, client, DixDestroyAccess);
     FreeResource(stuff->id, RT_NONE);
     return(client->noClientException);
 }
@@ -1698,7 +1698,7 @@ ProcClearToBackground(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xClearAreaReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     if (pWin->drawable.class == InputOnly)
@@ -1732,7 +1732,7 @@ ProcCopyArea(register ClientPtr client)
     if (stuff->dstDrawable != stuff->srcDrawable)
     {
 	SECURITY_VERIFY_DRAWABLE(pSrc, stuff->srcDrawable, client,
-				 SecurityReadAccess);
+				 DixReadAccess);
 	if ((pDst->pScreen != pSrc->pScreen) || (pDst->depth != pSrc->depth))
 	{
 	    client->errorValue = stuff->dstDrawable;
@@ -1772,7 +1772,7 @@ ProcCopyPlane(register ClientPtr client)
     if (stuff->dstDrawable != stuff->srcDrawable)
     {
 	SECURITY_VERIFY_DRAWABLE(psrcDraw, stuff->srcDrawable, client,
-				 SecurityReadAccess);
+				 DixReadAccess);
 	if (pdstDraw->pScreen != psrcDraw->pScreen)
 	{
 	    client->errorValue = stuff->dstDrawable;
@@ -2115,7 +2115,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 	client->errorValue = format;
         return(BadValue);
     }
-    SECURITY_VERIFY_DRAWABLE(pDraw, drawable, client, SecurityReadAccess);
+    SECURITY_VERIFY_DRAWABLE(pDraw, drawable, client, DixReadAccess);
 
     memset(&xgi, 0, sizeof(xGetImageReply));
     if(pDraw->type == DRAWABLE_WINDOW)
@@ -2447,7 +2447,7 @@ ProcCreateColormap(register ClientPtr client)
     mid = stuff->mid;
     LEGAL_NEW_RESOURCE(mid, client);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
 
@@ -2477,7 +2477,7 @@ ProcFreeColormap(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pmap = (ColormapPtr )SecurityLookupIDByType(client, stuff->id, RT_COLORMAP,
-						SecurityDestroyAccess);
+						DixDestroyAccess);
     if (pmap) 
     {
 	/* Freeing a default colormap is a no-op */
@@ -2505,7 +2505,7 @@ ProcCopyColormapAndFree(register ClientPtr client)
     mid = stuff->mid;
     LEGAL_NEW_RESOURCE(mid, client);
     if( (pSrcMap = (ColormapPtr )SecurityLookupIDByType(client,	stuff->srcCmap,
-		RT_COLORMAP, SecurityReadAccess|SecurityWriteAccess)) )
+		RT_COLORMAP, DixReadAccess|DixWriteAccess)) )
     {
 	result = CopyColormapAndFree(mid, pSrcMap, client->index);
 	if (client->noClientException != Success)
@@ -2528,7 +2528,7 @@ ProcInstallColormap(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->id,
-					    RT_COLORMAP, SecurityReadAccess);
+					    RT_COLORMAP, DixReadAccess);
     if (pcmp)
     {
         (*(pcmp->pScreen->InstallColormap)) (pcmp);
@@ -2549,7 +2549,7 @@ ProcUninstallColormap(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->id,
-					RT_COLORMAP, SecurityReadAccess);
+					RT_COLORMAP, DixReadAccess);
     if (pcmp)
     {
 	if(pcmp->mid != pcmp->pScreen->defColormap)
@@ -2573,7 +2573,7 @@ ProcListInstalledColormaps(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
 
     if (!pWin)
         return(BadWindow);
@@ -2608,7 +2608,7 @@ ProcAllocColor (register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xAllocColorReq);
     pmap = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pmap)
     {
 	acr.type = X_Reply;
@@ -2648,7 +2648,7 @@ ProcAllocNamedColor (register ClientPtr client)
 
     REQUEST_FIXED_SIZE(xAllocNamedColorReq, stuff->nbytes);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					    RT_COLORMAP, SecurityWriteAccess);
+					    RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	int		retval;
@@ -2700,7 +2700,7 @@ ProcAllocColorCells (register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xAllocColorCellsReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	xAllocColorCellsReply	accr;
@@ -2766,7 +2766,7 @@ ProcAllocColorPlanes(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xAllocColorPlanesReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	xAllocColorPlanesReply	acpr;
@@ -2830,7 +2830,7 @@ ProcFreeColors(register ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xFreeColorsReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	int	count;
@@ -2865,7 +2865,7 @@ ProcStoreColors (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xStoreColorsReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	int	count;
@@ -2899,7 +2899,7 @@ ProcStoreNamedColor (register ClientPtr client)
 
     REQUEST_FIXED_SIZE(xStoreNamedColorReq, stuff->nbytes);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityWriteAccess);
+					RT_COLORMAP, DixWriteAccess);
     if (pcmp)
     {
 	xColorItem	def;
@@ -2933,7 +2933,7 @@ ProcQueryColors(register ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xQueryColorsReq);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityReadAccess);
+					RT_COLORMAP, DixReadAccess);
     if (pcmp)
     {
 	int			count, retval;
@@ -2987,7 +2987,7 @@ ProcLookupColor(register ClientPtr client)
 
     REQUEST_FIXED_SIZE(xLookupColorReq, stuff->nbytes);
     pcmp = (ColormapPtr)SecurityLookupIDByType(client, stuff->cmap,
-					RT_COLORMAP, SecurityReadAccess);
+					RT_COLORMAP, DixReadAccess);
     if (pcmp)
     {
 	xLookupColorReply lcr;
@@ -3037,9 +3037,9 @@ ProcCreateCursor (register ClientPtr client)
     LEGAL_NEW_RESOURCE(stuff->cid, client);
 
     src = (PixmapPtr)SecurityLookupIDByType(client, stuff->source,
-					      RT_PIXMAP, SecurityReadAccess);
+					      RT_PIXMAP, DixReadAccess);
     msk = (PixmapPtr)SecurityLookupIDByType(client, stuff->mask,
-					      RT_PIXMAP, SecurityReadAccess);
+					      RT_PIXMAP, DixReadAccess);
     if (   src == (PixmapPtr)NULL)
     {
 	client->errorValue = stuff->source;
@@ -3139,7 +3139,7 @@ ProcFreeCursor (register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pCursor = (CursorPtr)SecurityLookupIDByType(client, stuff->id,
-					RT_CURSOR, SecurityDestroyAccess);
+					RT_CURSOR, DixDestroyAccess);
     if (pCursor) 
     {
 	FreeResource(stuff->id, RT_NONE);
@@ -3169,7 +3169,7 @@ ProcQueryBestSize (register ClientPtr client)
         return(BadValue);
     }
     SECURITY_VERIFY_GEOMETRABLE (pDraw, stuff->drawable, client,
-				 SecurityReadAccess);
+				 DixReadAccess);
     if (stuff->class != CursorShape && pDraw->type == UNDRAWABLE_WINDOW)
 	return (BadMatch);
     pScreen = pDraw->pScreen;

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -1197,7 +1197,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
     if (c->slept &&
 	c->pDraw &&
 	c->pDraw != (DrawablePtr)SecurityLookupIDByClass(client, c->did,
-					RC_DRAWABLE, SecurityWriteAccess))
+					RC_DRAWABLE, DixWriteAccess))
     {
 	/* Our drawable has disappeared.  Treat like client died... ask
 	   the FPE code to clean up after client and avoid further
@@ -1227,7 +1227,7 @@ doPolyText(ClientPtr client, register PTclosurePtr c)
 		 | ((Font)*(c->pElt+2)) << 16
 		 | ((Font)*(c->pElt+1)) << 24;
 	    pFont = (FontPtr)SecurityLookupIDByType(client, fid, RT_FONT,
-						    SecurityReadAccess);
+						    DixReadAccess);
 	    if (!pFont)
 	    {
 		client->errorValue = fid;
@@ -1489,7 +1489,7 @@ doImageText(ClientPtr client, register ITclosurePtr c)
     if (c->slept &&
 	c->pDraw &&
 	c->pDraw != (DrawablePtr)SecurityLookupIDByClass(client, c->did,
-					RC_DRAWABLE, SecurityWriteAccess))
+					RC_DRAWABLE, DixWriteAccess))
     {
 	/* Our drawable has disappeared.  Treat like client died... ask
 	   the FPE code to clean up after client. */
@@ -2044,7 +2044,7 @@ FontPtr
 find_old_font(XID id)
 {
     return (FontPtr) SecurityLookupIDByType(NullClient, id, RT_NONE,
-					    SecurityUnknownAccess);
+					    DixUnknownAccess);
 }
 
 Font

--- a/nx-X11/programs/Xserver/dix/dixutils.c
+++ b/nx-X11/programs/Xserver/dix/dixutils.c
@@ -260,13 +260,13 @@ SecurityLookupDrawable(XID rid, ClientPtr client, Mask access_mode)
 WindowPtr
 LookupWindow(XID rid, ClientPtr client)
 {
-    return SecurityLookupWindow(rid, client, SecurityUnknownAccess);
+    return SecurityLookupWindow(rid, client, DixUnknownAccess);
 }
 
 void *
 LookupDrawable(XID rid, ClientPtr client)
 {
-    return SecurityLookupDrawable(rid, client, SecurityUnknownAccess);
+    return SecurityLookupDrawable(rid, client, DixUnknownAccess);
 }
 
 #else /* not XCSECURITY */
@@ -317,7 +317,7 @@ ClientPtr
 LookupClient(XID rid, ClientPtr client)
 {
     void * pRes = (void *)SecurityLookupIDByClass(client, rid, RC_ANY,
-						    SecurityReadAccess);
+						    DixReadAccess);
     int clientIndex = CLIENT_ID(rid);
 
     if (clientIndex && pRes && clients[clientIndex] && !(rid & SERVER_BIT))

--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -2201,7 +2201,7 @@ XineramaWarpPointer(ClientPtr client)
 
     if (stuff->dstWid != None)
     {
-	dest = SecurityLookupWindow(stuff->dstWid, client, SecurityReadAccess);
+	dest = SecurityLookupWindow(stuff->dstWid, client, DixReadAccess);
 	if (!dest)
 	    return BadWindow;
     }
@@ -2214,7 +2214,7 @@ XineramaWarpPointer(ClientPtr client)
  	XID 	winID = stuff->srcWid;
         WindowPtr source;
 	
-	source = SecurityLookupWindow(winID, client, SecurityReadAccess);
+	source = SecurityLookupWindow(winID, client, DixReadAccess);
 	if (!source) return BadWindow;
 
 	winX = source->drawable.x;
@@ -2281,7 +2281,7 @@ ProcWarpPointer(ClientPtr client)
 
     if (stuff->dstWid != None)
     {
-	dest = SecurityLookupWindow(stuff->dstWid, client, SecurityReadAccess);
+	dest = SecurityLookupWindow(stuff->dstWid, client, DixReadAccess);
 	if (!dest)
 	    return BadWindow;
     }
@@ -2294,7 +2294,7 @@ ProcWarpPointer(ClientPtr client)
  	XID 	winID = stuff->srcWid;
         WindowPtr source;
 	
-	source = SecurityLookupWindow(winID, client, SecurityReadAccess);
+	source = SecurityLookupWindow(winID, client, DixReadAccess);
 	if (!source) return BadWindow;
 
 	winX = source->drawable.x;
@@ -3469,7 +3469,7 @@ SetInputFocus(
     else if ((focusID == FollowKeyboard) && followOK)
 	focusWin = inputInfo.keyboard->focus->win;
     else if (!(focusWin = SecurityLookupWindow(focusID, client,
-					       SecurityReadAccess)))
+					       DixReadAccess)))
 	return BadWindow;
     else
     {
@@ -3590,7 +3590,7 @@ ProcGrabPointer(ClientPtr client)
 	client->errorValue = stuff->eventMask;
         return BadValue;
     }
-    pWin = SecurityLookupWindow(stuff->grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
     if (stuff->confineTo == None)
@@ -3598,7 +3598,7 @@ ProcGrabPointer(ClientPtr client)
     else 
     {
 	confineTo = SecurityLookupWindow(stuff->confineTo, client,
-					 SecurityReadAccess);
+					 DixReadAccess);
 	if (!confineTo)
 	    return BadWindow;
     }
@@ -3607,7 +3607,7 @@ ProcGrabPointer(ClientPtr client)
     else
     {
 	cursor = (CursorPtr)SecurityLookupIDByType(client, stuff->cursor,
-						RT_CURSOR, SecurityReadAccess);
+						RT_CURSOR, DixReadAccess);
 	if (!cursor)
 	{
 	    client->errorValue = stuff->cursor;
@@ -3682,7 +3682,7 @@ ProcChangeActivePointerGrab(ClientPtr client)
     else
     {
 	newCursor = (CursorPtr)SecurityLookupIDByType(client, stuff->cursor,
-						RT_CURSOR, SecurityReadAccess);
+						RT_CURSOR, DixReadAccess);
 	if (!newCursor)
 	{
 	    client->errorValue = stuff->cursor;
@@ -3752,7 +3752,7 @@ GrabDevice(register ClientPtr client, register DeviceIntPtr dev,
 	client->errorValue = ownerEvents;
         return BadValue;
     }
-    pWin = SecurityLookupWindow(grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
     time = ClientTimeToServerTime(ctime);
@@ -3842,7 +3842,7 @@ ProcQueryPointer(ClientPtr client)
     DeviceIntPtr mouse = inputInfo.pointer;
 
     REQUEST_SIZE_MATCH(xResourceReq);
-    pWin = SecurityLookupWindow(stuff->id, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->id, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
     if (mouse->valuator->motionHintWindow)
@@ -4009,7 +4009,7 @@ ProcSendEvent(ClientPtr client)
     }
     else
 	pWin = SecurityLookupWindow(stuff->destination, client,
-				    SecurityReadAccess);
+				    DixReadAccess);
     if (!pWin)
 	return BadWindow;
     if ((stuff->propagate != xFalse) && (stuff->propagate != xTrue))
@@ -4048,7 +4048,7 @@ ProcUngrabKey(ClientPtr client)
     DeviceIntPtr keybd = inputInfo.keyboard;
 
     REQUEST_SIZE_MATCH(xUngrabKeyReq);
-    pWin = SecurityLookupWindow(stuff->grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
 
@@ -4119,7 +4119,7 @@ ProcGrabKey(ClientPtr client)
 	client->errorValue = stuff->modifiers;
 	return BadValue;
     }
-    pWin = SecurityLookupWindow(stuff->grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
 
@@ -4171,14 +4171,14 @@ ProcGrabButton(ClientPtr client)
 	client->errorValue = stuff->eventMask;
         return BadValue;
     }
-    pWin = SecurityLookupWindow(stuff->grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
     if (stuff->confineTo == None)
        confineTo = NullWindow;
     else {
 	confineTo = SecurityLookupWindow(stuff->confineTo, client,
-					 SecurityReadAccess);
+					 DixReadAccess);
 	if (!confineTo)
 	    return BadWindow;
     }
@@ -4187,7 +4187,7 @@ ProcGrabButton(ClientPtr client)
     else
     {
 	cursor = (CursorPtr)SecurityLookupIDByType(client, stuff->cursor,
-						RT_CURSOR, SecurityReadAccess);
+						RT_CURSOR, DixReadAccess);
 	if (!cursor)
 	{
 	    client->errorValue = stuff->cursor;
@@ -4222,7 +4222,7 @@ ProcUngrabButton(ClientPtr client)
 	client->errorValue = stuff->modifiers;
 	return BadValue;
     }
-    pWin = SecurityLookupWindow(stuff->grabWindow, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->grabWindow, client, DixReadAccess);
     if (!pWin)
 	return BadWindow;
     tempGrab.resource = client->clientAsMask;
@@ -4376,7 +4376,7 @@ ProcRecolorCursor(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xRecolorCursorReq);
     pCursor = (CursorPtr)SecurityLookupIDByType(client, stuff->cursor,
-					RT_CURSOR, SecurityWriteAccess);
+					RT_CURSOR, DixWriteAccess);
     if ( !pCursor) 
     {
 	client->errorValue = stuff->cursor;

--- a/nx-X11/programs/Xserver/dix/gc.c
+++ b/nx-X11/programs/Xserver/dix/gc.c
@@ -271,7 +271,7 @@ dixChangeGC(ClientPtr client, register GC *pGC, register BITS32 mask, CARD32 *pC
 		{
 		    NEXTVAL(XID, newpix);
 		    pPixmap = (PixmapPtr)SecurityLookupIDByType(client,
-					newpix, RT_PIXMAP, SecurityReadAccess);
+					newpix, RT_PIXMAP, DixReadAccess);
 		}
 		if (pPixmap)
 		{
@@ -307,7 +307,7 @@ dixChangeGC(ClientPtr client, register GC *pGC, register BITS32 mask, CARD32 *pC
 		{
 		    NEXTVAL(XID, newstipple)
 		    pPixmap = (PixmapPtr)SecurityLookupIDByType(client,
-				newstipple, RT_PIXMAP, SecurityReadAccess);
+				newstipple, RT_PIXMAP, DixReadAccess);
 		}
 		if (pPixmap)
 		{
@@ -349,7 +349,7 @@ dixChangeGC(ClientPtr client, register GC *pGC, register BITS32 mask, CARD32 *pC
 		{
 		    NEXTVAL(XID, newfont)
 		    pFont = (FontPtr)SecurityLookupIDByType(client, newfont,
-						RT_FONT, SecurityReadAccess);
+						RT_FONT, DixReadAccess);
 		}
 		if (pFont)
 		{
@@ -416,7 +416,7 @@ dixChangeGC(ClientPtr client, register GC *pGC, register BITS32 mask, CARD32 *pC
 		    }
 		    else
 		        pPixmap = (PixmapPtr)SecurityLookupIDByType(client,
-					pid, RT_PIXMAP, SecurityReadAccess);
+					pid, RT_PIXMAP, DixReadAccess);
 		}
 
 		if (pPixmap)

--- a/nx-X11/programs/Xserver/dix/property.c
+++ b/nx-X11/programs/Xserver/dix/property.c
@@ -106,7 +106,7 @@ ProcRotateProperties(ClientPtr client)
     REQUEST_FIXED_SIZE(xRotatePropertiesReq, stuff->nAtoms << 2);
     UpdateCurrentTime();
     pWin = (WindowPtr) SecurityLookupWindow(stuff->window, client,
-					    SecurityWriteAccess);
+					    DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     if (!stuff->nAtoms)
@@ -119,7 +119,7 @@ ProcRotateProperties(ClientPtr client)
     {
 #ifdef XCSECURITY
 	char action = SecurityCheckPropertyAccess(client, pWin, atoms[i],
-				SecurityReadAccess|SecurityWriteAccess);
+				DixReadAccess|DixWriteAccess);
 #endif
         if (!ValidAtom(atoms[i])
 #ifdef XCSECURITY
@@ -219,7 +219,7 @@ ProcChangeProperty(ClientPtr client)
     REQUEST_FIXED_SIZE(xChangePropertyReq, totalSize);
 
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
 	return(BadWindow);
     if (!ValidAtom(stuff->property))
@@ -235,7 +235,7 @@ ProcChangeProperty(ClientPtr client)
 
 #ifdef XCSECURITY
     switch (SecurityCheckPropertyAccess(client, pWin, stuff->property,
-					SecurityWriteAccess))
+					DixWriteAccess))
     {
 	case SecurityErrorOperation:
 	    client->errorValue = stuff->property;
@@ -469,7 +469,7 @@ ProcGetProperty(ClientPtr client)
     if (stuff->delete)
 	UpdateCurrentTime();
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
 	return BadWindow;
 
@@ -507,10 +507,10 @@ ProcGetProperty(ClientPtr client)
 
 #ifdef XCSECURITY
     {
-	Mask access_mode = SecurityReadAccess;
+	Mask access_mode = DixReadAccess;
 
 	if (stuff->delete)
-	    access_mode |= SecurityDestroyAccess;
+	    access_mode |= DixDestroyAccess;
 	switch(SecurityCheckPropertyAccess(client, pWin, stuff->property,
 					   access_mode))
 	{
@@ -614,7 +614,7 @@ ProcListProperties(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
 
@@ -659,7 +659,7 @@ ProcDeleteProperty(register ClientPtr client)
     REQUEST_SIZE_MATCH(xDeletePropertyReq);
     UpdateCurrentTime();
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
     if (!ValidAtom(stuff->property))
@@ -670,7 +670,7 @@ ProcDeleteProperty(register ClientPtr client)
 
 #ifdef XCSECURITY
     switch(SecurityCheckPropertyAccess(client, pWin, stuff->property,
-				       SecurityDestroyAccess))
+				       DixDestroyAccess))
     {
 	case SecurityErrorOperation:
 	    client->errorValue = stuff->property;

--- a/nx-X11/programs/Xserver/dix/resource.c
+++ b/nx-X11/programs/Xserver/dix/resource.c
@@ -878,14 +878,14 @@ void *
 LookupIDByType(XID id, RESTYPE rtype)
 {
     return SecurityLookupIDByType(NullClient, id, rtype,
-				  SecurityUnknownAccess);
+				  DixUnknownAccess);
 }
 
 void *
 LookupIDByClass(XID id, RESTYPE classes)
 {
     return SecurityLookupIDByClass(NullClient, id, classes,
-				   SecurityUnknownAccess);
+				   DixUnknownAccess);
 }
 
 #else /* not XCSECURITY */

--- a/nx-X11/programs/Xserver/dix/window.c
+++ b/nx-X11/programs/Xserver/dix/window.c
@@ -1028,7 +1028,7 @@ ChangeWindowAttributes(register WindowPtr pWin, Mask vmask, XID *vlist, ClientPt
 	    else
 	    {	
 		pPixmap = (PixmapPtr)SecurityLookupIDByType(client, pixID,
-						RT_PIXMAP, SecurityReadAccess);
+						RT_PIXMAP, DixReadAccess);
 		if (pPixmap != (PixmapPtr) NULL)
 		{
 		    if	((pPixmap->drawable.depth != pWin->drawable.depth) ||
@@ -1089,7 +1089,7 @@ ChangeWindowAttributes(register WindowPtr pWin, Mask vmask, XID *vlist, ClientPt
 	    else
 	    {	
 		pPixmap = (PixmapPtr)SecurityLookupIDByType(client, pixID,
-					RT_PIXMAP, SecurityReadAccess);
+					RT_PIXMAP, DixReadAccess);
 		if (pPixmap)
 		{
 		    if	((pPixmap->drawable.depth != pWin->drawable.depth) ||
@@ -1302,7 +1302,7 @@ ChangeWindowAttributes(register WindowPtr pWin, Mask vmask, XID *vlist, ClientPt
 		goto PatchUp;
 	    }
 	    pCmap = (ColormapPtr)SecurityLookupIDByType(client, cmap,
-					      RT_COLORMAP, SecurityReadAccess);
+					      RT_COLORMAP, DixReadAccess);
 	    if (!pCmap)
 	    {
 		error = BadColor;
@@ -1378,7 +1378,7 @@ ChangeWindowAttributes(register WindowPtr pWin, Mask vmask, XID *vlist, ClientPt
 	    else
 	    {
 		pCursor = (CursorPtr)SecurityLookupIDByType(client, cursorID,
-						RT_CURSOR, SecurityReadAccess);
+						RT_CURSOR, DixReadAccess);
 		if (!pCursor)
 		{
 		    error = BadCursor;
@@ -2252,7 +2252,7 @@ ConfigureWindow(register WindowPtr pWin, register Mask mask, XID *vlist, ClientP
 	    sibwid = (Window ) *pVlist;
 	    pVlist++;
 	    pSib = (WindowPtr )SecurityLookupIDByType(client, sibwid,
-						RT_WINDOW, SecurityReadAccess);
+						RT_WINDOW, DixReadAccess);
 	    if (!pSib)
 	    {
 		client->errorValue = sibwid;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -586,7 +586,7 @@ ProcReparentWindow(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xReparentWindowReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
         return(BadWindow);
 
@@ -596,7 +596,7 @@ ProcReparentWindow(register ClientPtr client)
     }
 
     pParent = (WindowPtr)SecurityLookupWindow(stuff->parent, client,
-					      SecurityWriteAccess);
+					      DixWriteAccess);
     if (!pParent)
         return(BadWindow);
     if (SAME_SCREENS(pWin->drawable, pParent->drawable))
@@ -630,7 +630,7 @@ ProcQueryTree(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->id, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     memset(&reply, 0, sizeof(xQueryTreeReply));
@@ -698,7 +698,7 @@ ProcSetSelectionOwner(register ClientPtr client)
     if (stuff->window != None)
     {
         pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					       SecurityReadAccess);
+					       DixReadAccess);
         if (!pWin)
             return(BadWindow);
     }
@@ -797,7 +797,7 @@ ProcConvertSelection(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xConvertSelectionReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->requestor, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
 
@@ -837,7 +837,7 @@ ProcConvertSelection(register ClientPtr client)
 #ifdef XCSECURITY
 	    && (!client->CheckAccess ||
 		(* client->CheckAccess)(client, CurrentSelections[i].window,
-					RT_WINDOW, SecurityReadAccess,
+					RT_WINDOW, DixReadAccess,
 					CurrentSelections[i].pWin))
 #endif
 	    )
@@ -918,7 +918,7 @@ ProcCloseFont(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pFont = (FontPtr)SecurityLookupIDByType(client, stuff->id, RT_FONT,
-					    SecurityDestroyAccess);
+					    DixDestroyAccess);
     if (pFont != (FontPtr)NULL)
     {
         #ifdef NXAGENT_SERVER
@@ -1015,7 +1015,7 @@ ProcFreePixmap(register ClientPtr client)
 
     REQUEST_SIZE_MATCH(xResourceReq);
     pMap = (PixmapPtr)SecurityLookupIDByType(client, stuff->id, RT_PIXMAP,
-					     SecurityDestroyAccess);
+					     DixDestroyAccess);
     if (pMap) 
     {
         #ifdef NXAGENT_SERVER

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -583,7 +583,7 @@ ProcSendEvent(ClientPtr client)
     }
     else
 	pWin = SecurityLookupWindow(stuff->destination, client,
-				    SecurityReadAccess);
+				    DixReadAccess);
     if (!pWin)
 	return BadWindow;
     if ((stuff->propagate != xFalse) && (stuff->propagate != xTrue))

--- a/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
@@ -131,7 +131,7 @@ ProcChangeProperty(ClientPtr client)
     if (pWin == NULL)
 #endif
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityWriteAccess);
+					   DixWriteAccess);
     if (!pWin)
 	return(BadWindow);
     if (!ValidAtom(stuff->property))
@@ -147,7 +147,7 @@ ProcChangeProperty(ClientPtr client)
 
 #ifdef XCSECURITY
     switch (SecurityCheckPropertyAccess(client, pWin, stuff->property,
-					SecurityWriteAccess))
+					DixWriteAccess))
     {
 	case SecurityErrorOperation:
 	    client->errorValue = stuff->property;
@@ -348,7 +348,7 @@ ProcGetProperty(ClientPtr client)
     if (stuff->delete)
 	UpdateCurrentTime();
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
 	return BadWindow;
 
@@ -439,10 +439,10 @@ ProcGetProperty(ClientPtr client)
 
 #ifdef XCSECURITY
     {
-	Mask access_mode = SecurityReadAccess;
+	Mask access_mode = DixReadAccess;
 
 	if (stuff->delete)
-	    access_mode |= SecurityDestroyAccess;
+	    access_mode |= DixDestroyAccess;
 	switch(SecurityCheckPropertyAccess(client, pWin, stuff->property,
 					   access_mode))
 	{

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -385,11 +385,11 @@ ProcRenderCreatePicture (ClientPtr client)
 
     LEGAL_NEW_RESOURCE(stuff->pid, client);
     SECURITY_VERIFY_DRAWABLE(pDrawable, stuff->drawable, client,
-			     SecurityWriteAccess);
+			     DixWriteAccess);
     pFormat = (PictFormatPtr) SecurityLookupIDByType (client, 
 						      stuff->format,
 						      PictFormatType,
-						      SecurityReadAccess);
+						      DixReadAccess);
     if (!pFormat)
     {
 	client->errorValue = stuff->format;
@@ -426,7 +426,7 @@ ProcRenderChangePicture (ClientPtr client)
     int error;
 
     REQUEST_AT_LEAST_SIZE(xRenderChangePictureReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
 
     len = client->req_len - (sizeof(xRenderChangePictureReq) >> 2);
@@ -450,7 +450,7 @@ ProcRenderSetPictureClipRectangles (ClientPtr client)
     int		    result;
 
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureClipRectanglesReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pPicture->pDrawable)
         return BadDrawable;
@@ -558,13 +558,13 @@ ProcRenderComposite (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_ALPHA (pMask, stuff->mask, client, SecurityReadAccess, 
+    VERIFY_ALPHA (pMask, stuff->mask, client, DixReadAccess,
 		  RenderErrBase + BadPicture);
 
     if ((pSrc->pDrawable && pSrc->pDrawable->pScreen != pDst->pDrawable->pScreen) ||
@@ -687,9 +687,9 @@ ProcRenderTrapezoids (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -700,7 +700,7 @@ ProcRenderTrapezoids (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -758,7 +758,7 @@ ProcRenderCreateGlyphSet (ClientPtr client)
     format = (PictFormatPtr) SecurityLookupIDByType (client,
 						     stuff->format,
 						     PictFormatType,
-						     SecurityReadAccess);
+						     DixReadAccess);
     if (!format)
     {
 	client->errorValue = stuff->format;
@@ -809,7 +809,7 @@ ProcRenderReferenceGlyphSet (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->existing,
 						     GlyphSetType,
-						     SecurityWriteAccess);
+						     DixWriteAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->existing;
@@ -834,7 +834,7 @@ ProcRenderFreeGlyphSet (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityDestroyAccess);
+						     DixDestroyAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -860,7 +860,7 @@ ProcRenderFreeGlyphs (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityWriteAccess);
+						     DixWriteAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -928,9 +928,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess,
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -941,7 +941,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -954,7 +954,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityReadAccess);
+						     DixReadAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -1027,7 +1027,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 		glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 								 gs,
 								 GlyphSetType,
-								 SecurityReadAccess);
+								 DixReadAccess);
 		if (!glyphSet)
 		{
 		    client->errorValue = gs;
@@ -1163,7 +1163,7 @@ ProcRenderFillRectangles (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -1212,7 +1212,7 @@ ProcRenderCreateCursor (ClientPtr client)
     REQUEST_SIZE_MATCH (xRenderCreateCursorReq);
     LEGAL_NEW_RESOURCE(stuff->cid, client);
     
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
     if (!pSrc->pDrawable)
         return BadDrawable;
@@ -1430,7 +1430,7 @@ ProcRenderSetPictureTransform (ClientPtr client)
     int		result;
 
     REQUEST_SIZE_MATCH(xRenderSetPictureTransformReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     result = SetPictureTransform (pPicture, (PictTransform *) &stuff->transform);
 
@@ -1453,7 +1453,7 @@ ProcRenderSetPictureFilter (ClientPtr client)
     char	*name;
     
     REQUEST_AT_LEAST_SIZE (xRenderSetPictureFilterReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     name = (char *) (stuff + 1);
     params = (xFixed *) (name + ((stuff->nbytes + 3) & ~3));
@@ -1490,7 +1490,7 @@ ProcRenderCreateAnimCursor (ClientPtr client)
     for (i = 0; i < ncursor; i++)
     {
 	cursors[i] = (CursorPtr)SecurityLookupIDByType(client, elt->cursor,
-						       RT_CURSOR, SecurityReadAccess);
+						       RT_CURSOR, DixReadAccess);
 	if (!cursors[i])
 	{
 	    free (cursors);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
@@ -503,7 +503,7 @@ ConfigureWindow(register WindowPtr pWin, register Mask mask, XID *vlist, ClientP
 	    sibwid = (Window ) *pVlist;
 	    pVlist++;
 	    pSib = (WindowPtr )SecurityLookupIDByType(client, sibwid,
-						RT_WINDOW, SecurityReadAccess);
+						RT_WINDOW, DixReadAccess);
 	    if (!pSib)
 	    {
 		client->errorValue = sibwid;

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -540,7 +540,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     if ((wmHints.flags & IconPixmapHint) && (wmHints.icon_pixmap != None))
     {
       PixmapPtr icon = (PixmapPtr)SecurityLookupIDByType(pClient, wmHints.icon_pixmap,
-                                                             RT_PIXMAP, SecurityDestroyAccess);
+                                                             RT_PIXMAP, DixDestroyAccess);
 
       if (icon)
       {
@@ -567,7 +567,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     if ((wmHints.flags & IconWindowHint) && (wmHints.icon_window != None))
     {
       WindowPtr icon = (WindowPtr)SecurityLookupWindow(wmHints.icon_window, pClient,
-                                                  SecurityDestroyAccess);
+                                                  DixDestroyAccess);
 
       if (icon)
       {
@@ -589,7 +589,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     if ((wmHints.flags & IconMaskHint) && (wmHints.icon_mask != None))
     {
       PixmapPtr icon = (PixmapPtr)SecurityLookupIDByType(pClient, wmHints.icon_mask,
-                                                             RT_PIXMAP, SecurityDestroyAccess);
+                                                             RT_PIXMAP, DixDestroyAccess);
 
       if (icon)
       {
@@ -611,7 +611,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     if ((wmHints.flags & WindowGroupHint) && (wmHints.window_group != None))
     {
       WindowPtr window = (WindowPtr)SecurityLookupWindow(wmHints.window_group, pClient,
-                                                  SecurityDestroyAccess);
+                                                  DixDestroyAccess);
 
       if (window)
       {
@@ -695,7 +695,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     for (i = 0; i < nUnits; i++)
     {
       pWindow = (WindowPtr)SecurityLookupWindow(input[i], pClient,
-                                                    SecurityDestroyAccess);
+                                                    DixDestroyAccess);
       if ((input[i] != None) && pWindow)
       {
         wind[i] = nxagentWindow(pWindow);

--- a/nx-X11/programs/Xserver/include/dix.h
+++ b/nx-X11/programs/Xserver/include/dix.h
@@ -138,13 +138,13 @@ SOFTWARE.
     }
 
 #define VERIFY_DRAWABLE(pDraw, did, client)\
-	SECURITY_VERIFY_DRAWABLE(pDraw, did, client, SecurityUnknownAccess)
+	SECURITY_VERIFY_DRAWABLE(pDraw, did, client, DixUnknownAccess)
 
 #define VERIFY_GEOMETRABLE(pDraw, did, client)\
-	SECURITY_VERIFY_GEOMETRABLE(pDraw, did, client, SecurityUnknownAccess)
+	SECURITY_VERIFY_GEOMETRABLE(pDraw, did, client, DixUnknownAccess)
 
 #define VERIFY_GC(pGC, rid, client)\
-	SECURITY_VERIFY_GC(pGC, rid, client, SecurityUnknownAccess)
+	SECURITY_VERIFY_GC(pGC, rid, client, DixUnknownAccess)
 
 #else /* not XCSECURITY */
 
@@ -255,8 +255,8 @@ SOFTWARE.
     if ((stuff->gc == INVALID) || (client->lastGCID != stuff->gc) ||\
 	(client->lastDrawableID != drawID))\
     {\
-	SECURITY_VERIFY_GEOMETRABLE(pDraw, drawID, client, SecurityWriteAccess);\
-	SECURITY_VERIFY_GC(pGC, stuff->gc, client, SecurityReadAccess);\
+	SECURITY_VERIFY_GEOMETRABLE(pDraw, drawID, client, DixWriteAccess);\
+	SECURITY_VERIFY_GC(pGC, stuff->gc, client, DixReadAccess);\
 	if ((pGC->depth != pDraw->depth) ||\
 	    (pGC->pScreen != pDraw->pScreen))\
 	    return (BadMatch);\

--- a/nx-X11/programs/Xserver/include/resource.h
+++ b/nx-X11/programs/Xserver/include/resource.h
@@ -220,10 +220,10 @@ extern void * LookupClientResourceComplex(
  * simultaneously.
  */
 
-#define SecurityUnknownAccess	0	/* don't know intentions */
-#define SecurityReadAccess	(1<<0)	/* inspecting the object */
-#define SecurityWriteAccess	(1<<1)	/* changing the object */
-#define SecurityDestroyAccess	(1<<2)	/* destroying the object */
+#define DixUnknownAccess	0	/* don't know intentions */
+#define DixReadAccess	(1<<0)	/* inspecting the object */
+#define DixWriteAccess	(1<<1)	/* changing the object */
+#define DixDestroyAccess	(1<<2)	/* destroying the object */
 
 #ifdef XCSECURITY
 

--- a/nx-X11/programs/Xserver/randr/randrstr.h
+++ b/nx-X11/programs/Xserver/randr/randrstr.h
@@ -443,12 +443,8 @@ extern _X_EXPORT RESTYPE RRCrtcType, RRModeType, RROutputType, RRProviderType;
                                 (SecurityLookupIDByType (client, id, \
                                                          RRProviderType, a)))
 
-#define DixUnknownAccess     SecurityUnknownAccess
-#define DixReadAccess        SecurityReadAccess
-#define DixWriteAccess       SecurityWriteAccess
-#define DixSetAttrAccess     SecurityWriteAccess
-#define DixUseAccess         SecurityWriteAccess
-#define DixDestroyAccess     SecurityDestroyAccess
+#define DixSetAttrAccess     DixWriteAccess
+#define DixUseAccess         DixWriteAccess
 
 #endif
 

--- a/nx-X11/programs/Xserver/randr/rrdispatch.c
+++ b/nx-X11/programs/Xserver/randr/rrdispatch.c
@@ -87,7 +87,7 @@ ProcRRSelectInput(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityWriteAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixWriteAccess);
     rc = pWin ? Success : BadWindow;
 #endif
     if (rc != Success)

--- a/nx-X11/programs/Xserver/randr/rrmode.c
+++ b/nx-X11/programs/Xserver/randr/rrmode.c
@@ -357,7 +357,7 @@ ProcRRCreateMode(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
     if (rc != Success)

--- a/nx-X11/programs/Xserver/randr/rrmonitor.c
+++ b/nx-X11/programs/Xserver/randr/rrmonitor.c
@@ -636,7 +636,7 @@ ProcRRGetMonitors(ClientPtr client)
 #ifndef NXAGENT_SERVER
     r = dixLookupWindow(&window, stuff->window, client, DixGetAttrAccess);
 #else
-    window = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    window = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     r = window ? Success : BadWindow;
 #endif
 
@@ -723,7 +723,7 @@ ProcRRSetMonitor(ClientPtr client)
 #ifndef NXAGENT_SERVER
     r = dixLookupWindow(&window, stuff->window, client, DixGetAttrAccess);
 #else
-    window = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    window = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     r = window ? Success : BadWindow;
 #endif
 
@@ -772,7 +772,7 @@ ProcRRDeleteMonitor(ClientPtr client)
 #ifndef NXAGENT_SERVER
     r = dixLookupWindow(&window, stuff->window, client, DixGetAttrAccess);
 #else
-    window = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    window = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     r = window ? Success : BadWindow;
 #endif
 

--- a/nx-X11/programs/Xserver/randr/rroutput.c
+++ b/nx-X11/programs/Xserver/randr/rroutput.c
@@ -583,7 +583,7 @@ ProcRRSetOutputPrimary(ClientPtr client)
 #ifndef NXAGENT_SERVER
     ret = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     ret = pWin ? Success : BadWindow;
 #endif
 
@@ -641,7 +641,7 @@ ProcRRGetOutputPrimary(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 

--- a/nx-X11/programs/Xserver/randr/rrprovider.c
+++ b/nx-X11/programs/Xserver/randr/rrprovider.c
@@ -69,7 +69,7 @@ ProcRRGetProviders(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 

--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -222,7 +222,7 @@ ProcRRGetScreenSizeRange(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 
@@ -276,7 +276,7 @@ ProcRRSetScreenSize(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
     if (rc != Success)
@@ -532,7 +532,7 @@ rrGetScreenResources(ClientPtr client, Bool query)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
     if (rc != Success)
@@ -806,7 +806,7 @@ ProcRRGetScreenInfo(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 
@@ -980,7 +980,7 @@ ProcRRSetScreenConfig(ClientPtr client)
     rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixWriteAccess);
 #else                           /* !defined(NXAGENT_SERVER) */
     pDraw =
-        SecurityLookupDrawable(stuff->drawable, client, SecurityWriteAccess);
+        SecurityLookupDrawable(stuff->drawable, client, DixWriteAccess);
     rc = pDraw ? Success : BadDrawable;
 #endif                          /* !defined(NXAGENT_SERVER) */
 

--- a/nx-X11/programs/Xserver/randr/rrxinerama.c
+++ b/nx-X11/programs/Xserver/randr/rrxinerama.c
@@ -150,7 +150,7 @@ ProcRRXineramaGetState(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 
@@ -205,7 +205,7 @@ ProcRRXineramaGetScreenCount(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
     if (rc != Success)
@@ -240,7 +240,7 @@ ProcRRXineramaGetScreenSize(ClientPtr client)
 #ifndef NXAGENT_SERVER
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
 #else
-    pWin = SecurityLookupWindow(stuff->window, client, SecurityReadAccess);
+    pWin = SecurityLookupWindow(stuff->window, client, DixReadAccess);
     rc = pWin ? Success : BadWindow;
 #endif
 

--- a/nx-X11/programs/Xserver/render/picture.c
+++ b/nx-X11/programs/Xserver/render/picture.c
@@ -1210,7 +1210,7 @@ ChangePicture (PicturePtr	pPicture,
 			pAlpha = (PicturePtr) SecurityLookupIDByType(client,
 								     pid, 
 								     PictureType, 
-								     SecurityWriteAccess|SecurityReadAccess);
+								     DixWriteAccess|DixReadAccess);
 			if (!pAlpha)
 			{
 			    client->errorValue = pid;
@@ -1271,7 +1271,7 @@ ChangePicture (PicturePtr	pPicture,
 			pPixmap = (PixmapPtr)SecurityLookupIDByType(client,
 								    pid, 
 								    RT_PIXMAP,
-								    SecurityReadAccess);
+								    DixReadAccess);
 			if (!pPixmap)
 			{
 			    client->errorValue = pid;

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -567,7 +567,7 @@ ProcRenderQueryPictIndexValues (ClientPtr client)
     pFormat = (PictFormatPtr) SecurityLookupIDByType (client, 
 						      stuff->format,
 						      PictFormatType,
-						      SecurityReadAccess);
+						      DixReadAccess);
 
     if (!pFormat)
     {
@@ -636,11 +636,11 @@ ProcRenderCreatePicture (ClientPtr client)
 
     LEGAL_NEW_RESOURCE(stuff->pid, client);
     SECURITY_VERIFY_DRAWABLE(pDrawable, stuff->drawable, client,
-			     SecurityWriteAccess);
+			     DixWriteAccess);
     pFormat = (PictFormatPtr) SecurityLookupIDByType (client, 
 						      stuff->format,
 						      PictFormatType,
-						      SecurityReadAccess);
+						      DixReadAccess);
     if (!pFormat)
     {
 	client->errorValue = stuff->format;
@@ -674,7 +674,7 @@ ProcRenderChangePicture (ClientPtr client)
     int len;
 
     REQUEST_AT_LEAST_SIZE(xRenderChangePictureReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
 
     len = client->req_len - (sizeof(xRenderChangePictureReq) >> 2);
@@ -694,7 +694,7 @@ ProcRenderSetPictureClipRectangles (ClientPtr client)
     int		    result;
 
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureClipRectanglesReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pPicture->pDrawable)
         return BadDrawable;
@@ -721,7 +721,7 @@ ProcRenderFreePicture (ClientPtr client)
 
     REQUEST_SIZE_MATCH(xRenderFreePictureReq);
 
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityDestroyAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixDestroyAccess,
 		    RenderErrBase + BadPicture);
     FreeResource (stuff->picture, RT_NONE);
     return(client->noClientException);
@@ -752,13 +752,13 @@ ProcRenderComposite (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_ALPHA (pMask, stuff->mask, client, SecurityReadAccess, 
+    VERIFY_ALPHA (pMask, stuff->mask, client, DixReadAccess,
 		  RenderErrBase + BadPicture);
     if ((pSrc->pDrawable && pSrc->pDrawable->pScreen != pDst->pDrawable->pScreen) ||
 	(pMask && pMask->pDrawable && pSrc->pDrawable->pScreen != pMask->pDrawable->pScreen))
@@ -800,9 +800,9 @@ ProcRenderTrapezoids (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -813,7 +813,7 @@ ProcRenderTrapezoids (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -848,9 +848,9 @@ ProcRenderTriangles (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -861,7 +861,7 @@ ProcRenderTriangles (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -895,9 +895,9 @@ ProcRenderTriStrip (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -908,7 +908,7 @@ ProcRenderTriStrip (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -942,9 +942,9 @@ ProcRenderTriFan (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -955,7 +955,7 @@ ProcRenderTriFan (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -1008,7 +1008,7 @@ ProcRenderCreateGlyphSet (ClientPtr client)
     format = (PictFormatPtr) SecurityLookupIDByType (client,
 						     stuff->format,
 						     PictFormatType,
-						     SecurityReadAccess);
+						     DixReadAccess);
     if (!format)
     {
 	client->errorValue = stuff->format;
@@ -1056,7 +1056,7 @@ ProcRenderReferenceGlyphSet (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->existing,
 						     GlyphSetType,
-						     SecurityWriteAccess);
+						     DixWriteAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->existing;
@@ -1083,7 +1083,7 @@ ProcRenderFreeGlyphSet (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityDestroyAccess);
+						     DixDestroyAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -1118,7 +1118,7 @@ ProcRenderAddGlyphs (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityWriteAccess);
+						     DixWriteAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -1223,7 +1223,7 @@ ProcRenderFreeGlyphs (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityWriteAccess);
+						     DixWriteAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -1278,9 +1278,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess,
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -1291,7 +1291,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	pFormat = (PictFormatPtr) SecurityLookupIDByType (client,
 							  stuff->maskFormat,
 							  PictFormatType,
-							  SecurityReadAccess);
+							  DixReadAccess);
 	if (!pFormat)
 	{
 	    client->errorValue = stuff->maskFormat;
@@ -1304,7 +1304,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
     glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 						     stuff->glyphset,
 						     GlyphSetType,
-						     SecurityReadAccess);
+						     DixReadAccess);
     if (!glyphSet)
     {
 	client->errorValue = stuff->glyphset;
@@ -1366,7 +1366,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 		glyphSet = (GlyphSetPtr) SecurityLookupIDByType (client,
 								 gs,
 								 GlyphSetType,
-								 SecurityReadAccess);
+								 DixReadAccess);
 		if (!glyphSet)
 		{
 		    client->errorValue = gs;
@@ -1447,7 +1447,7 @@ ProcRenderFillRectangles (ClientPtr client)
 	client->errorValue = stuff->op;
 	return BadValue;
     }
-    VERIFY_PICTURE (pDst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pDst, stuff->dst, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pDst->pDrawable)
         return BadDrawable;
@@ -1515,7 +1515,7 @@ ProcRenderCreateCursor (ClientPtr client)
     REQUEST_SIZE_MATCH (xRenderCreateCursorReq);
     LEGAL_NEW_RESOURCE(stuff->cid, client);
     
-    VERIFY_PICTURE (pSrc, stuff->src, client, SecurityReadAccess, 
+    VERIFY_PICTURE (pSrc, stuff->src, client, DixReadAccess,
 		    RenderErrBase + BadPicture);
     if (!pSrc->pDrawable)
         return BadDrawable;
@@ -1699,7 +1699,7 @@ ProcRenderSetPictureTransform (ClientPtr client)
     int		result;
 
     REQUEST_SIZE_MATCH(xRenderSetPictureTransformReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     result = SetPictureTransform (pPicture, (PictTransform *) &stuff->transform);
     if (client->noClientException != Success)
@@ -1726,7 +1726,7 @@ ProcRenderQueryFilters (ClientPtr client)
     char			*names;
 
     REQUEST_SIZE_MATCH(xRenderQueryFiltersReq);
-    SECURITY_VERIFY_DRAWABLE(pDrawable, stuff->drawable, client, SecurityReadAccess);
+    SECURITY_VERIFY_DRAWABLE(pDrawable, stuff->drawable, client, DixReadAccess);
     
     pScreen = pDrawable->pScreen;
     nbytesName = 0;
@@ -1828,7 +1828,7 @@ ProcRenderSetPictureFilter (ClientPtr client)
     char	*name;
     
     REQUEST_AT_LEAST_SIZE (xRenderSetPictureFilterReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     name = (char *) (stuff + 1);
     params = (xFixed *) (name + ((stuff->nbytes + 3) & ~3));
@@ -1862,7 +1862,7 @@ ProcRenderCreateAnimCursor (ClientPtr client)
     for (i = 0; i < ncursor; i++)
     {
 	cursors[i] = (CursorPtr)SecurityLookupIDByType(client, elt->cursor,
-						       RT_CURSOR, SecurityReadAccess);
+						       RT_CURSOR, DixReadAccess);
 	if (!cursors[i])
 	{
 	    free (cursors);
@@ -1891,7 +1891,7 @@ ProcRenderAddTraps (ClientPtr client)
     REQUEST(xRenderAddTrapsReq);
 
     REQUEST_AT_LEAST_SIZE(xRenderAddTrapsReq);
-    VERIFY_PICTURE (pPicture, stuff->picture, client, SecurityWriteAccess, 
+    VERIFY_PICTURE (pPicture, stuff->picture, client, DixWriteAccess,
 		    RenderErrBase + BadPicture);
     if (!pPicture->pDrawable)
         return BadDrawable;
@@ -2644,7 +2644,7 @@ PanoramiXRenderCreatePicture (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xRenderCreatePictureReq);
     if(!(refDraw = (PanoramiXRes *)SecurityLookupIDByClass(
-		client, stuff->drawable, XRC_DRAWABLE, SecurityWriteAccess)))
+		client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
 	return BadDrawable;
     if(!(newPict = (PanoramiXRes *) malloc(sizeof(PanoramiXRes))))
 	return BadAlloc;
@@ -2686,7 +2686,7 @@ PanoramiXRenderChangePicture (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xChangeWindowAttributesReq);
     
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess,
 		       RenderErrBase + BadPicture);
     
     FOR_NSCREENS_BACKWARD(j) {
@@ -2707,7 +2707,7 @@ PanoramiXRenderSetPictureClipRectangles (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureClipRectanglesReq);
     
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess,
 		       RenderErrBase + BadPicture);
     
     FOR_NSCREENS_BACKWARD(j) {
@@ -2728,7 +2728,7 @@ PanoramiXRenderSetPictureTransform (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureTransformReq);
     
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess,
 		       RenderErrBase + BadPicture);
     
     FOR_NSCREENS_BACKWARD(j) {
@@ -2749,7 +2749,7 @@ PanoramiXRenderSetPictureFilter (ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureFilterReq);
     
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess,
 		       RenderErrBase + BadPicture);
     
     FOR_NSCREENS_BACKWARD(j) {
@@ -2772,7 +2772,7 @@ PanoramiXRenderFreePicture (ClientPtr client)
 
     client->errorValue = stuff->picture;
 
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, SecurityDestroyAccess,
+    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixDestroyAccess,
 		       RenderErrBase + BadPicture);
     
 
@@ -2798,11 +2798,11 @@ PanoramiXRenderComposite (ClientPtr client)
 
     REQUEST_SIZE_MATCH(xRenderCompositeReq);
     
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess, 
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_ALPHA (msk, stuff->mask, client, SecurityReadAccess, 
+    VERIFY_XIN_ALPHA (msk, stuff->mask, client, DixReadAccess,
 		      RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
     
     orig = *stuff;
@@ -2846,9 +2846,9 @@ PanoramiXRenderCompositeGlyphs (ClientPtr client)
     INT16	    xSrc, ySrc;
 
     REQUEST_AT_LEAST_SIZE(xRenderCompositeGlyphsReq);
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess,
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     if (client->req_len << 2 >= (sizeof (xRenderCompositeGlyphsReq) +
@@ -2889,7 +2889,7 @@ PanoramiXRenderFillRectangles (ClientPtr client)
     int		    extra_len;
 
     REQUEST_AT_LEAST_SIZE (xRenderFillRectanglesReq);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess, 
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
     extra_len = (client->req_len << 2) - sizeof (xRenderFillRectanglesReq);
     if (extra_len &&
@@ -2936,9 +2936,9 @@ PanoramiXRenderTrapezoids(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderTrapezoidsReq);
     
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess,
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderTrapezoidsReq);
@@ -2998,9 +2998,9 @@ PanoramiXRenderTriangles(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderTrianglesReq);
     
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess,
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderTrianglesReq);
@@ -3056,9 +3056,9 @@ PanoramiXRenderTriStrip(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderTriStripReq);
     
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess,
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderTriStripReq);
@@ -3110,9 +3110,9 @@ PanoramiXRenderTriFan(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderTriFanReq);
     
-    VERIFY_XIN_PICTURE (src, stuff->src, client, SecurityReadAccess,
+    VERIFY_XIN_PICTURE (src, stuff->src, client, DixReadAccess,
 			RenderErrBase + BadPicture);
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderTriFanReq);
@@ -3166,7 +3166,7 @@ PanoramiXRenderColorTrapezoids(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderColorTrapezoidsReq);
     
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderColorTrapezoidsReq);
@@ -3210,7 +3210,7 @@ PanoramiXRenderColorTriangles(ClientPtr client)
     
     REQUEST_AT_LEAST_SIZE (xRenderColorTrianglesReq);
     
-    VERIFY_XIN_PICTURE (dst, stuff->dst, client, SecurityWriteAccess,
+    VERIFY_XIN_PICTURE (dst, stuff->dst, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
 
     extra_len = (client->req_len << 2) - sizeof (xRenderColorTrianglesReq);
@@ -3256,7 +3256,7 @@ PanoramiXRenderAddTraps (ClientPtr client)
     INT16    	    x_off, y_off;
 
     REQUEST_AT_LEAST_SIZE (xRenderAddTrapsReq);
-    VERIFY_XIN_PICTURE (picture, stuff->picture, client, SecurityWriteAccess, 
+    VERIFY_XIN_PICTURE (picture, stuff->picture, client, DixWriteAccess,
 			RenderErrBase + BadPicture);
     extra_len = (client->req_len << 2) - sizeof (xRenderAddTrapsReq);
     if (extra_len &&

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -193,7 +193,7 @@ ProcXFixesSelectCursorInput (ClientPtr client)
 
     REQUEST_SIZE_MATCH (xXFixesSelectCursorInputReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     if (stuff->eventMask & ~CursorAllEvents)
@@ -362,7 +362,7 @@ ProcXFixesSetCursorName (ClientPtr client)
     Atom atom;
 
     REQUEST_AT_LEAST_SIZE(xXFixesSetCursorNameReq);
-    VERIFY_CURSOR(pCursor, stuff->cursor, client, SecurityWriteAccess);
+    VERIFY_CURSOR(pCursor, stuff->cursor, client, DixWriteAccess);
     tchar = (char *) &stuff[1];
     atom = MakeAtom (tchar, stuff->nbytes, TRUE);
     if (atom == BAD_RESOURCE)
@@ -394,7 +394,7 @@ ProcXFixesGetCursorName (ClientPtr client)
     int len;
 
     REQUEST_SIZE_MATCH(xXFixesGetCursorNameReq);
-    VERIFY_CURSOR(pCursor, stuff->cursor, client, SecurityReadAccess);
+    VERIFY_CURSOR(pCursor, stuff->cursor, client, DixReadAccess);
     if (pCursor->name)
 	str = NameForAtom (pCursor->name);
     else
@@ -619,8 +619,8 @@ ProcXFixesChangeCursor (ClientPtr client)
     REQUEST(xXFixesChangeCursorReq);
 
     REQUEST_SIZE_MATCH(xXFixesChangeCursorReq);
-    VERIFY_CURSOR (pSource, stuff->source, client, SecurityReadAccess);
-    VERIFY_CURSOR (pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_CURSOR (pSource, stuff->source, client, DixReadAccess);
+    VERIFY_CURSOR (pDestination, stuff->destination, client, DixWriteAccess);
 
     ReplaceCursor (pSource, TestForCursor, (void *) pDestination);
     return (client->noClientException);
@@ -653,7 +653,7 @@ ProcXFixesChangeCursorByName (ClientPtr client)
     REQUEST(xXFixesChangeCursorByNameReq);
 
     REQUEST_FIXED_SIZE(xXFixesChangeCursorByNameReq, stuff->nbytes);
-    VERIFY_CURSOR(pSource, stuff->source, client, SecurityReadAccess);
+    VERIFY_CURSOR(pSource, stuff->source, client, DixReadAccess);
     tchar = (char *) &stuff[1];
     name = MakeAtom (tchar, stuff->nbytes, FALSE);
     if (name)

--- a/nx-X11/programs/Xserver/xfixes/region.c
+++ b/nx-X11/programs/Xserver/xfixes/region.c
@@ -117,7 +117,7 @@ ProcXFixesCreateRegionFromBitmap (ClientPtr client)
 
     pPixmap = (PixmapPtr) SecurityLookupIDByType (client, stuff->bitmap,
 						  RT_PIXMAP,
-						  SecurityReadAccess);
+						  DixReadAccess);
     if (!pPixmap)
     {
 	client->errorValue = stuff->bitmap;
@@ -222,7 +222,7 @@ ProcXFixesCreateRegionFromGC (ClientPtr client)
     REQUEST_SIZE_MATCH (xXFixesCreateRegionFromGCReq);
     LEGAL_NEW_RESOURCE (stuff->region, client);
 
-    SECURITY_VERIFY_GC(pGC, stuff->gc, client, SecurityReadAccess);
+    SECURITY_VERIFY_GC(pGC, stuff->gc, client, DixReadAccess);
     
     switch (pGC->clientClipType) {
     case CT_PIXMAP:
@@ -269,7 +269,7 @@ ProcXFixesCreateRegionFromPicture (ClientPtr client)
     REQUEST_SIZE_MATCH (xXFixesCreateRegionFromPictureReq);
     LEGAL_NEW_RESOURCE (stuff->region, client);
 
-    VERIFY_PICTURE(pPicture, stuff->picture, client, SecurityReadAccess,
+    VERIFY_PICTURE(pPicture, stuff->picture, client, DixReadAccess,
 		   RenderErrBase + BadPicture);
     
     switch (pPicture->clientClipType) {
@@ -316,7 +316,7 @@ ProcXFixesDestroyRegion (ClientPtr client)
     RegionPtr	pRegion;
 
     REQUEST_SIZE_MATCH(xXFixesDestroyRegionReq);
-    VERIFY_REGION(pRegion, stuff->region, client, SecurityWriteAccess);
+    VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
     FreeResource (stuff->region, RT_NONE);
     return(client->noClientException);
 }
@@ -340,7 +340,7 @@ ProcXFixesSetRegion (ClientPtr client)
     REQUEST (xXFixesSetRegionReq);
 
     REQUEST_AT_LEAST_SIZE(xXFixesSetRegionReq);
-    VERIFY_REGION(pRegion, stuff->region, client, SecurityWriteAccess);
+    VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
     
     things = (client->req_len << 2) - sizeof (xXFixesCreateRegionReq);
     if (things & 4)
@@ -377,8 +377,8 @@ ProcXFixesCopyRegion (ClientPtr client)
     RegionPtr	pSource, pDestination;
     REQUEST (xXFixesCopyRegionReq);
     
-    VERIFY_REGION(pSource, stuff->source, client, SecurityReadAccess);
-    VERIFY_REGION(pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
+    VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
     
     if (!RegionCopy(pDestination, pSource))
 	return BadAlloc;
@@ -406,9 +406,9 @@ ProcXFixesCombineRegion (ClientPtr client)
     REQUEST (xXFixesCombineRegionReq);
 
     REQUEST_SIZE_MATCH (xXFixesCombineRegionReq);
-    VERIFY_REGION(pSource1, stuff->source1, client, SecurityReadAccess);
-    VERIFY_REGION(pSource2, stuff->source2, client, SecurityReadAccess);
-    VERIFY_REGION(pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_REGION(pSource1, stuff->source1, client, DixReadAccess);
+    VERIFY_REGION(pSource2, stuff->source2, client, DixReadAccess);
+    VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
     
     switch (stuff->xfixesReqType) {
     case X_XFixesUnionRegion:
@@ -452,8 +452,8 @@ ProcXFixesInvertRegion (ClientPtr client)
     REQUEST(xXFixesInvertRegionReq);
 
     REQUEST_SIZE_MATCH(xXFixesInvertRegionReq);
-    VERIFY_REGION(pSource, stuff->source, client, SecurityReadAccess);
-    VERIFY_REGION(pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
+    VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
 
     /* Compute bounds, limit to 16 bits */
     bounds.x1 = stuff->x;
@@ -499,7 +499,7 @@ ProcXFixesTranslateRegion (ClientPtr client)
     REQUEST(xXFixesTranslateRegionReq);
 
     REQUEST_SIZE_MATCH(xXFixesTranslateRegionReq);
-    VERIFY_REGION(pRegion, stuff->region, client, SecurityWriteAccess);
+    VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
 
     RegionTranslate(pRegion, stuff->dx, stuff->dy);
     return (client->noClientException);
@@ -525,8 +525,8 @@ ProcXFixesRegionExtents (ClientPtr client)
     REQUEST(xXFixesRegionExtentsReq);
 
     REQUEST_SIZE_MATCH(xXFixesRegionExtentsReq);
-    VERIFY_REGION(pSource, stuff->source, client, SecurityReadAccess);
-    VERIFY_REGION(pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
+    VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
 
     RegionReset(pDestination, RegionExtents(pSource));
 
@@ -557,7 +557,7 @@ ProcXFixesFetchRegion (ClientPtr client)
     REQUEST(xXFixesFetchRegionReq);
 
     REQUEST_SIZE_MATCH(xXFixesFetchRegionReq);
-    VERIFY_REGION(pRegion, stuff->region, client, SecurityReadAccess);
+    VERIFY_REGION(pRegion, stuff->region, client, DixReadAccess);
 
     pExtent = RegionExtents(pRegion);
     pBox = RegionRects (pRegion);
@@ -618,8 +618,8 @@ ProcXFixesSetGCClipRegion (ClientPtr client)
     REQUEST(xXFixesSetGCClipRegionReq);
 
     REQUEST_SIZE_MATCH(xXFixesSetGCClipRegionReq);
-    SECURITY_VERIFY_GC(pGC, stuff->gc, client, SecurityWriteAccess);
-    VERIFY_REGION_OR_NONE (pRegion, stuff->region, client, SecurityReadAccess);
+    SECURITY_VERIFY_GC(pGC, stuff->gc, client, DixWriteAccess);
+    VERIFY_REGION_OR_NONE (pRegion, stuff->region, client, DixReadAccess);
 
     if (pRegion)
     {
@@ -669,7 +669,7 @@ ProcXFixesSetWindowShapeRegion (ClientPtr client)
 	client->errorValue = stuff->dest;
 	return BadWindow;
     }
-    VERIFY_REGION_OR_NONE(pRegion, stuff->region, client, SecurityWriteAccess);
+    VERIFY_REGION_OR_NONE(pRegion, stuff->region, client, DixWriteAccess);
     pScreen = pWin->drawable.pScreen;
     switch (stuff->destKind) {
     case ShapeBounding:
@@ -756,9 +756,9 @@ ProcXFixesSetPictureClipRegion (ClientPtr client)
     REQUEST(xXFixesSetPictureClipRegionReq);
     
     REQUEST_SIZE_MATCH (xXFixesSetPictureClipRegionReq);
-    VERIFY_PICTURE(pPicture, stuff->picture, client, SecurityWriteAccess,
+    VERIFY_PICTURE(pPicture, stuff->picture, client, DixWriteAccess,
 		   RenderErrBase + BadPicture);
-    VERIFY_REGION_OR_NONE(pRegion, stuff->region, client, SecurityReadAccess);
+    VERIFY_REGION_OR_NONE(pRegion, stuff->region, client, DixReadAccess);
     
     return SetPictureClipRegion (pPicture, stuff->xOrigin, stuff->yOrigin,
 				 pRegion);
@@ -793,8 +793,8 @@ ProcXFixesExpandRegion (ClientPtr client)
     int		i;
 
     REQUEST_SIZE_MATCH (xXFixesExpandRegionReq);
-    VERIFY_REGION(pSource, stuff->source, client, SecurityReadAccess);
-    VERIFY_REGION(pDestination, stuff->destination, client, SecurityWriteAccess);
+    VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
+    VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
     
     nBoxes = RegionNumRects(pSource);
     pSrc = RegionRects(pSource);

--- a/nx-X11/programs/Xserver/xfixes/saveset.c
+++ b/nx-X11/programs/Xserver/xfixes/saveset.c
@@ -38,7 +38,7 @@ ProcXFixesChangeSaveSet(ClientPtr client)
 		  
     REQUEST_SIZE_MATCH(xXFixesChangeSaveSetReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     if (client->clientAsMask == (CLIENT_BITS(pWin->drawable.id)))

--- a/nx-X11/programs/Xserver/xfixes/select.c
+++ b/nx-X11/programs/Xserver/xfixes/select.c
@@ -198,7 +198,7 @@ ProcXFixesSelectSelectionInput (ClientPtr client)
 
     REQUEST_SIZE_MATCH (xXFixesSelectSelectionInputReq);
     pWin = (WindowPtr)SecurityLookupWindow(stuff->window, client,
-					   SecurityReadAccess);
+					   DixReadAccess);
     if (!pWin)
         return(BadWindow);
     if (stuff->eventMask & ~SelectionAllEvents)


### PR DESCRIPTION
One little step further with adapting ABI to latest X.org. The more adaptations we have, the easier it  becomes, backporting recent X.org code.

 Backported from X.org:

 commit 6c46645cfc1afda8aeabfe0ed4d9342673b702f1
 Author: Eamon Walsh <ewalsh@tycho.nsa.gov>
 Date:   Thu Dec 14 14:45:42 2006 -0500

    Naming change: Security*Access -> Dix*Access

 Backported-to-NX-by: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>