### PR TITLE
Switch from using libNX_X11's deprecated XKeycodeToKeysym() function …

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -934,7 +934,7 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
       {
         enum HandleEventResult result;
 
-        KeySym keysym;
+        XlibKeySym *keysym;
 
         #ifdef TEST
         fprintf(stderr, "nxagentDispatchEvents: Going to handle new KeyPress event.\n");
@@ -1101,12 +1101,17 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
          * sive delay.
          */
 
-        keysym = XKeycodeToKeysym(nxagentDisplay, X.xkey.keycode, 0);
+        int keysyms_per_keycode_return;
+        keysym = XGetKeyboardMapping(nxagentDisplay,
+                                     X.xkey.keycode,
+                                     1,
+                                     &keysyms_per_keycode_return);
 
-        if (nxagentMonitoredDuplicate(keysym) == 1)
+        if (nxagentMonitoredDuplicate(keysym[0]) == 1)
         {
           nxagentRemoveDuplicatedKeys(&X);
         }
+        free(keysym);
 
         if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow) == 1 && result == doNothing)
         {
@@ -4638,8 +4643,16 @@ void nxagentDumpInputDevicesState(void)
       {
         if (val & (mask << k))
         {
+          int keysyms_per_keycode_return;
+          XlibKeySym *keysym = XGetKeyboardMapping(nxagentDisplay,
+                                                     i * 8 + k,
+                                                     1,
+                                                     &keysyms_per_keycode_return);
+
+
           fprintf(stderr, "\n\t[%d] [%s]", i * 8 + k,
-                      XKeysymToString(XKeycodeToKeysym(nxagentDisplay, i * 8 + k, 0)));
+                      XKeysymToString(keysym[0]));
+          free(keysym);
         }
       }
     }


### PR DESCRIPTION
…to using XGetKeyboardMapping().

 Fixes ArcticaProject/nx-libs#229.