### PR TITLE
replace (DE)ALLOCATE_LOCAL by malloc/free

### DIFF
--- a/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
@@ -1257,7 +1257,7 @@ int PanoramiXPolyPoint(ClientPtr client)
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
     npoint = ((client->req_len << 2) - sizeof(xPolyPointReq)) >> 2;
     if (npoint > 0) {
-        origPts = (xPoint *) ALLOCATE_LOCAL(npoint * sizeof(xPoint));
+        origPts = (xPoint *) malloc(npoint * sizeof(xPoint));
         memcpy((char *) origPts, (char *) &stuff[1], npoint * sizeof(xPoint));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1284,7 +1284,7 @@ int PanoramiXPolyPoint(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyPoint])(client);
 	    if(result != Success) break;
         }
-        DEALLOCATE_LOCAL(origPts);
+        free(origPts);
         return (result);
     } else
 	return (client->noClientException);
@@ -1315,7 +1315,7 @@ int PanoramiXPolyLine(ClientPtr client)
     isRoot = (draw->type == XRT_WINDOW) && draw->u.win.root;
     npoint = ((client->req_len << 2) - sizeof(xPolyLineReq)) >> 2;
     if (npoint > 0){
-        origPts = (xPoint *) ALLOCATE_LOCAL(npoint * sizeof(xPoint));
+        origPts = (xPoint *) malloc(npoint * sizeof(xPoint));
         memcpy((char *) origPts, (char *) &stuff[1], npoint * sizeof(xPoint));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1342,7 +1342,7 @@ int PanoramiXPolyLine(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyLine])(client);
 	    if(result != Success) break;
         }
-        DEALLOCATE_LOCAL(origPts);
+        free(origPts);
         return (result);
    } else
 	return (client->noClientException);
@@ -1376,7 +1376,7 @@ int PanoramiXPolySegment(ClientPtr client)
     if(nsegs & 4) return BadLength;
     nsegs >>= 3;
     if (nsegs > 0) {
-	origSegs = (xSegment *) ALLOCATE_LOCAL(nsegs * sizeof(xSegment));
+	origSegs = (xSegment *) malloc(nsegs * sizeof(xSegment));
         memcpy((char *) origSegs, (char *) &stuff[1], nsegs * sizeof(xSegment));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1403,7 +1403,7 @@ int PanoramiXPolySegment(ClientPtr client)
 	    result = (* SavedProcVector[X_PolySegment])(client);
 	    if(result != Success) break;
     	}
-	DEALLOCATE_LOCAL(origSegs);
+	free(origSegs);
 	return (result);
     } else
 	  return (client->noClientException);
@@ -1438,7 +1438,7 @@ int PanoramiXPolyRectangle(ClientPtr client)
     if(nrects & 4) return BadLength;
     nrects >>= 3;
     if (nrects > 0){
-	origRecs = (xRectangle *) ALLOCATE_LOCAL(nrects * sizeof(xRectangle));
+	origRecs = (xRectangle *) malloc(nrects * sizeof(xRectangle));
 	memcpy((char *)origRecs,(char *)&stuff[1],nrects * sizeof(xRectangle));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1464,7 +1464,7 @@ int PanoramiXPolyRectangle(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyRectangle])(client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(origRecs);
+	free(origRecs);
 	return (result);
     } else
        return (client->noClientException);
@@ -1498,7 +1498,7 @@ int PanoramiXPolyArc(ClientPtr client)
     if(narcs % sizeof(xArc)) return BadLength;
     narcs /= sizeof(xArc);
     if (narcs > 0){
-	origArcs = (xArc *) ALLOCATE_LOCAL(narcs * sizeof(xArc));
+	origArcs = (xArc *) malloc(narcs * sizeof(xArc));
 	memcpy((char *) origArcs, (char *) &stuff[1], narcs * sizeof(xArc));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1522,7 +1522,7 @@ int PanoramiXPolyArc(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyArc])(client);
 	    if(result != Success) break;
         }
-	DEALLOCATE_LOCAL(origArcs);
+	free(origArcs);
 	return (result);
     } else
        return (client->noClientException);
@@ -1554,7 +1554,7 @@ int PanoramiXFillPoly(ClientPtr client)
 
     count = ((client->req_len << 2) - sizeof(xFillPolyReq)) >> 2;
     if (count > 0){
-	locPts = (DDXPointPtr) ALLOCATE_LOCAL(count * sizeof(DDXPointRec));
+	locPts = (DDXPointPtr) malloc(count * sizeof(DDXPointRec));
 	memcpy((char *)locPts, (char *)&stuff[1], count * sizeof(DDXPointRec));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1581,7 +1581,7 @@ int PanoramiXFillPoly(ClientPtr client)
 	    result = (* SavedProcVector[X_FillPoly])(client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(locPts);
+	free(locPts);
 	return (result);
     } else
        return (client->noClientException);
@@ -1615,7 +1615,7 @@ int PanoramiXPolyFillRectangle(ClientPtr client)
     if(things & 4) return BadLength;
     things >>= 3;
     if (things > 0){
-	origRects = (xRectangle *) ALLOCATE_LOCAL(things * sizeof(xRectangle));
+	origRects = (xRectangle *) malloc(things * sizeof(xRectangle));
 	memcpy((char*)origRects,(char*)&stuff[1], things * sizeof(xRectangle));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1640,7 +1640,7 @@ int PanoramiXPolyFillRectangle(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyFillRectangle])(client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(origRects);
+	free(origRects);
 	return (result);
     } else
        return (client->noClientException);
@@ -1674,7 +1674,7 @@ int PanoramiXPolyFillArc(ClientPtr client)
     IF_RETURN((narcs % sizeof(xArc)), BadLength);
     narcs /= sizeof(xArc);
     if (narcs > 0) {
-	origArcs = (xArc *) ALLOCATE_LOCAL(narcs * sizeof(xArc));
+	origArcs = (xArc *) malloc(narcs * sizeof(xArc));
 	memcpy((char *) origArcs, (char *)&stuff[1], narcs * sizeof(xArc));
         FOR_NSCREENS_FORWARD(j){
 
@@ -1699,7 +1699,7 @@ int PanoramiXPolyFillArc(ClientPtr client)
 	    result = (* SavedProcVector[X_PolyFillArc])(client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(origArcs);
+	free(origArcs);
 	return (result);
     } else
        return (client->noClientException);

--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -595,7 +595,7 @@ CreateSaverWindow (pScreen)
     wantMap = wColormap (pWin);
     if (wantMap == None)
 	return TRUE;
-    installedMaps = (Colormap *) ALLOCATE_LOCAL (pScreen->maxInstalledCmaps *
+    installedMaps = (Colormap *) malloc (pScreen->maxInstalledCmaps *
 						 sizeof (Colormap));
     numInstalled = (*pWin->drawable.pScreen->ListInstalledColormaps)
 						    (pScreen, installedMaps);
@@ -603,7 +603,7 @@ CreateSaverWindow (pScreen)
 	if (installedMaps[i] == wantMap)
 	    break;
 
-    DEALLOCATE_LOCAL ((char *) installedMaps);
+    free ((char *) installedMaps);
 
     if (i < numInstalled)
 	return TRUE;

--- a/nx-X11/programs/Xserver/Xext/security.c
+++ b/nx-X11/programs/Xserver/Xext/security.c
@@ -1371,7 +1371,7 @@ SecurityCensorImage(client, pVisibleRegion, widthBytesLine, pDraw, x, y, w, h,
 
 	/* convert region to list-of-rectangles for PolyFillRect */
 
-	pRects = (xRectangle *)ALLOCATE_LOCAL(nRects * sizeof(xRectangle *));
+	pRects = (xRectangle *)malloc(nRects * sizeof(xRectangle *));
 	if (!pRects)
 	{
 	    failed = TRUE;
@@ -1423,7 +1423,7 @@ SecurityCensorImage(client, pVisibleRegion, widthBytesLine, pDraw, x, y, w, h,
 	     */
 	    bzero(pBuf, (int)(widthBytesLine * h));
 	}
-	if (pRects)     DEALLOCATE_LOCAL(pRects);
+	if (pRects)     free(pRects);
 	if (pScratchGC) FreeScratchGC(pScratchGC);
 	if (pPix)       FreeScratchPixmapHeader(pPix);
     }

--- a/nx-X11/programs/Xserver/Xext/shape.c
+++ b/nx-X11/programs/Xserver/Xext/shape.c
@@ -1044,7 +1044,7 @@ ProcShapeGetRectangles (client)
     }
     if (!region) {
 	nrects = 1;
-	rects = (xRectangle *) ALLOCATE_LOCAL (sizeof (xRectangle));
+	rects = (xRectangle *) malloc (sizeof (xRectangle));
 	if (!rects)
 	    return BadAlloc;
 	switch (stuff->kind) {
@@ -1071,7 +1071,7 @@ ProcShapeGetRectangles (client)
 	BoxPtr box;
 	nrects = RegionNumRects(region);
 	box = RegionRects(region);
-	rects = (xRectangle *) ALLOCATE_LOCAL (nrects * sizeof (xRectangle));
+	rects = (xRectangle *) malloc (nrects * sizeof (xRectangle));
 	if (!rects && nrects)
 	    return BadAlloc;
 	for (i = 0; i < nrects; i++, box++) {
@@ -1094,7 +1094,7 @@ ProcShapeGetRectangles (client)
     }
     WriteToClient (client, sizeof (rep), &rep);
     WriteToClient (client, nrects * sizeof (xRectangle), rects);
-    DEALLOCATE_LOCAL (rects);
+    free (rects);
     return client->noClientException;
 }
 

--- a/nx-X11/programs/Xserver/Xext/sync.c
+++ b/nx-X11/programs/Xserver/Xext/sync.c
@@ -578,7 +578,7 @@ SyncSendCounterNotifyEvents(client, ppAwait, num_events)
     if (client->clientGone)
 	return;
     pev = pEvents = (xSyncCounterNotifyEvent *)
-		 ALLOCATE_LOCAL(num_events * sizeof(xSyncCounterNotifyEvent));
+		 malloc(num_events * sizeof(xSyncCounterNotifyEvent));
     if (!pEvents) 
 	return;
     UpdateCurrentTime();
@@ -598,7 +598,7 @@ SyncSendCounterNotifyEvents(client, ppAwait, num_events)
     }
     /* swapping will be taken care of by this */
     WriteEventsToClient(client, num_events, (xEvent *)pEvents);
-    DEALLOCATE_LOCAL(pEvents);
+    free(pEvents);
 }
 
 
@@ -708,7 +708,7 @@ SyncAwaitTriggerFired(pTrigger)
 
     pAwaitUnion = (SyncAwaitUnion *)pAwait->pHeader;
     numwaits = pAwaitUnion->header.num_waitconditions;
-    ppAwait = (SyncAwait **)ALLOCATE_LOCAL(numwaits * sizeof(SyncAwait *));
+    ppAwait = (SyncAwait **)malloc(numwaits * sizeof(SyncAwait *));
     if (!ppAwait)
 	goto bail;
 
@@ -777,7 +777,7 @@ SyncAwaitTriggerFired(pTrigger)
     if (num_events)
 	SyncSendCounterNotifyEvents(pAwaitUnion->header.client, ppAwait,
 				    num_events);
-    DEALLOCATE_LOCAL(ppAwait);
+    free(ppAwait);
 
 bail:
     /* unblock the client */
@@ -1371,7 +1371,7 @@ ProcSyncListSystemCounters(client)
 
     if (len)
     {
-	walklist = list = (xSyncSystemCounter *) ALLOCATE_LOCAL(len);
+	walklist = list = (xSyncSystemCounter *) malloc(len);
 	if (!list)
 	    return BadAlloc;
     }
@@ -1415,7 +1415,7 @@ ProcSyncListSystemCounters(client)
     if (len) 
     {
 	WriteToClient(client, len, list);
-	DEALLOCATE_LOCAL(list);
+	free(list);
     }
 
     return (client->noClientException);

--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
@@ -66,7 +66,6 @@
 #include <nx-X11/X.h>
 #include <nx-X11/Xproto.h>
 #include "misc.h"
-#include "os.h"
 #include "dixstruct.h"
 #include "gcstruct.h"
 #include "dixfontstr.h"
@@ -491,7 +490,7 @@ ProcXF86BigfontQueryFont(
 	    } else {
 #endif
 		pCI = (xCharInfo *)
-		      ALLOCATE_LOCAL(nCharInfos * sizeof(xCharInfo));
+		      malloc(nCharInfos * sizeof(xCharInfo));
 		if (!pCI)
 		    return BadAlloc;
 #ifdef HAS_SHM
@@ -554,9 +553,9 @@ ProcXF86BigfontQueryFont(
 		hashModulus = nCharInfos+1;
 
 	    tmp = (CARD16*)
-		  ALLOCATE_LOCAL((4*nCharInfos+1) * sizeof(CARD16));
+		  malloc((4*nCharInfos+1) * sizeof(CARD16));
 	    if (!tmp) {
-		if (!pDesc) DEALLOCATE_LOCAL(pCI);
+		if (!pDesc) free(pCI);
 		return BadAlloc;
 	    }
 	    pIndex2UniqIndex = tmp;
@@ -643,8 +642,8 @@ ProcXF86BigfontQueryFont(
 	char* p;
 	if (!reply) {
 	    if (nCharInfos > 0) {
-		if (shmid == -1) DEALLOCATE_LOCAL(pIndex2UniqIndex);
-		if (!pDesc) DEALLOCATE_LOCAL(pCI);
+		if (shmid == -1) free(pIndex2UniqIndex);
+		if (!pDesc) free(pCI);
 	    }
 	    return BadAlloc;
 	}
@@ -721,8 +720,8 @@ ProcXF86BigfontQueryFont(
 	WriteToClient(client, rlength, reply);
 	free(reply);
 	if (nCharInfos > 0) {
-	    if (shmid == -1) DEALLOCATE_LOCAL(pIndex2UniqIndex);
-	    if (!pDesc) DEALLOCATE_LOCAL(pCI);
+	    if (shmid == -1) free(pIndex2UniqIndex);
+	    if (!pDesc) free(pCI);
 	}
 	return (client->noClientException);
     }

--- a/nx-X11/programs/Xserver/Xext/xres.c
+++ b/nx-X11/programs/Xserver/Xext/xres.c
@@ -49,7 +49,7 @@ ProcXResQueryClients (ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXResQueryClientsReq);
 
-    current_clients = ALLOCATE_LOCAL((currentMaxClients - 1) * sizeof(int));
+    current_clients = malloc((currentMaxClients - 1) * sizeof(int));
 
     num_clients = 0;
     for(i = 1; i < currentMaxClients; i++) {
@@ -85,7 +85,7 @@ ProcXResQueryClients (ClientPtr client)
         }
     }
 
-    DEALLOCATE_LOCAL(current_clients);
+    free(current_clients);
 
     return (client->noClientException);
 }
@@ -118,7 +118,7 @@ ProcXResQueryClientResources (ClientPtr client)
         return BadValue;
     }
 
-    counts = ALLOCATE_LOCAL((lastResourceType + 1) * sizeof(int));
+    counts = malloc((lastResourceType + 1) * sizeof(int));
 
     memset(counts, 0, (lastResourceType + 1) * sizeof(int));
 
@@ -164,7 +164,7 @@ ProcXResQueryClientResources (ClientPtr client)
         }
     }
 
-    DEALLOCATE_LOCAL(counts);
+    free(counts);
     
     return (client->noClientException);
 }

--- a/nx-X11/programs/Xserver/Xi/gtmotion.c
+++ b/nx-X11/programs/Xserver/Xi/gtmotion.c
@@ -147,7 +147,7 @@ ProcXGetDeviceMotionEvents(client)
     {
 	size = sizeof(Time) + (axes * sizeof (INT32));
 	tsize = num_events * size;
-	coords = (INT32 *) ALLOCATE_LOCAL(tsize);
+	coords = (INT32 *) malloc(tsize);
 	if (!coords)
 	    {
 	    SendErrorToClient(client, IReqCode, X_GetDeviceMotionEvents, 0, 
@@ -179,7 +179,7 @@ ProcXGetDeviceMotionEvents(client)
 	WriteToClient(client, length * 4, coords);
         }
     if (coords)
-	DEALLOCATE_LOCAL(coords);
+	free(coords);
     return Success;
 }
 

--- a/nx-X11/programs/Xserver/dix/colormap.c
+++ b/nx-X11/programs/Xserver/dix/colormap.c
@@ -740,7 +740,7 @@ UpdateColors (ColormapPtr pmap)
 
     pVisual = pmap->pVisual;
     size = pVisual->ColormapEntries;
-    defs = (xColorItem *)ALLOCATE_LOCAL(size * sizeof(xColorItem));
+    defs = (xColorItem *)malloc(size * sizeof(xColorItem));
     if (!defs)
 	return;
     n = 0;
@@ -790,7 +790,7 @@ UpdateColors (ColormapPtr pmap)
     }
     if (n)
 	(*pmap->pScreen->StoreColors)(pmap, n, defs);
-    DEALLOCATE_LOCAL(defs);
+    free(defs);
 }
 
 /* Get a read-only color from a ColorMap (probably slow for large maps)
@@ -1741,14 +1741,14 @@ AllocDirect (int client, ColormapPtr pmap, int c, int r, int g, int b, Bool cont
     for(p = pixels; p < pixels + c; p++)
 	*p = 0;
 
-    ppixRed = (Pixel *)ALLOCATE_LOCAL(npixR * sizeof(Pixel));
-    ppixGreen = (Pixel *)ALLOCATE_LOCAL(npixG * sizeof(Pixel));
-    ppixBlue = (Pixel *)ALLOCATE_LOCAL(npixB * sizeof(Pixel));
+    ppixRed = (Pixel *)malloc(npixR * sizeof(Pixel));
+    ppixGreen = (Pixel *)malloc(npixG * sizeof(Pixel));
+    ppixBlue = (Pixel *)malloc(npixB * sizeof(Pixel));
     if (!ppixRed || !ppixGreen || !ppixBlue)
     {
-	if (ppixBlue) DEALLOCATE_LOCAL(ppixBlue);
-	if (ppixGreen) DEALLOCATE_LOCAL(ppixGreen);
-	if (ppixRed) DEALLOCATE_LOCAL(ppixRed);
+	if (ppixBlue) free(ppixBlue);
+	if (ppixGreen) free(ppixGreen);
+	if (ppixRed) free(ppixRed);
 	return(BadAlloc);
     }
 
@@ -1786,9 +1786,9 @@ AllocDirect (int client, ColormapPtr pmap, int c, int r, int g, int b, Bool cont
 	if (okB)
 	    for(ppix = ppixBlue, npix = npixB; --npix >= 0; ppix++)
 		pmap->blue[*ppix].refcnt = 0;
-	DEALLOCATE_LOCAL(ppixBlue);
-	DEALLOCATE_LOCAL(ppixGreen);
-	DEALLOCATE_LOCAL(ppixRed);
+	free(ppixBlue);
+	free(ppixGreen);
+	free(ppixRed);
 	return(BadAlloc);
     }
 
@@ -1830,9 +1830,9 @@ AllocDirect (int client, ColormapPtr pmap, int c, int r, int g, int b, Bool cont
     for (pDst = pixels; pDst < pixels + c; pDst++)
 	*pDst |= ALPHAMASK(pmap->pVisual);
 
-    DEALLOCATE_LOCAL(ppixBlue);
-    DEALLOCATE_LOCAL(ppixGreen);
-    DEALLOCATE_LOCAL(ppixRed);
+    free(ppixBlue);
+    free(ppixGreen);
+    free(ppixRed);
 
     return (Success);
 }
@@ -1848,7 +1848,7 @@ AllocPseudo (int client, ColormapPtr pmap, int c, int r, Bool contig,
     npix = c << r;
     if ((r >= 32) || (npix > pmap->freeRed) || (npix < c))
 	return(BadAlloc);
-    if(!(ppixTemp = (Pixel *)ALLOCATE_LOCAL(npix * sizeof(Pixel))))
+    if(!(ppixTemp = (Pixel *)malloc(npix * sizeof(Pixel))))
 	return(BadAlloc);
     ok = AllocCP(pmap, pmap->red, c, r, contig, ppixTemp, pmask);
 
@@ -1878,7 +1878,7 @@ AllocPseudo (int client, ColormapPtr pmap, int c, int r, Bool contig,
 	pmap->numPixelsRed[client] += npix;
 	pmap->freeRed -= npix;
     }
-    DEALLOCATE_LOCAL(ppixTemp);
+    free(ppixTemp);
     return (ok ? Success : BadAlloc);
 }
 
@@ -2078,7 +2078,7 @@ AllocShared (ColormapPtr pmap, Pixel *ppix, int c, int r, int g, int b,
 
     npixClientNew = c << (r + g + b);
     npixShared = (c << r) + (c << g) + (c << b);
-    psharedList = (SHAREDCOLOR **)ALLOCATE_LOCAL(npixShared *
+    psharedList = (SHAREDCOLOR **)malloc(npixShared *
 						 sizeof(SHAREDCOLOR *));
     if (!psharedList)
 	return FALSE;
@@ -2193,7 +2193,7 @@ AllocShared (ColormapPtr pmap, Pixel *ppix, int c, int r, int g, int b,
 	    }
 	}
     }
-    DEALLOCATE_LOCAL(psharedList);
+    free(psharedList);
     return TRUE;
 }
 
@@ -2667,7 +2667,7 @@ IsMapInstalled(Colormap map, WindowPtr pWin)
     Colormap	*pmaps;
     int		imap, nummaps, found;
 
-    pmaps = (Colormap *) ALLOCATE_LOCAL( 
+    pmaps = (Colormap *) malloc(
              pWin->drawable.pScreen->maxInstalledCmaps * sizeof(Colormap));
     if(!pmaps)
 	return(FALSE);
@@ -2682,7 +2682,7 @@ IsMapInstalled(Colormap map, WindowPtr pWin)
 	    break;
 	}
     }
-    DEALLOCATE_LOCAL(pmaps);
+    free(pmaps);
     return (found);
 }
 

--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -1547,7 +1547,7 @@ ProcGetMotionEvents(ClientPtr client)
     {
 	if (CompareTimeStamps(stop, currentTime) == LATER)
 	    stop = currentTime;
-	coords = (xTimecoord *)ALLOCATE_LOCAL(mouse->valuator->numMotionEvents
+	coords = (xTimecoord *)malloc(mouse->valuator->numMotionEvents
 					      * sizeof(xTimecoord));
 	if (!coords)
 	    return BadAlloc;
@@ -1581,7 +1581,7 @@ ProcGetMotionEvents(ClientPtr client)
 				 (char *)coords);
     }
     if (coords)
-	DEALLOCATE_LOCAL(coords);
+	free(coords);
     return Success;
 }
 

--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -334,7 +334,7 @@ Dispatch(void)
     InitSelections();
     nClients = 0;
 
-    clientReady = (int *) ALLOCATE_LOCAL(sizeof(int) * MaxClients);
+    clientReady = (int *) malloc(sizeof(int) * MaxClients);
     if (!clientReady)
 	return;
 
@@ -439,7 +439,7 @@ Dispatch(void)
     ddxBeforeReset ();
 #endif
     KillAllClients();
-    DEALLOCATE_LOCAL(clientReady);
+    free(clientReady);
     dispatchException &= ~DE_RESET;
 }
 
@@ -830,7 +830,7 @@ ProcQueryTree(register ClientPtr client)
     {
 	int curChild = 0;
 
-	childIDs = (Window *) ALLOCATE_LOCAL(numChildren * sizeof(Window));
+	childIDs = (Window *) malloc(numChildren * sizeof(Window));
 	if (!childIDs)
 	    return BadAlloc;
 	for (pChild = pWin->lastChild; pChild != pHead; pChild = pChild->prevSib)
@@ -845,7 +845,7 @@ ProcQueryTree(register ClientPtr client)
     {
     	client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
 	WriteSwappedDataToClient(client, numChildren * sizeof(Window), childIDs);
-	DEALLOCATE_LOCAL(childIDs);
+	free(childIDs);
     }
 
     return(client->noClientException);
@@ -1336,7 +1336,7 @@ ProcQueryFont(register ClientPtr client)
 	             FONTINFONPROPS(FONTCHARSET(pFont)) * sizeof(xFontProp)  +
 		     nprotoxcistructs * sizeof(xCharInfo);
 
-	reply = (xQueryFontReply *)ALLOCATE_LOCAL(rlength);
+	reply = (xQueryFontReply *)malloc(rlength);
 	if(!reply)
 	{
 	    return(BadAlloc);
@@ -1349,7 +1349,7 @@ ProcQueryFont(register ClientPtr client)
 	QueryFont( pFont, reply, nprotoxcistructs);
 
         WriteReplyToClient(client, rlength, reply);
-	DEALLOCATE_LOCAL(reply);
+	free(reply);
 	return(client->noClientException);
     }
 }
@@ -2182,7 +2182,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 		length += widthBytesLine;
 	    }
 	}
-	if(!(pBuf = (char *) ALLOCATE_LOCAL(length)))
+	if(!(pBuf = (char *) malloc(length)))
 	    return (BadAlloc);
 	memset(pBuf, 0, length);
 	WriteReplyToClient(client, sizeof (xGetImageReply), &xgi);
@@ -2292,7 +2292,7 @@ DoGetImage(register ClientPtr client, int format, Drawable drawable,
 	RegionDestroy(pVisibleRegion);
 #endif
     if (!im_return)
-	DEALLOCATE_LOCAL(pBuf);
+	free(pBuf);
     return (client->noClientException);
 }
 
@@ -2552,7 +2552,7 @@ ProcListInstalledColormaps(register ClientPtr client)
         return(BadWindow);
 
     preply = (xListInstalledColormapsReply *) 
-		ALLOCATE_LOCAL(sizeof(xListInstalledColormapsReply) +
+		malloc(sizeof(xListInstalledColormapsReply) +
 		     pWin->drawable.pScreen->maxInstalledCmaps *
 		     sizeof(Colormap));
     if(!preply)
@@ -2567,7 +2567,7 @@ ProcListInstalledColormaps(register ClientPtr client)
     WriteReplyToClient(client, sizeof (xListInstalledColormapsReply), preply);
     client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
     WriteSwappedDataToClient(client, nummaps * sizeof(Colormap), &preply[1]);
-    DEALLOCATE_LOCAL(preply);
+    free(preply);
     return(client->noClientException);
 }
 
@@ -2695,7 +2695,7 @@ ProcAllocColorCells (register ClientPtr client)
 	}
 	nmasks = stuff->planes;
 	length = ((long)npixels + (long)nmasks) * sizeof(Pixel);
-	ppixels = (Pixel *)ALLOCATE_LOCAL(length);
+	ppixels = (Pixel *)malloc(length);
 	if(!ppixels)
             return(BadAlloc);
 	pmasks = ppixels + npixels;
@@ -2703,7 +2703,7 @@ ProcAllocColorCells (register ClientPtr client)
 	if( (retval = AllocColorCells(client->index, pcmp, npixels, nmasks, 
 				    (Bool)stuff->contiguous, ppixels, pmasks)) )
 	{
-	    DEALLOCATE_LOCAL(ppixels);
+	    free(ppixels);
             if (client->noClientException != Success)
                 return(client->noClientException);
 	    else
@@ -2722,7 +2722,7 @@ ProcAllocColorCells (register ClientPtr client)
 	    client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
 	    WriteSwappedDataToClient(client, length, ppixels);
 	}
-	DEALLOCATE_LOCAL(ppixels);
+	free(ppixels);
         return (client->noClientException);        
     }
     else
@@ -2763,7 +2763,7 @@ ProcAllocColorPlanes(register ClientPtr client)
 	acpr.sequenceNumber = client->sequence;
 	acpr.nPixels = npixels;
 	length = (long)npixels * sizeof(Pixel);
-	ppixels = (Pixel *)ALLOCATE_LOCAL(length);
+	ppixels = (Pixel *)malloc(length);
 	if(!ppixels)
             return(BadAlloc);
 	if( (retval = AllocColorPlanes(client->index, pcmp, npixels,
@@ -2771,7 +2771,7 @@ ProcAllocColorPlanes(register ClientPtr client)
 	    (Bool)stuff->contiguous, ppixels,
 	    &acpr.redMask, &acpr.greenMask, &acpr.blueMask)) )
 	{
-            DEALLOCATE_LOCAL(ppixels);
+            free(ppixels);
             if (client->noClientException != Success)
                 return(client->noClientException);
 	    else
@@ -2786,7 +2786,7 @@ ProcAllocColorPlanes(register ClientPtr client)
 	    client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
 	    WriteSwappedDataToClient(client, length, ppixels);
 	}
-	DEALLOCATE_LOCAL(ppixels);
+	free(ppixels);
         return (client->noClientException);        
     }
     else
@@ -2915,13 +2915,13 @@ ProcQueryColors(register ClientPtr client)
 	xQueryColorsReply	qcr;
 
 	count = ((client->req_len << 2) - sizeof(xQueryColorsReq)) >> 2;
-	prgbs = (xrgb *)ALLOCATE_LOCAL(count * sizeof(xrgb));
+	prgbs = (xrgb *)malloc(count * sizeof(xrgb));
 	if(!prgbs && count)
             return(BadAlloc);
 	memset(prgbs, 0, count * sizeof(xrgb));
 	if( (retval = QueryColors(pcmp, count, (Pixel *)&stuff[1], prgbs)) )
 	{
-   	    if (prgbs) DEALLOCATE_LOCAL(prgbs);
+	    if (prgbs) free(prgbs);
 	    if (client->noClientException != Success)
                 return(client->noClientException);
 	    else
@@ -2942,7 +2942,7 @@ ProcQueryColors(register ClientPtr client)
 	    client->pSwapReplyFunc = (ReplySwapPtr) SQColorsExtend;
 	    WriteSwappedDataToClient(client, count * sizeof(xrgb), prgbs);
 	}
-	if (prgbs) DEALLOCATE_LOCAL(prgbs);
+	if (prgbs) free(prgbs);
 	return(client->noClientException);
 	
     }

--- a/nx-X11/programs/Xserver/dix/dixfonts.c
+++ b/nx-X11/programs/Xserver/dix/dixfonts.c
@@ -793,7 +793,7 @@ finish:
     reply.nFonts = nnames;
     reply.sequenceNumber = client->sequence;
 
-    bufptr = bufferStart = (char *) ALLOCATE_LOCAL(reply.length << 2);
+    bufptr = bufferStart = (char *) malloc(reply.length << 2);
 
     if (!bufptr && reply.length) {
 	SendErrorToClient(client, X_ListFonts, 0, 0, BadAlloc);
@@ -818,7 +818,7 @@ finish:
     client->pSwapReplyFunc = ReplySwapVector[X_ListFonts];
     WriteSwappedDataToClient(client, sizeof(xListFontsReply), &reply);
     WriteToClient(client, stringLens + nnames, bufferStart);
-    DEALLOCATE_LOCAL(bufferStart);
+    free(bufferStart);
 
 bail:
     if (c->slept)
@@ -1861,7 +1861,7 @@ SetDefaultFontPath(char *path)
 
     /* get enough for string, plus values -- use up commas */
     len = strlen(temp_path) + 1;
-    nump = cp = newpath = (unsigned char *) ALLOCATE_LOCAL(len);
+    nump = cp = newpath = (unsigned char *) malloc(len);
     if (!newpath) {
 	free(temp_path);
 	return BadAlloc;
@@ -1884,7 +1884,7 @@ SetDefaultFontPath(char *path)
 
     err = SetFontPathElements(num, newpath, &bad, TRUE);
 
-    DEALLOCATE_LOCAL(newpath);
+    free(newpath);
     free(temp_path);
 
     return err;

--- a/nx-X11/programs/Xserver/dix/extension.c
+++ b/nx-X11/programs/Xserver/dix/extension.c
@@ -358,7 +358,7 @@ ProcListExtensions(ClientPtr client)
 		total_length += strlen(extensions[i]->aliases[j]) + 1;
 	}
         reply.length = (total_length + 3) >> 2;
-	buffer = bufptr = (char *)ALLOCATE_LOCAL(total_length);
+	buffer = bufptr = (char *)malloc(total_length);
 	if (!buffer)
 	    return(BadAlloc);
         for (i=0;  i<NumExtensions; i++)
@@ -384,7 +384,7 @@ ProcListExtensions(ClientPtr client)
     if (reply.length)
     {
         WriteToClient(client, total_length, buffer);
-    	DEALLOCATE_LOCAL(buffer);
+        free(buffer);
     }
     return(client->noClientException);
 }

--- a/nx-X11/programs/Xserver/dix/grabs.c
+++ b/nx-X11/programs/Xserver/dix/grabs.c
@@ -321,16 +321,16 @@ DeletePassiveGrabFromList(GrabPtr pMinuendGrab)
 	i++;
     if (!i)
 	return TRUE;
-    deletes = (GrabPtr *)ALLOCATE_LOCAL(i * sizeof(GrabPtr));
-    adds = (GrabPtr *)ALLOCATE_LOCAL(i * sizeof(GrabPtr));
-    updates = (Mask ***)ALLOCATE_LOCAL(i * sizeof(Mask **));
-    details = (Mask **)ALLOCATE_LOCAL(i * sizeof(Mask *));
+    deletes = (GrabPtr *)malloc(i * sizeof(GrabPtr));
+    adds = (GrabPtr *)malloc(i * sizeof(GrabPtr));
+    updates = (Mask ***)malloc(i * sizeof(Mask **));
+    details = (Mask **)malloc(i * sizeof(Mask *));
     if (!deletes || !adds || !updates || !details)
     {
-	if (details) DEALLOCATE_LOCAL(details);
-	if (updates) DEALLOCATE_LOCAL(updates);
-	if (adds) DEALLOCATE_LOCAL(adds);
-	if (deletes) DEALLOCATE_LOCAL(deletes);
+	if (details) free(details);
+	if (updates) free(updates);
+	if (adds) free(adds);
+	if (deletes) free(deletes);
 	return FALSE;
     }
     ndels = nadds = nups = 0;
@@ -425,10 +425,10 @@ DeletePassiveGrabFromList(GrabPtr pMinuendGrab)
 	    *updates[i] = details[i];
 	}
     }
-    DEALLOCATE_LOCAL(details);
-    DEALLOCATE_LOCAL(updates);
-    DEALLOCATE_LOCAL(adds);
-    DEALLOCATE_LOCAL(deletes);
+    free(details);
+    free(updates);
+    free(adds);
+    free(deletes);
     return ok;
 
 #undef UPDATE

--- a/nx-X11/programs/Xserver/dix/property.c
+++ b/nx-X11/programs/Xserver/dix/property.c
@@ -111,7 +111,7 @@ ProcRotateProperties(ClientPtr client)
     if (!stuff->nAtoms)
 	return(Success);
     atoms = (Atom *) & stuff[1];
-    props = (PropertyPtr *)ALLOCATE_LOCAL(stuff->nAtoms * sizeof(PropertyPtr));
+    props = (PropertyPtr *)malloc(stuff->nAtoms * sizeof(PropertyPtr));
     if (!props)
 	return(BadAlloc);
     for (i = 0; i < stuff->nAtoms; i++)
@@ -126,21 +126,21 @@ ProcRotateProperties(ClientPtr client)
 #endif
 	   )
         {
-            DEALLOCATE_LOCAL(props);
+            free(props);
 	    client->errorValue = atoms[i];
             return BadAtom;
         }
 #ifdef XCSECURITY
 	if (SecurityIgnoreOperation == action)
         {
-            DEALLOCATE_LOCAL(props);
+            free(props);
 	    return Success;
 	}
 #endif
         for (j = i + 1; j < stuff->nAtoms; j++)
             if (atoms[j] == atoms[i])
             {
-                DEALLOCATE_LOCAL(props);
+                free(props);
                 return BadMatch;
             }
         pProp = wUserProps (pWin);
@@ -150,7 +150,7 @@ ProcRotateProperties(ClientPtr client)
                 goto found;
 	    pProp = pProp->next;
         }
-        DEALLOCATE_LOCAL(props);
+        free(props);
         return BadMatch;
 found: 
         props[i] = pProp;
@@ -181,7 +181,7 @@ found:
             props[i]->propertyName = atoms[(i + delta) % stuff->nAtoms];
 	}
     }
-    DEALLOCATE_LOCAL(props);
+    free(props);
     return Success;
 }
 
@@ -630,7 +630,7 @@ ProcListProperties(ClientPtr client)
 	numProps++;
     }
     if (numProps)
-        if(!(pAtoms = (Atom *)ALLOCATE_LOCAL(numProps * sizeof(Atom))))
+        if(!(pAtoms = (Atom *)malloc(numProps * sizeof(Atom))))
             return(BadAlloc);
 
     memset(&xlpr, 0, sizeof(xListPropertiesReply));
@@ -650,7 +650,7 @@ ProcListProperties(ClientPtr client)
     {
         client->pSwapReplyFunc = (ReplySwapPtr)Swap32Write;
         WriteSwappedDataToClient(client, numProps * sizeof(Atom), pAtoms);
-        DEALLOCATE_LOCAL(pAtoms);
+        free(pAtoms);
     }
     return(client->noClientException);
 }

--- a/nx-X11/programs/Xserver/dix/resource.c
+++ b/nx-X11/programs/Xserver/dix/resource.c
@@ -470,13 +470,13 @@ RebuildTable(int client)
      */
 
     j = 2 * clientTable[client].buckets;
-    tails = (ResourcePtr **)ALLOCATE_LOCAL(j * sizeof(ResourcePtr *));
+    tails = (ResourcePtr **)malloc(j * sizeof(ResourcePtr *));
     if (!tails)
 	return;
     resources = (ResourcePtr *)malloc(j * sizeof(ResourcePtr));
     if (!resources)
     {
-	DEALLOCATE_LOCAL(tails);
+	free(tails);
 	return;
     }
     for (rptr = resources, tptr = tails; --j >= 0; rptr++, tptr++)
@@ -499,7 +499,7 @@ RebuildTable(int client)
 	    *tptr = &res->next;
 	}
     }
-    DEALLOCATE_LOCAL(tails);
+    free(tails);
     clientTable[client].buckets *= 2;
     free(clientTable[client].resources);
     clientTable[client].resources = resources;

--- a/nx-X11/programs/Xserver/dix/swaprep.c
+++ b/nx-X11/programs/Xserver/dix/swaprep.c
@@ -98,7 +98,7 @@ CopySwap32Write(ClientPtr pClient, int size, CARD32 *pbuf)
     CARD32 tmpbuf[1];
     
     /* Allocate as big a buffer as we can... */
-    while (!(pbufT = (CARD32 *) ALLOCATE_LOCAL(bufsize)))
+    while (!(pbufT = (CARD32 *) malloc(bufsize)))
     {
         bufsize >>= 1;
 	if (bufsize == 4)
@@ -130,7 +130,7 @@ CopySwap32Write(ClientPtr pClient, int size, CARD32 *pbuf)
 	}
 
     if (pbufT != tmpbuf)
-	DEALLOCATE_LOCAL ((char *) pbufT);
+	free ((char *) pbufT);
 }
 
 /**
@@ -146,7 +146,7 @@ CopySwap16Write(ClientPtr pClient, int size, short *pbuf)
     short tmpbuf[2];
     
     /* Allocate as big a buffer as we can... */
-    while (!(pbufT = (short *) ALLOCATE_LOCAL(bufsize)))
+    while (!(pbufT = (short *) malloc(bufsize)))
     {
         bufsize >>= 1;
 	if (bufsize == 4)
@@ -178,7 +178,7 @@ CopySwap16Write(ClientPtr pClient, int size, short *pbuf)
 	}
 
     if (pbufT != tmpbuf)
-	DEALLOCATE_LOCAL ((char *) pbufT);
+	free ((char *) pbufT);
 }
 
 
@@ -1137,7 +1137,7 @@ WriteSConnectionInfo(ClientPtr pClient, unsigned long size, char *pInfo)
 {
     char	*pInfoTBase;
 
-    pInfoTBase = (char *) ALLOCATE_LOCAL(size);
+    pInfoTBase = (char *) malloc(size);
     if (!pInfoTBase)
     {
 	pClient->noClientException = -1;
@@ -1145,7 +1145,7 @@ WriteSConnectionInfo(ClientPtr pClient, unsigned long size, char *pInfo)
     }
     SwapConnSetupInfo(pInfo, pInfoTBase);
     WriteToClient(pClient, (int)size, pInfoTBase);
-    DEALLOCATE_LOCAL(pInfoTBase);
+    free(pInfoTBase);
 }
 
 void

--- a/nx-X11/programs/Xserver/fb/fbcopy.c
+++ b/nx-X11/programs/Xserver/fb/fbcopy.c
@@ -298,7 +298,7 @@ fbCopyRegion (DrawablePtr   pSrcDrawable,
 	if (nbox > 1)
 	{
 	    /* keep ordering in each band, reverse order of bands */
-	    pboxNew1 = (BoxPtr)ALLOCATE_LOCAL(sizeof(BoxRec) * nbox);
+	    pboxNew1 = (BoxPtr)malloc(sizeof(BoxRec) * nbox);
 	    if(!pboxNew1)
 		return;
 	    pboxBase = pboxNext = pbox+nbox-1;
@@ -335,11 +335,11 @@ fbCopyRegion (DrawablePtr   pSrcDrawable,
 	if (nbox > 1)
 	{
 	    /* reverse order of rects in each band */
-	    pboxNew2 = (BoxPtr)ALLOCATE_LOCAL(sizeof(BoxRec) * nbox);
+	    pboxNew2 = (BoxPtr)malloc(sizeof(BoxRec) * nbox);
 	    if(!pboxNew2)
 	    {
 		if (pboxNew1)
-		    DEALLOCATE_LOCAL(pboxNew1);
+		    free(pboxNew1);
 		return;
 	    }
 	    pboxBase = pboxNext = pbox;
@@ -374,9 +374,9 @@ fbCopyRegion (DrawablePtr   pSrcDrawable,
 		 reverse, upsidedown, bitPlane, closure);
     
     if (pboxNew1)
-	DEALLOCATE_LOCAL (pboxNew1);
+	free (pboxNew1);
     if (pboxNew2)
-	DEALLOCATE_LOCAL (pboxNew2);
+	free (pboxNew2);
 }
 
 RegionPtr

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdamage.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdamage.c
@@ -112,7 +112,7 @@ damageText (DrawablePtr	    pDrawable,
 
     imageblt = (textType == TT_IMAGE8) || (textType == TT_IMAGE16);
 
-    charinfo = (CharInfoPtr *) ALLOCATE_LOCAL(count * sizeof(CharInfoPtr));
+    charinfo = (CharInfoPtr *) malloc(count * sizeof(CharInfoPtr));
     if (!charinfo)
 	return x;
 
@@ -139,7 +139,7 @@ damageText (DrawablePtr	    pDrawable,
 #endif
 
     }
-    DEALLOCATE_LOCAL(charinfo);
+    free(charinfo);
     return x + w;
 }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -274,7 +274,7 @@ Dispatch(void)
 
     #endif
 
-    clientReady = (int *) ALLOCATE_LOCAL(sizeof(int) * MaxClients);
+    clientReady = (int *) malloc(sizeof(int) * MaxClients);
     if (!clientReady)
 	return;
 
@@ -571,7 +571,7 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
     saveAgentState("TERMINATED");
 
     KillAllClients();
-    DEALLOCATE_LOCAL(clientReady);
+    free(clientReady);
     dispatchException &= ~DE_RESET;
 }
 
@@ -653,7 +653,7 @@ ProcQueryTree(register ClientPtr client)
     {
 	int curChild = 0;
 
-	childIDs = (Window *) ALLOCATE_LOCAL(numChildren * sizeof(Window));
+	childIDs = (Window *) malloc(numChildren * sizeof(Window));
 	if (!childIDs)
 	    return BadAlloc;
 	for (pChild = pWin->lastChild; pChild != pHead; pChild = pChild->prevSib)
@@ -673,7 +673,7 @@ ProcQueryTree(register ClientPtr client)
     {
     	client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
 	WriteSwappedDataToClient(client, numChildren * sizeof(Window), childIDs);
-	DEALLOCATE_LOCAL(childIDs);
+	free(childIDs);
     }
 
     return(client->noClientException);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdixfonts.c
@@ -564,7 +564,7 @@ finish:
     reply.nFonts = nnames;
     reply.sequenceNumber = client->sequence;
 
-    bufptr = bufferStart = (char *) ALLOCATE_LOCAL(reply.length << 2);
+    bufptr = bufferStart = (char *) malloc(reply.length << 2);
 
     if (!bufptr && reply.length) {
 	SendErrorToClient(client, X_ListFonts, 0, 0, BadAlloc);
@@ -607,7 +607,7 @@ finish:
     client->pSwapReplyFunc = ReplySwapVector[X_ListFonts];
     WriteSwappedDataToClient(client, sizeof(xListFontsReply), &reply);
     WriteToClient(client, stringLens + nnames, bufferStart);
-    DEALLOCATE_LOCAL(bufferStart);
+    free(bufferStart);
 
 bail:
     if (c->slept)
@@ -968,7 +968,7 @@ SetDefaultFontPath(char *path)
 
     /* get enough for string, plus values -- use up commas */
     len = strlen(temp_path) + 1;
-    nump = cp = newpath = (unsigned char *) ALLOCATE_LOCAL(len);
+    nump = cp = newpath = (unsigned char *) malloc(len);
     if (!newpath) {
 	free(temp_path);
 	return BadAlloc;
@@ -991,7 +991,7 @@ SetDefaultFontPath(char *path)
 
     err = SetFontPathElements(num, newpath, &bad, TRUE);
 
-    DEALLOCATE_LOCAL(newpath);
+    free(newpath);
     free(temp_path);
 
     return err;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXextension.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXextension.c
@@ -163,7 +163,7 @@ ProcListExtensions(ClientPtr client)
 		total_length += strlen(extensions[i]->aliases[j]) + 1;
 	}
         reply.length = (total_length + 3) >> 2;
-	buffer = bufptr = (char *)ALLOCATE_LOCAL(total_length);
+	buffer = bufptr = (char *)malloc(total_length);
 	if (!buffer)
 	    return(BadAlloc);
         for (i=0;  i<NumExtensions; i++)
@@ -189,7 +189,7 @@ ProcListExtensions(ClientPtr client)
     if (reply.length)
     {
         WriteToClient(client, total_length, buffer);
-    	DEALLOCATE_LOCAL(buffer);
+        free(buffer);
     }
     return(client->noClientException);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
@@ -566,7 +566,7 @@ int what;
 	}
     }
 
-    prect = (xRectangle *)ALLOCATE_LOCAL(RegionNumRects(prgn) *
+    prect = (xRectangle *)malloc(RegionNumRects(prgn) *
 					 sizeof(xRectangle));
     if (!prect)
 	return;
@@ -591,7 +591,7 @@ int what;
 	pGC = GetScratchGC(pWin->drawable.depth, pWin->drawable.pScreen);
 	if (!pGC)
 	{
-	    DEALLOCATE_LOCAL(prect);
+	    free(prect);
 	    return;
 	}
 	/*
@@ -723,7 +723,7 @@ int what;
     }
     prect -= numRects;
     (*pGC->ops->PolyFillRect)((DrawablePtr)pWin, pGC, numRects, prect);
-    DEALLOCATE_LOCAL(prect);
+    free(prect);
 
     if (pWin->backStorage)
 	(*pWin->drawable.pScreen->DrawGuarantee) (pWin, pGC, GuaranteeNothing);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -987,7 +987,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	glyphsBase = glyphsLocal;
     else
     {
-	glyphsBase = (GlyphPtr *) ALLOCATE_LOCAL (nglyph * sizeof (GlyphPtr));
+	glyphsBase = (GlyphPtr *) malloc (nglyph * sizeof (GlyphPtr));
 	if (!glyphsBase)
 	    return BadAlloc;
     }
@@ -995,7 +995,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	listsBase = listsLocal;
     else
     {
-	listsBase = (GlyphListPtr) ALLOCATE_LOCAL (nlist * sizeof (GlyphListRec));
+	listsBase = (GlyphListPtr) malloc (nlist * sizeof (GlyphListRec));
 	if (!listsBase)
 	    return BadAlloc;
     }
@@ -1031,9 +1031,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 		{
 		    client->errorValue = gs;
 		    if (glyphsBase != glyphsLocal)
-			DEALLOCATE_LOCAL (glyphsBase);
+			free (glyphsBase);
 		    if (listsBase != listsLocal)
-			DEALLOCATE_LOCAL (listsBase);
+			free (listsBase);
 		    return RenderErrBase + BadGlyphSet;
 		}
 	    }
@@ -1140,9 +1140,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
     nxagentGlyphsExtents = NullBox;
 
     if (glyphsBase != glyphsLocal)
-	DEALLOCATE_LOCAL (glyphsBase);
+	free (glyphsBase);
     if (listsBase != listsLocal)
-	DEALLOCATE_LOCAL (listsBase);
+	free (listsBase);
     
     free(elementsBase);
 

--- a/nx-X11/programs/Xserver/include/os.h
+++ b/nx-X11/programs/Xserver/include/os.h
@@ -50,9 +50,6 @@ SOFTWARE.
 #define OS_H
 
 #include "misc.h"
-#define ALLOCATE_LOCAL_FALLBACK(_size) malloc((unsigned long)(_size))
-#define DEALLOCATE_LOCAL_FALLBACK(_ptr) free((void *)(_ptr))
-#include <nx-X11/Xalloca.h>
 #include <stdarg.h>
 
 #define NullFID ((FID) 0)

--- a/nx-X11/programs/Xserver/mi/miarc.c
+++ b/nx-X11/programs/Xserver/mi/miarc.c
@@ -954,14 +954,14 @@ miFillWideEllipse(
 
     yorgu = parc->height + pGC->lineWidth;
     n = (sizeof(int) * 2) * yorgu;
-    widths = (int *)ALLOCATE_LOCAL(n + (sizeof(DDXPointRec) * 2) * yorgu);
+    widths = (int *)malloc(n + (sizeof(DDXPointRec) * 2) * yorgu);
     if (!widths)
 	return;
     points = (DDXPointPtr)((char *)widths + n);
     spdata = miComputeWideEllipse((int)pGC->lineWidth, parc, &mustFree);
     if (!spdata)
     {
-	DEALLOCATE_LOCAL(widths);
+	free(widths);
 	return;
     }
     pts = points;
@@ -1054,7 +1054,7 @@ miFillWideEllipse(
 	free(spdata);
     (*pGC->ops->FillSpans)(pDraw, pGC, pts - points, points, widths, FALSE);
 
-    DEALLOCATE_LOCAL(widths);
+    free(widths);
 }
 
 /*
@@ -1927,13 +1927,13 @@ miComputeArcs (
 	isDoubleDash = (pGC->lineStyle == LineDoubleDash);
 	dashOffset = pGC->dashOffset;
 
-	data = (struct arcData *) ALLOCATE_LOCAL (narcs * sizeof (struct arcData));
+	data = (struct arcData *) malloc (narcs * sizeof (struct arcData));
 	if (!data)
 	    return (miPolyArcPtr)NULL;
 	arcs = (miPolyArcPtr) malloc (sizeof (*arcs) * (isDoubleDash ? 2 : 1));
 	if (!arcs)
 	{
-	    DEALLOCATE_LOCAL(data);
+	    free(data);
 	    return (miPolyArcPtr)NULL;
 	}
 	for (i = 0; i < narcs; i++) {
@@ -2282,11 +2282,11 @@ miComputeArcs (
 			arcs[iphase].arcs[arcs[iphase].narcs-1].cap =
 			         arcs[iphase].ncaps;
 		}
-	DEALLOCATE_LOCAL(data);
+	free(data);
 	return arcs;
 arcfail:
 	miFreeArcs(arcs, pGC);
-	DEALLOCATE_LOCAL(data);
+	free(data);
 	return (miPolyArcPtr)NULL;
 }
 
@@ -3190,8 +3190,8 @@ fillSpans (
 
 	if (nspans == 0)
 		return;
-	xSpan = xSpans = (DDXPointPtr) ALLOCATE_LOCAL (nspans * sizeof (DDXPointRec));
-	xWidth = xWidths = (int *) ALLOCATE_LOCAL (nspans * sizeof (int));
+	xSpan = xSpans = (DDXPointPtr) malloc (nspans * sizeof (DDXPointRec));
+	xWidth = xWidths = (int *) malloc (nspans * sizeof (int));
 	if (xSpans && xWidths)
 	{
 	    i = 0;
@@ -3211,9 +3211,9 @@ fillSpans (
 	}
 	disposeFinalSpans ();
 	if (xSpans)
-	    DEALLOCATE_LOCAL (xSpans);
+	    free (xSpans);
 	if (xWidths)
-	    DEALLOCATE_LOCAL (xWidths);
+	    free (xWidths);
 	finalMiny = 0;
 	finalMaxy = -1;
 	finalSize = 0;

--- a/nx-X11/programs/Xserver/mi/mibitblt.c
+++ b/nx-X11/programs/Xserver/mi/mibitblt.c
@@ -143,21 +143,21 @@ miCopyArea(pSrcDrawable, pDstDrawable,
     }
 
     pptFirst = ppt = (DDXPointPtr)
-        ALLOCATE_LOCAL(heightSrc * sizeof(DDXPointRec));
+        malloc(heightSrc * sizeof(DDXPointRec));
     pwidthFirst = pwidth = (unsigned int *)
-        ALLOCATE_LOCAL(heightSrc * sizeof(unsigned int));
+        malloc(heightSrc * sizeof(unsigned int));
     numRects = RegionNumRects(prgnSrcClip);
     boxes = RegionRects(prgnSrcClip);
     ordering = (unsigned int *)
-        ALLOCATE_LOCAL(numRects * sizeof(unsigned int));
+        malloc(numRects * sizeof(unsigned int));
     if(!pptFirst || !pwidthFirst || !ordering)
     {
        if (ordering)
-	   DEALLOCATE_LOCAL(ordering);
+	   free(ordering);
        if (pwidthFirst)
-           DEALLOCATE_LOCAL(pwidthFirst);
+           free(pwidthFirst);
        if (pptFirst)
-           DEALLOCATE_LOCAL(pptFirst);
+           free(pptFirst);
        return (RegionPtr)NULL;
     }
 
@@ -264,9 +264,9 @@ miCopyArea(pSrcDrawable, pDstDrawable,
     if(realSrcClip)
 	RegionDestroy(prgnSrcClip);
 		
-    DEALLOCATE_LOCAL(ordering);
-    DEALLOCATE_LOCAL(pwidthFirst);
-    DEALLOCATE_LOCAL(pptFirst);
+    free(ordering);
+    free(pwidthFirst);
+    free(pptFirst);
     return prgnExposed;
 }
 
@@ -436,12 +436,12 @@ miOpqStipDrawable(pDraw, pGC, prgnSrc, pbits, srcx, w, h, dstx, dsty)
     dixChangeGC(NullClient, pGCT, GCBackground, NULL, gcv);
     ValidateGC((DrawablePtr)pPixmap, pGCT);
     miClearDrawable((DrawablePtr)pPixmap, pGCT);
-    ppt = pptFirst = (DDXPointPtr)ALLOCATE_LOCAL(h * sizeof(DDXPointRec));
-    pwidth = pwidthFirst = (int *)ALLOCATE_LOCAL(h * sizeof(int));
+    ppt = pptFirst = (DDXPointPtr)malloc(h * sizeof(DDXPointRec));
+    pwidth = pwidthFirst = (int *)malloc(h * sizeof(int));
     if(!pptFirst || !pwidthFirst)
     {
-	if (pwidthFirst) DEALLOCATE_LOCAL(pwidthFirst);
-	if (pptFirst) DEALLOCATE_LOCAL(pptFirst);
+	if (pwidthFirst) free(pwidthFirst);
+	if (pptFirst) free(pptFirst);
 	FreeScratchGC(pGCT);
 	return;
     }
@@ -467,8 +467,8 @@ miOpqStipDrawable(pDraw, pGC, prgnSrc, pbits, srcx, w, h, dstx, dsty)
 
     (*pGCT->ops->SetSpans)((DrawablePtr)pPixmap, pGCT, (char *)pbits,
 			   pptFirst, pwidthFirst, h, TRUE);
-    DEALLOCATE_LOCAL(pwidthFirst);
-    DEALLOCATE_LOCAL(pptFirst);
+    free(pwidthFirst);
+    free(pptFirst);
 
 
     /* Save current values from the client GC */
@@ -810,14 +810,14 @@ miPutImage(pDraw, pGC, depth, x, y, w, h, leftPad, format, pImage)
 	break;
 
       case ZPixmap:
-    	ppt = pptFirst = (DDXPointPtr)ALLOCATE_LOCAL(h * sizeof(DDXPointRec));
-    	pwidth = pwidthFirst = (int *)ALLOCATE_LOCAL(h * sizeof(int));
+	ppt = pptFirst = (DDXPointPtr)malloc(h * sizeof(DDXPointRec));
+	pwidth = pwidthFirst = (int *)malloc(h * sizeof(int));
 	if(!pptFirst || !pwidthFirst)
         {
 	   if (pwidthFirst)
-               DEALLOCATE_LOCAL(pwidthFirst);
+               free(pwidthFirst);
            if (pptFirst)
-               DEALLOCATE_LOCAL(pptFirst);
+               free(pptFirst);
            return;
         }
 	if (pGC->miTranslate)
@@ -836,8 +836,8 @@ miPutImage(pDraw, pGC, depth, x, y, w, h, leftPad, format, pImage)
 
 	(*pGC->ops->SetSpans)(pDraw, pGC, (char *)pImage, pptFirst,
 			      pwidthFirst, h, TRUE);
-	DEALLOCATE_LOCAL(pwidthFirst);
-	DEALLOCATE_LOCAL(pptFirst);
+	free(pwidthFirst);
+	free(pptFirst);
 	break;
     }
 }

--- a/nx-X11/programs/Xserver/mi/mibstore.c
+++ b/nx-X11/programs/Xserver/mi/mibstore.c
@@ -963,8 +963,8 @@ miBSFillSpans(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted)
 
     PROLOGUE(pGC);
 
-    pptCopy = (DDXPointPtr)ALLOCATE_LOCAL(nInit*sizeof(DDXPointRec));
-    pwidthCopy=(int *)ALLOCATE_LOCAL(nInit*sizeof(int));
+    pptCopy = (DDXPointPtr)malloc(nInit*sizeof(DDXPointRec));
+    pwidthCopy=(int *)malloc(nInit*sizeof(int));
     if (pptCopy && pwidthCopy)
     {
 	copyData(pptInit, pptCopy, nInit, MoreCopy0);
@@ -992,8 +992,8 @@ miBSFillSpans(pDrawable, pGC, nInit, pptInit, pwidthInit, fSorted)
 				  pBackingGC, nInit, pptCopy, pwidthCopy,
 				  fSorted);
     }
-    if (pwidthCopy) DEALLOCATE_LOCAL(pwidthCopy);
-    if (pptCopy) DEALLOCATE_LOCAL(pptCopy);
+    if (pwidthCopy) free(pwidthCopy);
+    if (pptCopy) free(pptCopy);
 
     EPILOGUE (pGC);
 }
@@ -1026,8 +1026,8 @@ miBSSetSpans(pDrawable, pGC, psrc, ppt, pwidth, nspans, fSorted)
 
     PROLOGUE(pGC);
 
-    pptCopy = (DDXPointPtr)ALLOCATE_LOCAL(nspans*sizeof(DDXPointRec));
-    pwidthCopy=(int *)ALLOCATE_LOCAL(nspans*sizeof(int));
+    pptCopy = (DDXPointPtr)malloc(nspans*sizeof(DDXPointRec));
+    pwidthCopy=(int *)malloc(nspans*sizeof(int));
     if (pptCopy && pwidthCopy)
     {
 	copyData(ppt, pptCopy, nspans, MoreCopy0);
@@ -1054,8 +1054,8 @@ miBSSetSpans(pDrawable, pGC, psrc, ppt, pwidth, nspans, fSorted)
 	(* pBackingGC->ops->SetSpans)(pBackingDrawable, pBackingGC,
 				psrc, pptCopy, pwidthCopy, nspans, fSorted);
     }
-    if (pwidthCopy) DEALLOCATE_LOCAL(pwidthCopy);
-    if (pptCopy) DEALLOCATE_LOCAL(pptCopy);
+    if (pwidthCopy) free(pwidthCopy);
+    if (pptCopy) free(pptCopy);
 
     EPILOGUE (pGC);
 }
@@ -1209,14 +1209,14 @@ miBSDoCopy(
     numRectsObs = RegionNumRects(pRgnObs);
     nrects = numRectsExp + numRectsObs;
     
-    boxes = (struct BoxDraw *)ALLOCATE_LOCAL(nrects * sizeof(struct BoxDraw));
-    sequence = (int *) ALLOCATE_LOCAL(nrects * sizeof(int));
+    boxes = (struct BoxDraw *)malloc(nrects * sizeof(struct BoxDraw));
+    sequence = (int *) malloc(nrects * sizeof(int));
     *ppRgn = NULL;
 
     if (!boxes || !sequence)
     {
-	if (sequence) DEALLOCATE_LOCAL(sequence);
-	if (boxes) DEALLOCATE_LOCAL(boxes);
+	if (sequence) free(sequence);
+	if (boxes) free(boxes);
 	RegionDestroy(pRgnExp);
 	RegionDestroy(pRgnObs);
 
@@ -1424,8 +1424,8 @@ miBSDoCopy(
 			  pBox->x1 + dx, pBox->y1 + dy, plane);
 	}
     }
-    DEALLOCATE_LOCAL(sequence);
-    DEALLOCATE_LOCAL(boxes);
+    free(sequence);
+    free(boxes);
 
     pGC->graphicsExposures = graphicsExposures;
     /*
@@ -1720,7 +1720,7 @@ miBSPolyPoint (pDrawable, pGC, mode, npt, pptInit)
 
     PROLOGUE(pGC);
 
-    pptCopy = (xPoint *)ALLOCATE_LOCAL(npt*sizeof(xPoint));
+    pptCopy = (xPoint *)malloc(npt*sizeof(xPoint));
     if (pptCopy)
     {
 	copyPoints(pptInit, pptCopy, npt, mode);
@@ -1730,7 +1730,7 @@ miBSPolyPoint (pDrawable, pGC, mode, npt, pptInit)
 	(* pBackingGC->ops->PolyPoint) (pBackingDrawable,
 				   pBackingGC, mode, npt, pptCopy);
 
-	DEALLOCATE_LOCAL(pptCopy);
+	free(pptCopy);
     }
 
     EPILOGUE (pGC);
@@ -1760,7 +1760,7 @@ miBSPolylines (pDrawable, pGC, mode, npt, pptInit)
 
     PROLOGUE(pGC);
 
-    pptCopy = (DDXPointPtr)ALLOCATE_LOCAL(npt*sizeof(DDXPointRec));
+    pptCopy = (DDXPointPtr)malloc(npt*sizeof(DDXPointRec));
     if (pptCopy)
     {
 	copyPoints(pptInit, pptCopy, npt, mode);
@@ -1768,7 +1768,7 @@ miBSPolylines (pDrawable, pGC, mode, npt, pptInit)
 	(* pGC->ops->Polylines)(pDrawable, pGC, mode, npt, pptInit);
 	(* pBackingGC->ops->Polylines)(pBackingDrawable,
 				  pBackingGC, mode, npt, pptCopy);
-	DEALLOCATE_LOCAL(pptCopy);
+	free(pptCopy);
     }
 
     EPILOGUE (pGC);
@@ -1799,7 +1799,7 @@ miBSPolySegment(pDrawable, pGC, nseg, pSegs)
 
     PROLOGUE(pGC);
 
-    pSegsCopy = (xSegment *)ALLOCATE_LOCAL(nseg*sizeof(xSegment));
+    pSegsCopy = (xSegment *)malloc(nseg*sizeof(xSegment));
     if (pSegsCopy)
     {
 	copyData(pSegs, pSegsCopy, nseg << 1, MoreCopy0);
@@ -1808,7 +1808,7 @@ miBSPolySegment(pDrawable, pGC, nseg, pSegs)
 	(* pBackingGC->ops->PolySegment)(pBackingDrawable,
 				    pBackingGC, nseg, pSegsCopy);
 
-	DEALLOCATE_LOCAL(pSegsCopy);
+	free(pSegsCopy);
     }
 
     EPILOGUE (pGC);
@@ -1838,7 +1838,7 @@ miBSPolyRectangle(pDrawable, pGC, nrects, pRects)
 
     PROLOGUE(pGC);
 
-    pRectsCopy =(xRectangle *)ALLOCATE_LOCAL(nrects*sizeof(xRectangle));
+    pRectsCopy =(xRectangle *)malloc(nrects*sizeof(xRectangle));
     if (pRectsCopy)
     {
 	copyData(pRects, pRectsCopy, nrects, MoreCopy2);
@@ -1847,7 +1847,7 @@ miBSPolyRectangle(pDrawable, pGC, nrects, pRects)
 	(* pBackingGC->ops->PolyRectangle)(pBackingDrawable,
 				      pBackingGC, nrects, pRectsCopy);
 
-	DEALLOCATE_LOCAL(pRectsCopy);
+	free(pRectsCopy);
     }
 
     EPILOGUE (pGC);
@@ -1876,7 +1876,7 @@ miBSPolyArc(pDrawable, pGC, narcs, parcs)
 
     PROLOGUE(pGC);
 
-    pArcsCopy = (xArc *)ALLOCATE_LOCAL(narcs*sizeof(xArc));
+    pArcsCopy = (xArc *)malloc(narcs*sizeof(xArc));
     if (pArcsCopy)
     {
 	copyData(parcs, pArcsCopy, narcs, MoreCopy4);
@@ -1885,7 +1885,7 @@ miBSPolyArc(pDrawable, pGC, narcs, parcs)
 	(* pBackingGC->ops->PolyArc)(pBackingDrawable, pBackingGC,
 				narcs, pArcsCopy);
 
-	DEALLOCATE_LOCAL(pArcsCopy);
+	free(pArcsCopy);
     }
 
     EPILOGUE (pGC);
@@ -1916,7 +1916,7 @@ miBSFillPolygon(pDrawable, pGC, shape, mode, count, pPts)
 
     PROLOGUE(pGC);
 
-    pPtsCopy = (DDXPointPtr)ALLOCATE_LOCAL(count*sizeof(DDXPointRec));
+    pPtsCopy = (DDXPointPtr)malloc(count*sizeof(DDXPointRec));
     if (pPtsCopy)
     {
 	copyPoints(pPts, pPtsCopy, count, mode);
@@ -1925,7 +1925,7 @@ miBSFillPolygon(pDrawable, pGC, shape, mode, count, pPts)
 				    pBackingGC, shape, mode,
 				    count, pPtsCopy);
 
-	DEALLOCATE_LOCAL(pPtsCopy);
+	free(pPtsCopy);
     }
 
     EPILOGUE (pGC);
@@ -1956,7 +1956,7 @@ miBSPolyFillRect(pDrawable, pGC, nrectFill, prectInit)
     PROLOGUE(pGC);
 
     pRectCopy =
-	(xRectangle *)ALLOCATE_LOCAL(nrectFill*sizeof(xRectangle));
+	(xRectangle *)malloc(nrectFill*sizeof(xRectangle));
     if (pRectCopy)
     {
 	copyData(prectInit, pRectCopy, nrectFill, MoreCopy2);
@@ -1965,7 +1965,7 @@ miBSPolyFillRect(pDrawable, pGC, nrectFill, prectInit)
 	(* pBackingGC->ops->PolyFillRect)(pBackingDrawable,
 				     pBackingGC, nrectFill, pRectCopy);
 
-	DEALLOCATE_LOCAL(pRectCopy);
+	free(pRectCopy);
     }
 
     EPILOGUE (pGC);
@@ -1995,14 +1995,14 @@ miBSPolyFillArc(pDrawable, pGC, narcs, parcs)
 
     PROLOGUE(pGC);
 
-    pArcsCopy = (xArc *)ALLOCATE_LOCAL(narcs*sizeof(xArc));
+    pArcsCopy = (xArc *)malloc(narcs*sizeof(xArc));
     if (pArcsCopy)
     {
 	copyData(parcs, pArcsCopy, narcs, MoreCopy4);
 	(* pGC->ops->PolyFillArc)(pDrawable, pGC, narcs, parcs);
 	(* pBackingGC->ops->PolyFillArc)(pBackingDrawable,
 				    pBackingGC, narcs, pArcsCopy);
-	DEALLOCATE_LOCAL(pArcsCopy);
+	free(pArcsCopy);
     }
 
     EPILOGUE (pGC);
@@ -2391,7 +2391,7 @@ miBSClearBackingStore(pWin, x, y, w, h, generateExposures)
 		 * PolyFillRect in the proper mode, as set in the GC above.
 		 */
 		numRects = RegionNumRects(pRgn);
-		rects = (xRectangle *)ALLOCATE_LOCAL(numRects*sizeof(xRectangle));
+		rects = (xRectangle *)malloc(numRects*sizeof(xRectangle));
 	    
 		if (rects)
 		{
@@ -2407,7 +2407,7 @@ miBSClearBackingStore(pWin, x, y, w, h, generateExposures)
 		    (* pGC->ops->PolyFillRect) (
 				(DrawablePtr)pBackingStore->pBackingPixmap,
 				       pGC, numRects, rects);
-		    DEALLOCATE_LOCAL(rects);
+		    free(rects);
 		}	
 		FreeScratchGC(pGC);
 	    }
@@ -2483,7 +2483,7 @@ miBSFillVirtualBits (pDrawable, pGC, pRgn, x, y, state, pixunion, planeMask)
     if (state == None)
 	return;
     numRects = RegionNumRects(pRgn);
-    pRect = (xRectangle *)ALLOCATE_LOCAL(numRects * sizeof(xRectangle));
+    pRect = (xRectangle *)malloc(numRects * sizeof(xRectangle));
     if (!pRect)
 	return;
     pWin = 0;
@@ -2554,7 +2554,7 @@ miBSFillVirtualBits (pDrawable, pGC, pRgn, x, y, state, pixunion, planeMask)
     (*pGC->ops->PolyFillRect) (pDrawable, pGC, numRects, pRect);
     if (pWin)
 	(*pWin->drawable.pScreen->DrawGuarantee) (pWin, pGC, GuaranteeNothing);
-    DEALLOCATE_LOCAL (pRect);
+    free (pRect);
 }
 
 /*-

--- a/nx-X11/programs/Xserver/mi/miexpose.c
+++ b/nx-X11/programs/Xserver/mi/miexpose.c
@@ -395,7 +395,7 @@ miSendGraphicsExpose (client, pRgn, drawable, major, minor)
 
 	numRects = RegionNumRects(pRgn);
 	pBox = RegionRects(pRgn);
-	if(!(pEvent = (xEvent *)ALLOCATE_LOCAL(numRects * sizeof(xEvent))))
+	if(!(pEvent = (xEvent *)malloc(numRects * sizeof(xEvent))))
 		return;
 	pe = pEvent;
 
@@ -413,7 +413,7 @@ miSendGraphicsExpose (client, pRgn, drawable, major, minor)
 	}
 	TryClientEvents(client, pEvent, numRects,
 			    (Mask)0, NoEventMask, NullGrab);
-	DEALLOCATE_LOCAL(pEvent);
+	free(pEvent);
     }
     else
     {
@@ -442,7 +442,7 @@ miSendExposures(pWin, pRgn, dx, dy)
 
     pBox = RegionRects(pRgn);
     numRects = RegionNumRects(pRgn);
-    if(!(pEvent = (xEvent *) ALLOCATE_LOCAL(numRects * sizeof(xEvent))))
+    if(!(pEvent = (xEvent *) malloc(numRects * sizeof(xEvent))))
 	return;
     memset(pEvent, 0, numRects * sizeof(xEvent));
 
@@ -473,7 +473,7 @@ miSendExposures(pWin, pRgn, dx, dy)
 	    win = PanoramiXFindIDByScrnum(XRT_WINDOW, 
 			pWin->drawable.id, scrnum);
 	    if(!win) {
-		DEALLOCATE_LOCAL(pEvent);
+		free(pEvent);
 		return;
 	    }
 	    realWin = win->info[0].id;
@@ -490,7 +490,7 @@ miSendExposures(pWin, pRgn, dx, dy)
 
     DeliverEvents(pWin, pEvent, numRects, NullWindow);
 
-    DEALLOCATE_LOCAL(pEvent);
+    free(pEvent);
 }
 
 #ifndef NXAGENT_SERVER
@@ -705,7 +705,7 @@ int what;
 	}
     }
 
-    prect = (xRectangle *)ALLOCATE_LOCAL(RegionNumRects(prgn) *
+    prect = (xRectangle *)malloc(RegionNumRects(prgn) *
 					 sizeof(xRectangle));
     if (!prect)
 	return;
@@ -730,7 +730,7 @@ int what;
 	pGC = GetScratchGC(pWin->drawable.depth, pWin->drawable.pScreen);
 	if (!pGC)
 	{
-	    DEALLOCATE_LOCAL(prect);
+	    free(prect);
 	    return;
 	}
 	/*
@@ -862,7 +862,7 @@ int what;
     }
     prect -= numRects;
     (*pGC->ops->PolyFillRect)((DrawablePtr)pWin, pGC, numRects, prect);
-    DEALLOCATE_LOCAL(prect);
+    free(prect);
 
     if (pWin->backStorage)
 	(*pWin->drawable.pScreen->DrawGuarantee) (pWin, pGC, GuaranteeNothing);

--- a/nx-X11/programs/Xserver/mi/mifillarc.c
+++ b/nx-X11/programs/Xserver/mi/mifillarc.c
@@ -559,13 +559,13 @@ miFillEllipseI(
     int *widths;
     register int *wids;
 
-    points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * arc->height);
+    points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * arc->height);
     if (!points)
 	return;
-    widths = (int *)ALLOCATE_LOCAL(sizeof(int) * arc->height);
+    widths = (int *)malloc(sizeof(int) * arc->height);
     if (!widths)
     {
-	DEALLOCATE_LOCAL(points);
+	free(points);
 	return;
     }
     miFillArcSetup(arc, &info);
@@ -583,8 +583,8 @@ miFillEllipseI(
 	ADDSPANS();
     }
     (*pGC->ops->FillSpans)(pDraw, pGC, pts - points, points, widths, FALSE);
-    DEALLOCATE_LOCAL(widths);
-    DEALLOCATE_LOCAL(points);
+    free(widths);
+    free(points);
 }
 
 static void
@@ -602,13 +602,13 @@ miFillEllipseD(
     int *widths;
     register int *wids;
 
-    points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * arc->height);
+    points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * arc->height);
     if (!points)
 	return;
-    widths = (int *)ALLOCATE_LOCAL(sizeof(int) * arc->height);
+    widths = (int *)malloc(sizeof(int) * arc->height);
     if (!widths)
     {
-	DEALLOCATE_LOCAL(points);
+	free(points);
 	return;
     }
     miFillArcDSetup(arc, &info);
@@ -626,8 +626,8 @@ miFillEllipseD(
 	ADDSPANS();
     }
     (*pGC->ops->FillSpans)(pDraw, pGC, pts - points, points, widths, FALSE);
-    DEALLOCATE_LOCAL(widths);
-    DEALLOCATE_LOCAL(points);
+    free(widths);
+    free(points);
 }
 
 #define ADDSPAN(l,r) \
@@ -674,13 +674,13 @@ miFillArcSliceI(
     slw = arc->height;
     if (slice.flip_top || slice.flip_bot)
 	slw += (arc->height >> 1) + 1;
-    points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * slw);
+    points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * slw);
     if (!points)
 	return;
-    widths = (int *)ALLOCATE_LOCAL(sizeof(int) * slw);
+    widths = (int *)malloc(sizeof(int) * slw);
     if (!widths)
     {
-	DEALLOCATE_LOCAL(points);
+	free(points);
 	return;
     }
     if (pGC->miTranslate)
@@ -711,8 +711,8 @@ miFillArcSliceI(
 	}
     }
     (*pGC->ops->FillSpans)(pDraw, pGC, pts - points, points, widths, FALSE);
-    DEALLOCATE_LOCAL(widths);
-    DEALLOCATE_LOCAL(points);
+    free(widths);
+    free(points);
 }
 
 static void
@@ -738,13 +738,13 @@ miFillArcSliceD(
     slw = arc->height;
     if (slice.flip_top || slice.flip_bot)
 	slw += (arc->height >> 1) + 1;
-    points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * slw);
+    points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * slw);
     if (!points)
 	return;
-    widths = (int *)ALLOCATE_LOCAL(sizeof(int) * slw);
+    widths = (int *)malloc(sizeof(int) * slw);
     if (!widths)
     {
-	DEALLOCATE_LOCAL(points);
+	free(points);
 	return;
     }
     if (pGC->miTranslate)
@@ -775,8 +775,8 @@ miFillArcSliceD(
 	}
     }
     (*pGC->ops->FillSpans)(pDraw, pGC, pts - points, points, widths, FALSE);
-    DEALLOCATE_LOCAL(widths);
-    DEALLOCATE_LOCAL(points);
+    free(widths);
+    free(points);
 }
 
 /* MIPOLYFILLARC -- The public entry for the PolyFillArc request.

--- a/nx-X11/programs/Xserver/mi/mifillrct.c
+++ b/nx-X11/programs/Xserver/mi/mifillrct.c
@@ -106,12 +106,12 @@ miPolyFillRect(pDrawable, pGC, nrectFill, prectInit)
 	    maxheight = max(maxheight, prect->height);
     }
 
-    pptFirst = (DDXPointPtr) ALLOCATE_LOCAL(maxheight * sizeof(DDXPointRec));
-    pwFirst = (int *) ALLOCATE_LOCAL(maxheight * sizeof(int));
+    pptFirst = (DDXPointPtr) malloc(maxheight * sizeof(DDXPointRec));
+    pwFirst = (int *) malloc(maxheight * sizeof(int));
     if(!pptFirst || !pwFirst)
     {
-	if (pwFirst) DEALLOCATE_LOCAL(pwFirst);
-	if (pptFirst) DEALLOCATE_LOCAL(pptFirst);
+	if (pwFirst) free(pwFirst);
+	if (pptFirst) free(pptFirst);
 	return;
     }
 
@@ -137,6 +137,6 @@ miPolyFillRect(pDrawable, pGC, nrectFill, prectInit)
 			   1);
 	prect++;
     }
-    DEALLOCATE_LOCAL(pwFirst);
-    DEALLOCATE_LOCAL(pptFirst);
+    free(pwFirst);
+    free(pptFirst);
 }

--- a/nx-X11/programs/Xserver/mi/mifpolycon.c
+++ b/nx-X11/programs/Xserver/mi/mifpolycon.c
@@ -118,15 +118,15 @@ miFillSppPoly(dst, pgc, count, ptsIn, xTrans, yTrans, xFtrans, yFtrans)
     y = ymax - ymin + 1;
     if ((count < 3) || (y <= 0))
 	return;
-    ptsOut = FirstPoint = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * y);
-    width = FirstWidth = (int *) ALLOCATE_LOCAL(sizeof(int) * y);
-    Marked = (int *) ALLOCATE_LOCAL(sizeof(int) * count);
+    ptsOut = FirstPoint = (DDXPointPtr)malloc(sizeof(DDXPointRec) * y);
+    width = FirstWidth = (int *) malloc(sizeof(int) * y);
+    Marked = (int *) malloc(sizeof(int) * count);
 
     if(!ptsOut || !width || !Marked)
     {
-	if (Marked) DEALLOCATE_LOCAL(Marked);
-	if (width) DEALLOCATE_LOCAL(width);
-	if (ptsOut) DEALLOCATE_LOCAL(ptsOut);
+	if (Marked) free(Marked);
+	if (width) free(width);
+	if (ptsOut) free(ptsOut);
 	return;
     }
 
@@ -240,9 +240,9 @@ miFillSppPoly(dst, pgc, count, ptsIn, xTrans, yTrans, xFtrans, yFtrans)
     /* Finally, fill the spans we've collected */
     (*pgc->ops->FillSpans)(dst, pgc, 
 		      ptsOut-FirstPoint, FirstPoint, FirstWidth, 1);
-    DEALLOCATE_LOCAL(Marked);
-    DEALLOCATE_LOCAL(FirstWidth);
-    DEALLOCATE_LOCAL(FirstPoint);
+    free(Marked);
+    free(FirstWidth);
+    free(FirstPoint);
 }
 
 

--- a/nx-X11/programs/Xserver/mi/miglblt.c
+++ b/nx-X11/programs/Xserver/mi/miglblt.c
@@ -138,7 +138,7 @@ miPolyGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
     DoChangeGC(pGCtmp, GCFunction|GCForeground|GCBackground, gcvals, 0);
 
     nbyLine = BitmapBytePad(width);
-    pbits = (unsigned char *)ALLOCATE_LOCAL(height*nbyLine);
+    pbits = (unsigned char *)malloc(height*nbyLine);
     if (!pbits)
     {
 	(*pDrawable->pScreen->DestroyPixmap)(pPixmap);
@@ -189,7 +189,7 @@ miPolyGlyphBlt(pDrawable, pGC, x, y, nglyph, ppci, pglyphBase)
 	x += pci->metrics.characterWidth;
     }
     (*pDrawable->pScreen->DestroyPixmap)(pPixmap);
-    DEALLOCATE_LOCAL(pbits);
+    free(pbits);
     FreeScratchGC(pGCtmp);
 }
 

--- a/nx-X11/programs/Xserver/mi/mipolycon.c
+++ b/nx-X11/programs/Xserver/mi/mipolycon.c
@@ -104,12 +104,12 @@ miFillConvexPoly(dst, pgc, count, ptsIn)
     dy = ymax - ymin + 1;
     if ((count < 3) || (dy < 0))
 	return(TRUE);
-    ptsOut = FirstPoint = (DDXPointPtr )ALLOCATE_LOCAL(sizeof(DDXPointRec)*dy);
-    width = FirstWidth = (int *)ALLOCATE_LOCAL(sizeof(int) * dy);
+    ptsOut = FirstPoint = (DDXPointPtr )malloc(sizeof(DDXPointRec)*dy);
+    width = FirstWidth = (int *)malloc(sizeof(int) * dy);
     if(!FirstPoint || !FirstWidth)
     {
-	if (FirstWidth) DEALLOCATE_LOCAL(FirstWidth);
-	if (FirstPoint) DEALLOCATE_LOCAL(FirstPoint);
+	if (FirstWidth) free(FirstWidth);
+	if (FirstPoint) free(FirstPoint);
 	return(FALSE);
     }
 
@@ -174,8 +174,8 @@ miFillConvexPoly(dst, pgc, count, ptsIn)
 	/* in case we're called with non-convex polygon */
 	if(i < 0)
         {
-	    DEALLOCATE_LOCAL(FirstWidth);
-	    DEALLOCATE_LOCAL(FirstPoint);
+	    free(FirstWidth);
+	    free(FirstPoint);
 	    return(TRUE);
 	}
         while (i-- > 0) 
@@ -209,8 +209,8 @@ miFillConvexPoly(dst, pgc, count, ptsIn)
     (*pgc->ops->FillSpans)(dst, pgc, 
 		      ptsOut-FirstPoint,FirstPoint,FirstWidth,
 		      1);
-    DEALLOCATE_LOCAL(FirstWidth);
-    DEALLOCATE_LOCAL(FirstPoint);
+    free(FirstWidth);
+    free(FirstPoint);
     return(TRUE);
 }
 

--- a/nx-X11/programs/Xserver/mi/mipolygen.c
+++ b/nx-X11/programs/Xserver/mi/mipolygen.c
@@ -92,13 +92,13 @@ miFillGeneralPoly(dst, pgc, count, ptsIn)
 	return(TRUE);
 
     if(!(pETEs = (EdgeTableEntry *)
-        ALLOCATE_LOCAL(sizeof(EdgeTableEntry) * count)))
+        malloc(sizeof(EdgeTableEntry) * count)))
 	return(FALSE);
     ptsOut = FirstPoint;
     width = FirstWidth;
     if (!miCreateETandAET(count, ptsIn, &ET, &AET, pETEs, &SLLBlock))
     {
-	DEALLOCATE_LOCAL(pETEs);
+	free(pETEs);
 	return(FALSE);
     }
     pSLL = ET.scanlines.next;
@@ -224,7 +224,7 @@ miFillGeneralPoly(dst, pgc, count, ptsIn)
      *     Get any spans that we missed by buffering
      */
     (*pgc->ops->FillSpans)(dst, pgc, nPts, FirstPoint, FirstWidth, 1);
-    DEALLOCATE_LOCAL(pETEs);
+    free(pETEs);
     miFreeStorage(SLLBlock.next);
     return(TRUE);
 }

--- a/nx-X11/programs/Xserver/mi/mipolypnt.c
+++ b/nx-X11/programs/Xserver/mi/mipolypnt.c
@@ -106,7 +106,7 @@ miPolyPoint(pDrawable, pGC, mode, npt, pptInit)
 	DoChangeGC(pGC, GCFillStyle, &fsNew, 0);
 	ValidateGC(pDrawable, pGC);
     }
-    if(!(pwidthInit = (int *)ALLOCATE_LOCAL(npt * sizeof(int))))
+    if(!(pwidthInit = (int *)malloc(npt * sizeof(int))))
 	return;
     pwidth = pwidthInit;
     for(i = 0; i < npt; i++)
@@ -118,6 +118,6 @@ miPolyPoint(pDrawable, pGC, mode, npt, pptInit)
 	DoChangeGC(pGC, GCFillStyle, &fsOld, 0);
 	ValidateGC(pDrawable, pGC);
     }
-    DEALLOCATE_LOCAL(pwidthInit);
+    free(pwidthInit);
 }
 

--- a/nx-X11/programs/Xserver/mi/mipolyrect.c
+++ b/nx-X11/programs/Xserver/mi/mipolyrect.c
@@ -94,7 +94,7 @@ miPolyRectangle(pDraw, pGC, nrects, pRects)
 	offset2 = pGC->lineWidth;
 	offset1 = offset2 >> 1;
 	offset3 = offset2 - offset1;
-	tmp = (xRectangle *) ALLOCATE_LOCAL(ntmp * sizeof (xRectangle));
+	tmp = (xRectangle *) malloc(ntmp * sizeof (xRectangle));
 	if (!tmp)
 	    return;
 	t = tmp;
@@ -162,7 +162,7 @@ miPolyRectangle(pDraw, pGC, nrects, pRects)
 	    }
 	}
 	(*pGC->ops->PolyFillRect) (pDraw, pGC, t - tmp, tmp);
-	DEALLOCATE_LOCAL ((void *) tmp);
+	free ((void *) tmp);
     }
     else
     {

--- a/nx-X11/programs/Xserver/mi/mispans.c
+++ b/nx-X11/programs/Xserver/mi/mispans.c
@@ -531,7 +531,7 @@ void miFillUniqueSpanGroup(pDraw, pGC, spanGroup)
 	free(points);
 	free(widths);
 	free(yspans);
-	free(ysizes);		/* use (DE)ALLOCATE_LOCAL for these? */
+	free(ysizes);
     }
 
     spanGroup->count = 0;

--- a/nx-X11/programs/Xserver/mi/miwideline.c
+++ b/nx-X11/programs/Xserver/mi/miwideline.c
@@ -105,13 +105,13 @@ miFillPolyHelper (pDrawable, pGC, pixel, spanData, y, overall_height,
     
     if (!spanData)
     {
-    	pptInit = (DDXPointPtr) ALLOCATE_LOCAL (overall_height * sizeof(*ppt));
+    	pptInit = (DDXPointPtr) malloc (overall_height * sizeof(*ppt));
     	if (!pptInit)
 	    return;
-    	pwidthInit = (int *) ALLOCATE_LOCAL (overall_height * sizeof(*pwidth));
+    	pwidthInit = (int *) malloc (overall_height * sizeof(*pwidth));
     	if (!pwidthInit)
     	{
-	    DEALLOCATE_LOCAL (pptInit);
+	    free (pptInit);
 	    return;
     	}
 	ppt = pptInit;
@@ -176,8 +176,8 @@ miFillPolyHelper (pDrawable, pGC, pixel, spanData, y, overall_height,
     if (!spanData)
     {
     	(*pGC->ops->FillSpans) (pDrawable, pGC, ppt - pptInit, pptInit, pwidthInit, TRUE);
-    	DEALLOCATE_LOCAL (pwidthInit);
-    	DEALLOCATE_LOCAL (pptInit);
+    	free (pwidthInit);
+    	free (pptInit);
     	if (pixel != oldPixel)
     	{
 	    DoChangeGC (pGC, GCForeground, &oldPixel, FALSE);
@@ -1056,13 +1056,13 @@ miLineArc (
     }
     if (!spanData)
     {
-    	points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * pGC->lineWidth);
+    	points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * pGC->lineWidth);
     	if (!points)
 	    return;
-    	widths = (int *)ALLOCATE_LOCAL(sizeof(int) * pGC->lineWidth);
+    	widths = (int *)malloc(sizeof(int) * pGC->lineWidth);
     	if (!widths)
     	{
-	    DEALLOCATE_LOCAL(points);
+	    free(points);
 	    return;
     	}
     	oldPixel = pGC->fgPixel;
@@ -1096,8 +1096,8 @@ miLineArc (
     if (!spanData)
     {
     	(*pGC->ops->FillSpans)(pDraw, pGC, n, points, widths, TRUE);
-    	DEALLOCATE_LOCAL(widths);
-    	DEALLOCATE_LOCAL(points);
+    	free(widths);
+    	free(points);
     	if (pixel != oldPixel)
     	{
 	    DoChangeGC(pGC, GCForeground, &oldPixel, FALSE);

--- a/nx-X11/programs/Xserver/mi/mizerarc.c
+++ b/nx-X11/programs/Xserver/mi/mizerarc.c
@@ -746,7 +746,7 @@ miZeroPolyArc(pDraw, pGC, narcs, parcs)
     dospans = (pGC->fillStyle != FillSolid);
     if (dospans)
     {
-	widths = (int *)ALLOCATE_LOCAL(sizeof(int) * numPts);
+	widths = (int *)malloc(sizeof(int) * numPts);
 	if (!widths)
 	    return;
 	maxw = 0;
@@ -763,12 +763,12 @@ miZeroPolyArc(pDraw, pGC, narcs, parcs)
 		   (unsigned char *) pGC->dash, (int)pGC->numInDashList,
 		   &dinfo.dashOffsetInit);
     }
-    points = (DDXPointPtr)ALLOCATE_LOCAL(sizeof(DDXPointRec) * numPts);
+    points = (DDXPointPtr)malloc(sizeof(DDXPointRec) * numPts);
     if (!points)
     {
 	if (dospans)
 	{
-	    DEALLOCATE_LOCAL(widths);
+	    free(widths);
 	}
 	return;
     }
@@ -845,9 +845,9 @@ miZeroPolyArc(pDraw, pGC, narcs, parcs)
 	    }
 	}
     }
-    DEALLOCATE_LOCAL(points);
+    free(points);
     if (dospans)
     {
-	DEALLOCATE_LOCAL(widths);
+	free(widths);
     }
 }

--- a/nx-X11/programs/Xserver/mi/mizerline.c
+++ b/nx-X11/programs/Xserver/mi/mizerline.c
@@ -155,8 +155,8 @@ miZeroLine(pDraw, pGC, mode, npt, pptInit)
     width = xright - xleft + 1;
     height = ybottom - ytop + 1;
     list_len = (height >= width) ? height : width;
-    pspanInit = (DDXPointPtr)ALLOCATE_LOCAL(list_len * sizeof(DDXPointRec));
-    pwidthInit = (int *)ALLOCATE_LOCAL(list_len * sizeof(int));
+    pspanInit = (DDXPointPtr)malloc(list_len * sizeof(DDXPointRec));
+    pwidthInit = (int *)malloc(list_len * sizeof(int));
     if (!pspanInit || !pwidthInit)
 	return;
 
@@ -359,8 +359,8 @@ miZeroLine(pDraw, pGC, mode, npt, pptInit)
 	(*pGC->ops->FillSpans)(pDraw, pGC, Nspans, pspanInit,
 			       pwidthInit, FALSE);
 
-    DEALLOCATE_LOCAL(pwidthInit);
-    DEALLOCATE_LOCAL(pspanInit);
+    free(pwidthInit);
+    free(pspanInit);
 }
 
 void

--- a/nx-X11/programs/Xserver/miext/damage/damage.c
+++ b/nx-X11/programs/Xserver/miext/damage/damage.c
@@ -1347,7 +1347,7 @@ damageText (DrawablePtr	    pDrawable,
 
     imageblt = (textType == TT_IMAGE8) || (textType == TT_IMAGE16);
 
-    charinfo = (CharInfoPtr *) ALLOCATE_LOCAL(count * sizeof(CharInfoPtr));
+    charinfo = (CharInfoPtr *) malloc(count * sizeof(CharInfoPtr));
     if (!charinfo)
 	return x;
 
@@ -1369,7 +1369,7 @@ damageText (DrawablePtr	    pDrawable,
 	    (*pGC->ops->PolyGlyphBlt)(pDrawable, pGC, x, y, n, charinfo,
 				      FONTGLYPHS(pGC->font));
     }
-    DEALLOCATE_LOCAL(charinfo);
+    free(charinfo);
     return x + w;
 }
 

--- a/nx-X11/programs/Xserver/record/record.c
+++ b/nx-X11/programs/Xserver/record/record.c
@@ -1763,7 +1763,7 @@ RecordRegisterClients(pContext, client, stuff)
      * range for extension replies.
      */
     maxSets = PREDEFSETS + 2 * stuff->nRanges;
-    si = (SetInfoPtr)ALLOCATE_LOCAL(sizeof(SetInfoRec) * maxSets);
+    si = (SetInfoPtr)malloc(sizeof(SetInfoRec) * maxSets);
     if (!si)
     {
 	err = BadAlloc;
@@ -1970,7 +1970,7 @@ bailout:
 	for (i = 0; i < maxSets; i++)
 	    if (si[i].intervals)
 		free(si[i].intervals);
-	DEALLOCATE_LOCAL(si);
+	free(si);
     }
     if (pCanonClients && pCanonClients != (XID *)&stuff[1])
 	free(pCanonClients);
@@ -2343,7 +2343,7 @@ ProcRecordGetContext(client)
 
     /* allocate and initialize space for record range info */
 
-    pRangeInfo = (GetContextRangeInfoPtr)ALLOCATE_LOCAL(
+    pRangeInfo = (GetContextRangeInfoPtr)malloc(
 				nRCAPs * sizeof(GetContextRangeInfoRec));
     if (!pRangeInfo && nRCAPs > 0)
 	return BadAlloc;
@@ -2460,7 +2460,7 @@ bailout:
     {
 	if (pRangeInfo[i].pRanges) free(pRangeInfo[i].pRanges);
     }
-    DEALLOCATE_LOCAL(pRangeInfo);
+    free(pRangeInfo);
     return err;
 } /* ProcRecordGetContext */
 
@@ -2882,14 +2882,14 @@ RecordConnectionSetupInfo(pContext, pci)
 
     if (pci->client->swapped)
     {
-	char * pConnSetup = (char *)ALLOCATE_LOCAL(prefixsize + restsize);
+	char * pConnSetup = (char *)malloc(prefixsize + restsize);
 	if (!pConnSetup)
 	    return;
 	SwapConnSetupPrefix(pci->prefix, pConnSetup);
 	SwapConnSetupInfo(pci->setup, pConnSetup + prefixsize);
 	RecordAProtocolElement(pContext, pci->client, XRecordClientStarted,
 			       (void *)pConnSetup, prefixsize + restsize, 0);
-	DEALLOCATE_LOCAL(pConnSetup);
+	free(pConnSetup);
     }
     else
     {

--- a/nx-X11/programs/Xserver/record/set.c
+++ b/nx-X11/programs/Xserver/record/set.c
@@ -71,9 +71,6 @@ typedef int Bool;
 
 typedef unsigned short CARD16;
 
-#define ALLOCATE_LOCAL malloc
-#define DEALLOCATE_LOCAL free
-
 #ifndef max
 #define max(_a, _b) ( ((_a) > (_b)) ? (_a) : (_b) )
 #endif
@@ -358,7 +355,7 @@ IntervalListCreateSet(pIntervals, nIntervals, pMem, memsize)
 
     if (nIntervals > 0)
     {
-	stackIntervals = (RecordSetInterval *)ALLOCATE_LOCAL(
+	stackIntervals = (RecordSetInterval *)malloc(
 				sizeof(RecordSetInterval) * nIntervals);
 	if (!stackIntervals) return NULL;
 
@@ -416,7 +413,7 @@ IntervalListCreateSet(pIntervals, nIntervals, pMem, memsize)
     memcpy(&prls[1], stackIntervals, nIntervals * sizeof(RecordSetInterval));
     prls->nIntervals = nIntervals;
 bailout:
-    if (stackIntervals) DEALLOCATE_LOCAL(stackIntervals);
+    if (stackIntervals) free(stackIntervals);
     return (RecordSetPtr)prls;
 }
 

--- a/nx-X11/programs/Xserver/render/mitri.c
+++ b/nx-X11/programs/Xserver/render/mitri.c
@@ -145,7 +145,7 @@ miTriStrip (CARD8	    op,
     if (npoint < 3)
 	return;
     ntri = npoint - 2;
-    tris = ALLOCATE_LOCAL (ntri * sizeof (xTriangle));
+    tris = malloc (ntri * sizeof (xTriangle));
     if (!tris)
 	return;
     for (tri = tris; npoint >= 3; npoint--, points++, tri++)
@@ -155,7 +155,7 @@ miTriStrip (CARD8	    op,
 	tri->p3 = points[2];
     }
     (*ps->Triangles) (op, pSrc, pDst, maskFormat, xSrc, ySrc, ntri, tris);
-    DEALLOCATE_LOCAL (tris);
+    free (tris);
 }
 
 void
@@ -177,7 +177,7 @@ miTriFan (CARD8		op,
     if (npoint < 3)
 	return;
     ntri = npoint - 2;
-    tris = ALLOCATE_LOCAL (ntri * sizeof (xTriangle));
+    tris = malloc (ntri * sizeof (xTriangle));
     if (!tris)
 	return;
     first = points++;
@@ -188,5 +188,5 @@ miTriFan (CARD8		op,
 	tri->p3 = points[1];
     }
     (*ps->Triangles) (op, pSrc, pDst, maskFormat, xSrc, ySrc, ntri, tris);
-    DEALLOCATE_LOCAL (tris);
+    free (tris);
 }

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -1338,7 +1338,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	glyphsBase = glyphsLocal;
     else
     {
-	glyphsBase = (GlyphPtr *) ALLOCATE_LOCAL (nglyph * sizeof (GlyphPtr));
+	glyphsBase = (GlyphPtr *) malloc (nglyph * sizeof (GlyphPtr));
 	if (!glyphsBase)
 	    return BadAlloc;
     }
@@ -1346,7 +1346,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 	listsBase = listsLocal;
     else
     {
-	listsBase = (GlyphListPtr) ALLOCATE_LOCAL (nlist * sizeof (GlyphListRec));
+	listsBase = (GlyphListPtr) malloc (nlist * sizeof (GlyphListRec));
 	if (!listsBase)
 	    return BadAlloc;
     }
@@ -1371,9 +1371,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 		{
 		    client->errorValue = gs;
 		    if (glyphsBase != glyphsLocal)
-			DEALLOCATE_LOCAL (glyphsBase);
+			free (glyphsBase);
 		    if (listsBase != listsLocal)
-			DEALLOCATE_LOCAL (listsBase);
+			free (listsBase);
 		    return RenderErrBase + BadGlyphSet;
 		}
 	    }
@@ -1427,9 +1427,9 @@ ProcRenderCompositeGlyphs (ClientPtr client)
 		     glyphsBase);
 
     if (glyphsBase != glyphsLocal)
-	DEALLOCATE_LOCAL (glyphsBase);
+	free (glyphsBase);
     if (listsBase != listsLocal)
-	DEALLOCATE_LOCAL (listsBase);
+	free (listsBase);
     
     return client->noClientException;
 }
@@ -2893,7 +2893,7 @@ PanoramiXRenderFillRectangles (ClientPtr client)
 			RenderErrBase + BadPicture);
     extra_len = (client->req_len << 2) - sizeof (xRenderFillRectanglesReq);
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len)))
+	(extra = (char *) malloc (extra_len)))
     {
 	memcpy (extra, stuff + 1, extra_len);
 	FOR_NSCREENS_FORWARD(j) {
@@ -2919,7 +2919,7 @@ PanoramiXRenderFillRectangles (ClientPtr client)
 	    result = (*PanoramiXSaveRenderVector[X_RenderFillRectangles]) (client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(extra);
+	free(extra);
     }
 
     return result;
@@ -2944,7 +2944,7 @@ PanoramiXRenderTrapezoids(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderTrapezoidsReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -2981,7 +2981,7 @@ PanoramiXRenderTrapezoids(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3006,7 +3006,7 @@ PanoramiXRenderTriangles(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderTrianglesReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -3039,7 +3039,7 @@ PanoramiXRenderTriangles(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3064,7 +3064,7 @@ PanoramiXRenderTriStrip(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderTriStripReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -3093,7 +3093,7 @@ PanoramiXRenderTriStrip(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3118,7 +3118,7 @@ PanoramiXRenderTriFan(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderTriFanReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -3147,7 +3147,7 @@ PanoramiXRenderTriFan(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3172,7 +3172,7 @@ PanoramiXRenderColorTrapezoids(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderColorTrapezoidsReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -3193,7 +3193,7 @@ PanoramiXRenderColorTrapezoids(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3216,7 +3216,7 @@ PanoramiXRenderColorTriangles(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof (xRenderColorTrianglesReq);
 
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len))) {
+	(extra = (char *) malloc (extra_len))) {
 	memcpy (extra, stuff + 1, extra_len);
 
 	FOR_NSCREENS_FORWARD(j) {
@@ -3237,7 +3237,7 @@ PanoramiXRenderColorTriangles(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        DEALLOCATE_LOCAL(extra);
+        free(extra);
     }
 
     return result;
@@ -3260,7 +3260,7 @@ PanoramiXRenderAddTraps (ClientPtr client)
 			RenderErrBase + BadPicture);
     extra_len = (client->req_len << 2) - sizeof (xRenderAddTrapsReq);
     if (extra_len &&
-	(extra = (char *) ALLOCATE_LOCAL (extra_len)))
+	(extra = (char *) malloc (extra_len)))
     {
 	memcpy (extra, stuff + 1, extra_len);
 	x_off = stuff->xOff;
@@ -3277,7 +3277,7 @@ PanoramiXRenderAddTraps (ClientPtr client)
 	    result = (*PanoramiXSaveRenderVector[X_RenderAddTraps]) (client);
 	    if(result != Success) break;
 	}
-	DEALLOCATE_LOCAL(extra);
+	free(extra);
     }
 
     return result;

--- a/nx-X11/programs/Xserver/xkb/xkb.c
+++ b/nx-X11/programs/Xserver/xkb/xkb.c
@@ -1301,7 +1301,7 @@ unsigned	i,len;
 char		*desc,*start;
 
     len= (rep->length*4)-(SIZEOF(xkbGetMapReply)-SIZEOF(xGenericReply));
-    start= desc= (char *)ALLOCATE_LOCAL(len);
+    start= desc= (char *)malloc(len);
     if (!start)
 	return BadAlloc;
     memset(start, 0, len);
@@ -1342,7 +1342,7 @@ char		*desc,*start;
     }
     WriteToClient(client, (i=SIZEOF(xkbGetMapReply)), rep);
     WriteToClient(client, len, start);
-    DEALLOCATE_LOCAL((char *)start);
+    free((char *)start);
     return client->noClientException;
 }
 
@@ -2486,7 +2486,7 @@ int		size;
 
     size= rep->length*4;
     if (size>0) {
-	data = (char *)ALLOCATE_LOCAL(size);
+	data = (char *)malloc(size);
 	if (data) {
 	    register unsigned i,bit;
 	    xkbModsWireDesc *	grp;
@@ -2534,7 +2534,7 @@ int		size;
     WriteToClient(client, SIZEOF(xkbGetCompatMapReply), rep);
     if (data) {
 	WriteToClient(client, size, data);
-	DEALLOCATE_LOCAL((char *)data);
+	free((char *)data);
     }
     return client->noClientException;
 }
@@ -2781,7 +2781,7 @@ register unsigned	bit;
     length = rep->length*4;
     if (length>0) {
 	CARD8 *to;
-	to= map= (CARD8 *)ALLOCATE_LOCAL(length);
+	to= map= (CARD8 *)malloc(length);
 	if (map) {
 	    xkbIndicatorMapWireDesc  *wire = (xkbIndicatorMapWireDesc *)to;
 	    for (i=0,bit=1;i<XkbNumIndicators;i++,bit<<=1) {
@@ -2819,7 +2819,7 @@ register unsigned	bit;
     WriteToClient(client, SIZEOF(xkbGetIndicatorMapReply), rep);
     if (map) {
 	WriteToClient(client, length, map);
-	DEALLOCATE_LOCAL((char *)map);
+	free((char *)map);
     }
     return client->noClientException;
 }
@@ -3308,7 +3308,7 @@ char *			desc;
 	swapl(&rep->indicators);
     }
 
-    start = desc = (char *)ALLOCATE_LOCAL(length);
+    start = desc = (char *)malloc(length);
     if ( !start )
 	return BadAlloc;
     if (which&XkbKeycodesNameMask) {
@@ -3429,7 +3429,7 @@ char *			desc;
     }
     WriteToClient(client, SIZEOF(xkbGetNamesReply), rep);
     WriteToClient(client, length, start);
-    DEALLOCATE_LOCAL((char *)start);
+    free((char *)start);
     return client->noClientException;
 }
 
@@ -4315,7 +4315,7 @@ XkbSendGeometry(	ClientPtr		client,
 
     if (geom!=NULL) {
 	len= rep->length*4;
-	start= desc= (char *)ALLOCATE_LOCAL(len);
+	start= desc= (char *)malloc(len);
 	if (!start)
 	    return BadAlloc;
 	desc=  XkbWriteCountedString(desc,geom->label_font,client->swapped);
@@ -4358,7 +4358,7 @@ XkbSendGeometry(	ClientPtr		client,
     if (len>0)
 	WriteToClient(client, len, start);
     if (start!=NULL)
-	DEALLOCATE_LOCAL((char *)start);
+	free((char *)start);
     if (freeGeom)
 	XkbFreeGeometry(geom,XkbGeomAllMask,True);
     return client->noClientException;
@@ -5753,12 +5753,12 @@ char *			str;
     }
     WriteToClient(client,SIZEOF(xkbGetDeviceInfoReply), &rep);
 
-    str= (char*) ALLOCATE_LOCAL(nameLen);
+    str= (char*) malloc(nameLen);
     if (!str) 
 	return BadAlloc;
     XkbWriteCountedString(str,dev->name,client->swapped);
     WriteToClient(client,nameLen,str);
-    DEALLOCATE_LOCAL(str);
+    free(str);
     length-= nameLen;
 
     if (rep.nBtnsRtrn>0) {

--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -179,7 +179,7 @@ char *			pval;
 	ErrorF("Atom error: %s not created\n",_XKB_RF_NAMES_PROP_ATOM);
 	return True;
     }
-    pval= (char*) ALLOCATE_LOCAL(len);
+    pval= (char*) malloc(len);
     if (!pval) {
 	ErrorF("Allocation error: %s proprerty not created\n",
 						_XKB_RF_NAMES_PROP_ATOM);
@@ -220,7 +220,7 @@ char *			pval;
     }
     ChangeWindowProperty(screenInfo.screens[0]->root,name,XA_STRING,8,PropModeReplace,
 							len,pval,True);
-    DEALLOCATE_LOCAL(pval);
+    free(pval);
     return True;
 }
 


### PR DESCRIPTION
This is basically a backport of the following commits + replacing
xalloc/xfree by malloc/free. Fixes ArcticaProject/nx-libs#358.

   commit 2761c103311a1160bc483fd0367d654733df8598
   Author: Daniel Stone <daniel@fooishbar.org>
   Date:   Mon Nov 5 14:03:26 2007 +0000

       OS: Remove usage of alloca

       Replace with heap allocations.

   commit 5e363500c86042c394595e1a6633581eb8fcd1bb
   Author: Daniel Stone <daniel@fooishbar.org>
   Date:   Mon Nov 5 14:38:28 2007 +0000

       OS: Remove ALLOCATE_LOCAL from os.h

       Remove ALLOCATE_LOCAL_FALLBACK and DEALLOCATE_LOCAL_FALLBACK from os.h, and
       remove the include of Xalloca.h as well.