### PR TITLE
Backport CVE-2017-2624 (timingsafe_memcmp)

### DIFF
--- a/nx-X11/config/cf/Imake.tmpl
+++ b/nx-X11/config/cf/Imake.tmpl
@@ -468,6 +468,9 @@ XCOMM the platform-specific parameters - edit site.def to change
 #ifndef HasBasename
 #define HasBasename		YES
 #endif
+#ifndef HasTimingsafeMemcmp
+#define HasTimingsafeMemcmp	NO	/* assume not */
+#endif
 #ifndef HasGetopt
 # if !defined(Win32Architecture)
 #  define HasGetopt		YES

--- a/nx-X11/programs/Xserver/include/os.h
+++ b/nx-X11/programs/Xserver/include/os.h
@@ -460,6 +460,11 @@ extern _X_EXPORT size_t
 strlcat(char *dst, const char *src, size_t siz);
 #endif
 
+#ifndef HAVE_TIMINGSAFE_MEMCMP
+extern _X_EXPORT int
+timingsafe_memcmp(const void *b1, const void *b2, size_t len);
+#endif
+
 /* Logging. */
 typedef enum _LogParameter {
     XLOG_FLUSH,

--- a/nx-X11/programs/Xserver/os/Imakefile
+++ b/nx-X11/programs/Xserver/os/Imakefile
@@ -120,12 +120,12 @@ BOOTSTRAPCFLAGS =
                   osinit.c utils.c log.c auth.c mitauth.c secauth.c \
                   $(XDMAUTHSRCS) $(RPCSRCS) xdmcp.c OtherSources \
                   xstrans.c $(SNPRINTF_SRCS) $(STRLCAT_SRCS) \
-		  $(REALLOCARRAY_SRCS) xprintf.c
+		  $(REALLOCARRAY_SRCS) xprintf.c timingsafe_memcmp.c
            OBJS = WaitFor.o access.o connection.o io.o $(COLOR_OBJS) \
                   osinit.o utils.o log.o auth.o mitauth.o secauth.o \
                   $(XDMAUTHOBJS) $(RPCOBJS) xdmcp.o OtherObjects \
                   xstrans.o $(SNPRINTF_OBJS) $(STRLCAT_OBJS) \
-		  $(REALLOCARRAY_OBJS) xprintf.o
+		  $(REALLOCARRAY_OBJS) xprintf.o timingsafe_memcmp.o
 
 #if UseMemLeak
      MEM_DEFINES = -DMEMBUG

--- a/nx-X11/programs/Xserver/os/Imakefile
+++ b/nx-X11/programs/Xserver/os/Imakefile
@@ -115,17 +115,22 @@ GETPEER_DEFINES = -DHAS_GETPEEREID
 # endif
 #endif
 
+#if !HasTimingsafeMemcmp
+TMEMCMP_SRCS = timingsafe_memcmp.c
+TMEMCMP_OBJS = timingsafe_memcmp.o
+#endif
+
 BOOTSTRAPCFLAGS = 
            SRCS = WaitFor.c access.c connection.c io.c $(COLOR_SRCS) \
                   osinit.c utils.c log.c auth.c mitauth.c secauth.c \
                   $(XDMAUTHSRCS) $(RPCSRCS) xdmcp.c OtherSources \
                   xstrans.c $(SNPRINTF_SRCS) $(STRLCAT_SRCS) \
-		  $(REALLOCARRAY_SRCS) xprintf.c timingsafe_memcmp.c
+		  $(REALLOCARRAY_SRCS) xprintf.c $(TMEMCMP_SRCS)
            OBJS = WaitFor.o access.o connection.o io.o $(COLOR_OBJS) \
                   osinit.o utils.o log.o auth.o mitauth.o secauth.o \
                   $(XDMAUTHOBJS) $(RPCOBJS) xdmcp.o OtherObjects \
                   xstrans.o $(SNPRINTF_OBJS) $(STRLCAT_OBJS) \
-		  $(REALLOCARRAY_OBJS) xprintf.o timingsafe_memcmp.o
+		  $(REALLOCARRAY_OBJS) xprintf.o $(TMEMCMP_OBJS)
 
 #if UseMemLeak
      MEM_DEFINES = -DMEMBUG

--- a/nx-X11/programs/Xserver/os/mitauth.c
+++ b/nx-X11/programs/Xserver/os/mitauth.c
@@ -82,7 +82,7 @@ MitCheckCookie (
 
     for (auth = mit_auth; auth; auth=auth->next) {
         if (data_length == auth->len &&
-	   memcmp (data, auth->data, (int) data_length) == 0)
+	   timingsafe_memcmp (data, auth->data, (int) data_length) == 0)
 	    return auth->id;
     }
     *reason = "Invalid MIT-MAGIC-COOKIE-1 key";

--- a/nx-X11/programs/Xserver/os/timingsafe_memcmp.c
+++ b/nx-X11/programs/Xserver/os/timingsafe_memcmp.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014 Google Inc.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <nx-X11/Xfuncproto.h>
+#include "os.h"
+
+int
+timingsafe_memcmp(const void *b1, const void *b2, size_t len)
+{
+        const unsigned char *p1 = b1, *p2 = b2;
+        size_t i;
+        int res = 0, done = 0;
+
+        for (i = 0; i < len; i++) {
+                /* lt is -1 if p1[i] < p2[i]; else 0. */
+                int lt = (p1[i] - p2[i]) >> CHAR_BIT;
+
+                /* gt is -1 if p1[i] > p2[i]; else 0. */
+                int gt = (p2[i] - p1[i]) >> CHAR_BIT;
+
+                /* cmp is 1 if p1[i] > p2[i]; -1 if p1[i] < p2[i]; else 0. */
+                int cmp = lt - gt;
+
+                /* set res = cmp if !done. */
+                res |= cmp & ~done;
+
+                /* set done if p1[i] != p2[i]. */
+                done |= lt | gt;
+        }
+
+        return (res);
+}


### PR DESCRIPTION
Fixes ArcticaProject/nx-libs#365

These two commits:

   commit 5c44169caed811e59a65ba346de1cadb46d266ec
   Author: Adam Jackson <ajax@redhat.com>
   Date:   Thu Mar 2 17:20:30 2017 -0500

       os: Squash missing declaration warning for timingsafe_memcmp

       timingsafe_memcmp.c:21:1: warning: no previous prototype for ‘timingsafe_memcmp’ [-Wmissing-prototypes]
        timingsafe_memcmp(const void *b1, const void *b2, size_t len)

       Signed-off-by: Adam Jackson <ajax@redhat.com>

   commit d7ac755f0b618eb1259d93c8a16ec6e39a18627c
   Author: Matthieu Herrb <matthieu@herrb.eu>
   Date:   Tue Feb 28 19:18:25 2017 +0100

       Use timingsafe_memcmp() to compare MIT-MAGIC-COOKIES CVE-2017-2624

       Provide the function definition for systems that don't have it.

       Signed-off-by: Matthieu Herrb <matthieu@herrb.eu>