### PR TITLE
xkb: Allow NULL as rulesFile in XkbSetRulesDflts.

### DIFF
--- a/nx-X11/programs/Xserver/xkb/xkbInit.c
+++ b/nx-X11/programs/Xserver/xkb/xkbInit.c
@@ -92,7 +92,7 @@ typedef struct	_SrvXkmInfo {
 #define	XKB_BIN_DIRECTORY	XKB_BASE_DIRECTORY
 #endif
 #ifndef XKB_DFLT_RULES_FILE
-#define	XKB_DFLT_RULES_FILE	"rules"
+#define	XKB_DFLT_RULES_FILE	"base"
 #endif
 #ifndef XKB_DFLT_KB_LAYOUT
 #define	XKB_DFLT_KB_LAYOUT	"us"
@@ -244,14 +244,34 @@ XkbSetRulesUsed(XkbRF_VarDefsPtr defs)
     return;
 }
 
+/**
+ * Set the default RMLVO for the next device to be initialised.
+ * If a parameter is NULL, the previous setting will be used. Use empty
+ * strings if you want to delete a previous setting.
+ *
+ * If @rulesFile is NULL and no previous @rulesFile has been set, the
+ * built-in default is chosen as default.
+ */
+
 void
 XkbSetRulesDflts(char *rulesFile,char *model,char *layout,
 					char *variant,char *options)
 {
-    if (XkbRulesFile)
-	_XkbFree(XkbRulesFile);
-    XkbRulesFile= Xstrdup(rulesFile);
-    rulesDefined= True;
+    if (!rulesFile && !XkbRulesFile)
+    {
+       LogMessage(X_WARNING, "[xkb] No rule given, and no previous rule "
+                             "defined. Defaulting to '%s'.\n",
+                              XKB_DFLT_RULES_FILE);
+       rulesFile = XKB_DFLT_RULES_FILE;
+    }
+
+    if (rulesFile) {
+       if (XkbRulesFile)
+           _XkbFree(XkbRulesFile);
+       XkbRulesFile= Xstrdup(rulesFile);
+       rulesDefined= True;
+    }
+
     if (model) {
 	if (XkbModelDflt)
 	    _XkbFree(XkbModelDflt);


### PR DESCRIPTION
If no rules file is given, simply re-use the previous one. If no RF is given
the first time this function is called, use the built-in default.
This includes fixing the built-in default to something that actually exists.

Signed-off-by: Peter Hutterer <peter.hutterer@redhat.com>
Backported-to-NX-by: Ulrich Sibiller <uli42@gmx.de>

see #371