### PR TITLE
Keystroke.c: ignore CapsLock and NumLock most of the time

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -204,8 +204,10 @@ static char *nxagentXkbGetRules(void);
 unsigned int nxagentAltMetaMask;
 unsigned int nxagentAltMask;
 unsigned int nxagentMetaMask;
+unsigned int nxagentCapsMask;
+unsigned int nxagentNumlockMask;
 
-static void nxagentCheckAltMetaKeys(CARD8, int);
+static void nxagentCheckModifierMasks(CARD8, int);
 
 CARD8 nxagentCapsLockKeycode = 66;
 CARD8 nxagentNumLockKeycode  = 77;
@@ -792,6 +794,8 @@ N/A
       nxagentAltMetaMask = 0;
       nxagentAltMask = 0;
       nxagentMetaMask = 0;
+      nxagentCapsMask = 0;
+      nxagentNumlockMask = 0;
 
       for (i = 0; i < 256; i++)
         modmap[i] = 0;
@@ -805,7 +809,7 @@ N/A
 
           if (keycode > 0)
           {
-            nxagentCheckAltMetaKeys(keycode, j);
+            nxagentCheckModifierMasks(keycode, j);
           }
         }
       XFreeModifiermap(modifier_keymap);
@@ -1377,7 +1381,7 @@ int nxagentResetKeyboard(void)
   }
 }
 
-void nxagentCheckAltMetaKeys(CARD8 keycode, int j)
+void nxagentCheckModifierMasks(CARD8 keycode, int j)
 {
   if (keycode == XKeysymToKeycode(nxagentDisplay, XK_Meta_L))
   {
@@ -1402,6 +1406,18 @@ void nxagentCheckAltMetaKeys(CARD8 keycode, int j)
     nxagentAltMetaMask |= 1 << j;
     nxagentAltMask |= 1 << j;
   }
+
+  if (keycode == XKeysymToKeycode(nxagentDisplay, XK_Num_Lock))
+  {
+    nxagentNumlockMask |= 1 << j;
+  }
+
+  if (keycode == XKeysymToKeycode(nxagentDisplay, XK_Caps_Lock) ||
+      keycode == XKeysymToKeycode(nxagentDisplay, XK_Shift_Lock) )
+  {
+    nxagentCapsMask |= 1 << j;
+  }
+
 }
 
 void nxagentCheckRemoteKeycodes()

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.h
@@ -126,4 +126,7 @@ CARD8 nxagentConvertKeycode(CARD8 k);
 extern CARD8 nxagentCapsLockKeycode;
 extern CARD8 nxagentNumLockKeycode;
 
+extern unsigned int nxagentCapsMask;
+extern unsigned int nxagentNumlockMask;
+
 #endif /* __Keyboard_H__ */

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
@@ -34,6 +34,7 @@
 #include "Events.h"
 #include "Options.h"
 #include "Keystroke.h"
+#include "Keyboard.h"
 #include "Drawable.h"
 #include "Init.h" /* extern int nxagentX2go */
 
@@ -148,6 +149,15 @@ static Bool modifier_matches(unsigned int mask, int compare_alt_meta, unsigned i
     mask &= ~nxagentAltMetaMask;
     state &= ~nxagentAltMetaMask;
   }
+
+  /* ignore CapsLock and/or Numlock if the keystroke does not
+     explicitly require them */
+
+  if ( !(mask & nxagentCapsMask) )
+    state &= ~nxagentCapsMask;
+
+  if ( !(mask & nxagentNumlockMask) )
+    state &= ~nxagentNumlockMask;
 
   /* all modifiers except meta/alt have to match exactly, extra bits are evil */
   if (mask != state) {


### PR DESCRIPTION
CapsLock and NumLock will only be taken into account for keystrokes
that explicitly require them. This is implemented for convenience and
fixes ArcticaProject/nx-libs#397