### PR TITLE
Xserver/dix/atom.c (et al.): Constify atom name strings.

### DIFF
--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -1066,7 +1066,7 @@ SecurityAuditResourceIDAccess(
 	    xChangePropertyReq *req =
 		(xChangePropertyReq *)client->requestBuffer;
 	    int propertyatom = req->property;
-	    char *propertyname = NameForAtom(propertyatom);
+	    const char *propertyname = NameForAtom(propertyatom);
 
 	    SecurityAudit("client %d attempted request %d with window 0x%x property %s of client %d\n",
 		   client->index, reqtype, id, propertyname, cid);

--- a/nx-X11/programs/Xserver/dix/atom.c
+++ b/nx-X11/programs/Xserver/dix/atom.c
@@ -62,7 +62,7 @@ typedef struct _Node {
     struct _Node   *left,   *right;
     Atom a;
     unsigned int fingerPrint;
-    char   *string;
+    const char   *string;
 } NodeRec, *NodePtr;
 
 static Atom lastAtom = None;
@@ -116,13 +116,11 @@ MakeAtom(const char *string, unsigned len, Bool makeit)
 	}
 	else
 	{
-	    nd->string = (char *) malloc(len + 1);
+	    nd->string = strndup(string, len);
 	    if (!nd->string) {
 		free(nd);
 		return BAD_RESOURCE;
 	    }
-	    strncpy(nd->string, string, (int)len);
-	    nd->string[len] = 0;
 	}
 	if ((lastAtom + 1) >= tableLength) {
 	    NodePtr *table;
@@ -131,7 +129,8 @@ MakeAtom(const char *string, unsigned len, Bool makeit)
 					 tableLength * (2 * sizeof(NodePtr)));
 	    if (!table) {
 		if (nd->string != string)
-		    free(nd->string);
+		     /* nd->string has been strdup'ed */
+		    free((char *)nd->string);
 		free(nd);
 		return BAD_RESOURCE;
 	    }
@@ -155,7 +154,7 @@ ValidAtom(Atom atom)
     return (atom != None) && (atom <= lastAtom);
 }
 
-char *
+const char *
 NameForAtom(Atom atom)
 {
     NodePtr node;
@@ -178,7 +177,7 @@ FreeAtom(NodePtr patom)
     if(patom->right)
 	FreeAtom(patom->right);
     if (patom->a > XA_LAST_PREDEFINED)
-	free(patom->string);
+	free((char *)patom->string);
     free(patom);
 }
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -886,7 +886,7 @@ ProcInternAtom(register ClientPtr client)
 int
 ProcGetAtomName(register ClientPtr client)
 {
-    char *str;
+    const char *str;
     xGetAtomNameReply reply;
     int len;
     REQUEST(xResourceReq);

--- a/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
@@ -336,7 +336,7 @@ int nxagentQueryAtoms(ScreenPtr pScreen)
 typedef struct {
     Atom local;
     Atom remote;
-    char *string;
+    const char *string;
     int  length;
 } AtomMap;
 
@@ -345,7 +345,7 @@ static unsigned int privAtomMapSize = 0;
 static unsigned int privLastAtom = 0;
 
 static void nxagentExpandCache(void);
-static void nxagentWriteAtom(Atom, Atom, char*, Bool);
+static void nxagentWriteAtom(Atom, Atom, const char*, Bool);
 static AtomMap* nxagentFindAtomByRemoteValue(Atom);
 static AtomMap* nxagentFindAtomByLocalValue(Atom);
 static AtomMap* nxagentFindAtomByName(char*, unsigned);
@@ -368,9 +368,9 @@ static void nxagentExpandCache(void)
  * then cache the atom-couple.
  */
 
-static void nxagentWriteAtom(Atom local, Atom remote, char *string, Bool duplicate)
+static void nxagentWriteAtom(Atom local, Atom remote, const char *string, Bool duplicate)
 {
-  char *s;
+  const char *s;
 
   /*
    * We could remove this string duplication if
@@ -460,7 +460,7 @@ static int nxagentInitAtomMap(char **atomNameList, int count, Atom *atomsRet)
   
   for (i = 0; i < privLastAtom; i++)
   {
-    name_list[count + i] = privAtomMap[i].string;
+    name_list[count + i] = (char *)privAtomMap[i].string;
     atom_list[count + i] = None;
   }
 
@@ -670,7 +670,7 @@ Atom nxagentMakeAtom(char *string, unsigned int length, Bool Makeit)
 Atom nxagentLocalToRemoteAtom(Atom local)
 {
   AtomMap *current;
-  char    *string;
+  const char    *string;
   Atom    remote;
 
   if (!ValidAtom(local))

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -1164,7 +1164,7 @@ FIXME: Why this pointer can be not a valid
 int nxagentConvertSelection(ClientPtr client, WindowPtr pWin, Atom selection,
                                 Window requestor, Atom property, Atom target, Time time)
 {
-  char *strTarget;
+  const char *strTarget;
   int i;
 
   if (agentClipboardStatus != 1 ||

--- a/nx-X11/programs/Xserver/hw/nxagent/Font.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Font.c
@@ -491,7 +491,7 @@ Bool nxagentRealizeFont(ScreenPtr pScreen, FontPtr pFont)
   int nprops;
   FontPropPtr props;
   int i;
-  char *name;
+  const char *name;
   char *origName = (char*) pScreen;
 
   FontSetPrivate(pFont, nxagentFontPrivateIndex, NULL);
@@ -513,7 +513,7 @@ Bool nxagentRealizeFont(ScreenPtr pScreen, FontPtr pFont)
 
   if (!value_atom) return False;
 
-  name = (char *)NameForAtom(value_atom);
+  name = NameForAtom(value_atom);
 
   #ifdef NXAGENT_FONTCACHE_DEBUG
   fprintf(stderr, "Font: nxagentRealizeFont, realizing font: %s\n", validateString(name));
@@ -602,7 +602,7 @@ Bool nxagentRealizeFont(ScreenPtr pScreen, FontPtr pFont)
        nxagentListRemoteFonts("*", nxagentMaxFontNames);
      }
 
-     nxagentFontPriv(pFont)->font_struct = nxagentLoadQueryFont(nxagentDisplay, name, pFont);
+     nxagentFontPriv(pFont)->font_struct = nxagentLoadQueryFont(nxagentDisplay, (char *)name, pFont);
      strcpy(nxagentFontPriv(pFont)->fontName, name);
      if (nxagentFontPriv(pFont)->font_struct != NULL)
      {

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -455,7 +455,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
     unsigned long nUnits;
     void        *value;
 {
-  char *propertyS, *typeS;
+  const char *propertyS, *typeS;
   Atom propertyX, typeX;
   char *output = NULL;
   nxagentWMHints wmHints;
@@ -634,7 +634,7 @@ int nxagentExportProperty(pWin, property, type, format, mode, nUnits, value)
   {
     XlibAtom *atoms = malloc(nUnits * sizeof(*atoms));
     Atom *input = value;
-    char *atomName = NULL;
+    const char *atomName = NULL;
     int i;
     int j = 0;
 
@@ -834,7 +834,7 @@ void nxagentImportProperty(Window window,
   WMState wmState;
 
   char *output = NULL;
-  char *typeS;
+  const char *typeS;
 
   pWin = nxagentWindowPtr(window);
 

--- a/nx-X11/programs/Xserver/include/dix.h
+++ b/nx-X11/programs/Xserver/include/dix.h
@@ -480,7 +480,7 @@ extern Atom MakeAtom(
 extern Bool ValidAtom(
     Atom /*atom*/);
 
-extern char *NameForAtom(
+extern const char *NameForAtom(
     Atom /*atom*/);
 
 extern void AtomError(void);

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -3529,7 +3529,7 @@ register int i,bit;
 static Bool
 _XkbCheckTypeName(Atom name,int typeNdx)
 {
-char *	str;
+const char *	str;
 
     str= NameForAtom(name);
     if ((strcmp(str,"ONE_LEVEL")==0)||(strcmp(str,"TWO_LEVEL")==0)||

--- a/nx-X11/programs/Xserver/xkb/xkbtext.c
+++ b/nx-X11/programs/Xserver/xkb/xkbtext.c
@@ -75,7 +75,7 @@ XkbAtomText(Display *dpy,Atom atm,unsigned format)
 {
 char	*rtrn,*tmp;
 
-    tmp= XkbAtomGetString(dpy,atm);
+    tmp= (char *)XkbAtomGetString(dpy,atm);
     if (tmp!=NULL) {
 	int	len;
 	len= strlen(tmp)+1;
@@ -118,7 +118,7 @@ char  numBuf[20];
     if (ndx>=XkbNumVirtualMods)
 	 tmp= "illegal";
     else if (vmodNames&&(vmodNames[ndx]!=None))
-	 tmp= XkbAtomGetString(dpy,vmodNames[ndx]);
+	 tmp= (char *)XkbAtomGetString(dpy,vmodNames[ndx]);
     if (tmp==NULL)
 	sprintf(tmp=numBuf,"%d",ndx);
 


### PR DESCRIPTION
 Inspired by X.org commits:

 commit 08093c25a91c07ab8af7cece9bba738b827cfd1b
 Author: Alan Coopersmith <alan.coopersmith@oracle.com>
 Date:   Mon Oct 24 23:16:30 2011 -0700

    Convert some malloc + strncpy pairs into strndup calls

    Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
    Reviewed-by: Jeremy Huddleston <jeremyhu@apple.com>

 commit 816b79dd061e9839cec94a4986a7820b70ca8a7f
 Author: Mikhail Gusarov <dottedmag@dottedmag.net>
 Date:   Thu May 13 03:45:21 2010 +0700

    Remove useless casts

    Signed-off-by: Mikhail Gusarov <dottedmag@dottedmag.net>
    Reviewed-by: Keith Packard <keithp@keithp.com>

 This PR ships a tiny change in MakeAtom, that we adopted.
 We did not adopt the full commit.

 commit 5623c27700b7b23a8dbbd8c8f45e5d4fa0c667e3
 Author: Alan Coopersmith <alan.coopersmith@sun.com>
 Date:   Mon Feb 2 19:25:14 2009 -0800

    Constify atom name strings

    Changes MakeAtom to take a const char * and NameForAtom to return them,
    since many callers pass pointers to constant strings stored in read-only
    ELF sections.   Updates in-tree callers as necessary to clear const
    mismatch warnings introduced by this change.

    Signed-off-by: Alan Coopersmith <alan.coopersmith@sun.com>
    Acked-by: Peter Hutterer <peter.hutterer@who-t.net>

 Backported-to-NX-by: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>