### PR TITLE
dix: remove client->lastDrawable/lastGC

### DIFF
--- a/nx-X11/programs/Xserver/dbe/dbe.c
+++ b/nx-X11/programs/Xserver/dbe/dbe.c
@@ -1842,7 +1842,7 @@ DbeExtensionInit()
 
     /* Create the resource types. */
     dbeDrawableResType =
-        CreateNewResourceType(DbeDrawableDelete) | RC_CACHED | RC_DRAWABLE;
+        CreateNewResourceType(DbeDrawableDelete) | RC_DRAWABLE;
     dbeWindowPrivResType =
         CreateNewResourceType(DbeWindowPrivDelete);
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -216,33 +216,6 @@ InitSelections()
 }
 #endif /* NXAGENT_SERVER */
 
-void 
-FlushClientCaches(XID id)
-{
-    int i;
-    register ClientPtr client;
-
-    client = clients[CLIENT_ID(id)];
-    if (client == NullClient)
-        return ;
-    for (i=0; i<currentMaxClients; i++)
-    {
-	client = clients[i];
-        if (client != NullClient)
-	{
-            if (client->lastDrawableID == id)
-	    {
-		client->lastDrawableID = screenInfo.screens[0]->root->drawable.id;
-		client->lastDrawable = (DrawablePtr)screenInfo.screens[0]->root;
-	    }
-            else if (client->lastGCID == id)
-	    {
-                client->lastGCID = INVALID;
-		client->lastGC = (GCPtr)NULL;
-	    }
-	}
-    }
-}
 #undef SMART_DEBUG
 
 #define SMART_SCHEDULE_DEFAULT_INTERVAL	20	    /* ms */
@@ -3629,20 +3602,7 @@ void InitClient(ClientPtr client, int i, void * ospriv)
     client->sequence = 0; 
     client->clientAsMask = ((Mask)i) << CLIENTOFFSET;
     client->clientGone = FALSE;
-    if (i)
-    {
-	client->closeDownMode = DestroyAll;
-	client->lastDrawable = (DrawablePtr)screenInfo.screens[0]->root;
-	client->lastDrawableID = screenInfo.screens[0]->root->drawable.id;
-    }
-    else
-    {
-	client->closeDownMode = RetainPermanent;
-	client->lastDrawable = (DrawablePtr)NULL;
-	client->lastDrawableID = INVALID;
-    }
-    client->lastGC = (GCPtr) NULL;
-    client->lastGCID = INVALID;
+    client->closeDownMode = i ? DestroyAll : RetainPermanent;
     client->numSaved = 0;
     client->saveSet = (SaveSetElt *)NULL;
     client->noClientException = Success;

--- a/nx-X11/programs/Xserver/dix/dixutils.c
+++ b/nx-X11/programs/Xserver/dix/dixutils.c
@@ -210,27 +210,10 @@ CompareISOLatin1Lowered(unsigned char *s1, int s1len,
 WindowPtr
 SecurityLookupWindow(XID rid, ClientPtr client, Mask access_mode)
 {
-    WindowPtr	pWin;
-
     client->errorValue = rid;
     if(rid == INVALID)
 	return NULL;
-    if (client->trustLevel != XSecurityClientTrusted)
-	return (WindowPtr)SecurityLookupIDByType(client, rid, RT_WINDOW, access_mode);
-    if (client->lastDrawableID == rid)
-    {
-        if (client->lastDrawable->type == DRAWABLE_WINDOW)
-            return ((WindowPtr) client->lastDrawable);
-        return (WindowPtr) NULL;
-    }
-    pWin = (WindowPtr)SecurityLookupIDByType(client, rid, RT_WINDOW, access_mode);
-    if (pWin && pWin->drawable.type == DRAWABLE_WINDOW) {
-	client->lastDrawable = (DrawablePtr) pWin;
-	client->lastDrawableID = rid;
-	client->lastGCID = INVALID;
-	client->lastGC = (GCPtr)NULL;
-    }
-    return pWin;
+    return (WindowPtr)SecurityLookupIDByType(client, rid, RT_WINDOW, access_mode);
 }
 
 
@@ -241,15 +224,10 @@ SecurityLookupDrawable(XID rid, ClientPtr client, Mask access_mode)
 
     if(rid == INVALID)
 	return (void *) NULL;
-    if (client->trustLevel != XSecurityClientTrusted)
-	return (DrawablePtr)SecurityLookupIDByClass(client, rid, RC_DRAWABLE,
-						    access_mode);
-    if (client->lastDrawableID == rid)
-	return ((void *) client->lastDrawable);
     pDraw = (DrawablePtr)SecurityLookupIDByClass(client, rid, RC_DRAWABLE,
 						 access_mode);
-    if (pDraw && (pDraw->type != UNDRAWABLE_WINDOW))
-        return (void *)pDraw;
+    if ((client->trustLevel != XSecurityClientTrusted) || (pDraw && (pDraw->type != UNDRAWABLE_WINDOW)))
+	return (void *)pDraw;
     return (void *)NULL;
 }
 
@@ -279,20 +257,7 @@ LookupWindow(XID rid, ClientPtr client)
     client->errorValue = rid;
     if(rid == INVALID)
 	return NULL;
-    if (client->lastDrawableID == rid)
-    {
-        if (client->lastDrawable->type == DRAWABLE_WINDOW)
-            return ((WindowPtr) client->lastDrawable);
-        return (WindowPtr) NULL;
-    }
-    pWin = (WindowPtr)LookupIDByType(rid, RT_WINDOW);
-    if (pWin && pWin->drawable.type == DRAWABLE_WINDOW) {
-	client->lastDrawable = (DrawablePtr) pWin;
-	client->lastDrawableID = rid;
-	client->lastGCID = INVALID;
-	client->lastGC = (GCPtr)NULL;
-    }
-    return pWin;
+    return (WindowPtr)LookupIDByType(rid, RT_WINDOW);
 }
 
 
@@ -303,8 +268,6 @@ LookupDrawable(XID rid, ClientPtr client)
 
     if(rid == INVALID)
 	return (void *) NULL;
-    if (client->lastDrawableID == rid)
-	return ((void *) client->lastDrawable);
     pDraw = (DrawablePtr)LookupIDByClass(rid, RC_DRAWABLE);
     if (pDraw && (pDraw->type != UNDRAWABLE_WINDOW))
         return (void *)pDraw;

--- a/nx-X11/programs/Xserver/include/dix.h
+++ b/nx-X11/programs/Xserver/include/dix.h
@@ -91,15 +91,11 @@ SOFTWARE.
 /* XXX if you are using this macro, you are probably not generating Match
  * errors where appropriate */
 #define LOOKUP_DRAWABLE(did, client)\
-    ((client->lastDrawableID == did) ? \
-     client->lastDrawable : (DrawablePtr)LookupDrawable(did, client))
+    ((DrawablePtr)LookupDrawable(did, client))
 
 #ifdef XCSECURITY
 
 #define SECURITY_VERIFY_DRAWABLE(pDraw, did, client, mode)\
-    if (client->lastDrawableID == did && !client->trustLevel)\
-	pDraw = client->lastDrawable;\
-    else \
     {\
 	pDraw = (DrawablePtr) SecurityLookupIDByClass(client, did, \
 						      RC_DRAWABLE, mode);\
@@ -113,9 +109,6 @@ SOFTWARE.
     }
 
 #define SECURITY_VERIFY_GEOMETRABLE(pDraw, did, client, mode)\
-    if (client->lastDrawableID == did && !client->trustLevel)\
-	pDraw = client->lastDrawable;\
-    else \
     {\
 	pDraw = (DrawablePtr) SecurityLookupIDByClass(client, did, \
 						      RC_DRAWABLE, mode);\
@@ -127,10 +120,7 @@ SOFTWARE.
     }
 
 #define SECURITY_VERIFY_GC(pGC, rid, client, mode)\
-    if (client->lastGCID == rid && !client->trustLevel)\
-        pGC = client->lastGC;\
-    else\
-	pGC = (GC *) SecurityLookupIDByType(client, rid, RT_GC, mode);\
+    pGC = (GC *) SecurityLookupIDByType(client, rid, RT_GC, mode);\
     if (!pGC)\
     {\
 	client->errorValue = rid;\
@@ -149,9 +139,6 @@ SOFTWARE.
 #else /* not XCSECURITY */
 
 #define VERIFY_DRAWABLE(pDraw, did, client)\
-    if (client->lastDrawableID == did)\
-	pDraw = client->lastDrawable;\
-    else \
     {\
 	pDraw = (DrawablePtr) LookupIDByClass(did, RC_DRAWABLE);\
 	if (!pDraw) \
@@ -164,9 +151,6 @@ SOFTWARE.
     }
 
 #define VERIFY_GEOMETRABLE(pDraw, did, client)\
-    if (client->lastDrawableID == did)\
-	pDraw = client->lastDrawable;\
-    else \
     {\
 	pDraw = (DrawablePtr) LookupIDByClass(did, RC_DRAWABLE);\
 	if (!pDraw) \
@@ -177,10 +161,7 @@ SOFTWARE.
     }
 
 #define VERIFY_GC(pGC, rid, client)\
-    if (client->lastGCID == rid)\
-        pGC = client->lastGC;\
-    else\
-	pGC = (GC *)LookupIDByType(rid, RT_GC);\
+    pGC = (GC *)LookupIDByType(rid, RT_GC);\
     if (!pGC)\
     {\
 	client->errorValue = rid;\
@@ -252,23 +233,12 @@ SOFTWARE.
 #endif /* NEED_DBE_BUF_BITS */
 
 #define VALIDATE_DRAWABLE_AND_GC(drawID, pDraw, pGC, client)\
-    if ((stuff->gc == INVALID) || (client->lastGCID != stuff->gc) ||\
-	(client->lastDrawableID != drawID))\
     {\
 	SECURITY_VERIFY_GEOMETRABLE(pDraw, drawID, client, DixWriteAccess);\
 	SECURITY_VERIFY_GC(pGC, stuff->gc, client, DixReadAccess);\
 	if ((pGC->depth != pDraw->depth) ||\
 	    (pGC->pScreen != pDraw->pScreen))\
 	    return (BadMatch);\
-	client->lastDrawable = pDraw;\
-	client->lastDrawableID = drawID;\
-	client->lastGC = pGC;\
-	client->lastGCID = stuff->gc;\
-    }\
-    else\
-    {\
-        pGC = client->lastGC;\
-        pDraw = client->lastDrawable;\
     }\
     SET_DBE_DSTBUF(pDraw, drawID);\
     if (pGC->serialNumber != pDraw->serialNumber)\
@@ -324,8 +294,6 @@ extern void UpdateCurrentTime(void);
 extern void UpdateCurrentTimeIf(void);
 
 extern void InitSelections(void);
-
-extern void FlushClientCaches(XID /*id*/);
 
 extern int dixDestroyPixmap(
     void * /*value*/,

--- a/nx-X11/programs/Xserver/include/dixstruct.h
+++ b/nx-X11/programs/Xserver/include/dixstruct.h
@@ -101,10 +101,6 @@ typedef struct _Client {
     int         clientGone;
     int         noClientException;	/* this client died or needs to be
 					 * killed */
-    DrawablePtr lastDrawable;
-    Drawable    lastDrawableID;
-    GCPtr       lastGC;
-    GContext    lastGCID;
     SaveSetElt	*saveSet;
     int         numSaved;
     void        *screenPrivate[MAXSCREENS];

--- a/nx-X11/programs/Xserver/include/resource.h
+++ b/nx-X11/programs/Xserver/include/resource.h
@@ -71,9 +71,9 @@ typedef unsigned long RESTYPE;
 
 /* types for Resource routines */
 
-#define RT_WINDOW	((RESTYPE)1|RC_CACHED|RC_DRAWABLE)
-#define RT_PIXMAP	((RESTYPE)2|RC_CACHED|RC_DRAWABLE)
-#define RT_GC		((RESTYPE)3|RC_CACHED)
+#define RT_WINDOW	((RESTYPE)1|RC_DRAWABLE)
+#define RT_PIXMAP	((RESTYPE)2|RC_DRAWABLE)
+#define RT_GC		((RESTYPE)3)
 #undef RT_FONT
 #undef RT_CURSOR
 #define RT_FONT		((RESTYPE)4)


### PR DESCRIPTION
This fixes ArcticaProject/nx-libs#306 and #322

Using client->lastDrawable and client->lastGC proved to be
unreliable. Doing the lookup everytime instead + checking for success
works!