### PR TITLE
Mesa subtree: Add quilt based patch system for bundled Mesa.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ SHELL:=/bin/bash
 
 	# clean auto-generated nxversion.def file \
 	if [ "x$@" == "xclean" ] || [ "x$@" = "xdistclean" ]; then \
+	    ./mesa-quilt pop -a; \
+	    rm -Rf nx-X11/extras/Mesa/.pc/; \
 	    rm -f nx-X11/config/cf/nxversion.def; \
 	    rm -f bin/nxagent; \
 	    rm -f bin/nxproxy; \
@@ -72,6 +74,7 @@ build-full:
 
 	cd nxcompshad && autoconf && (${CONFIGURE}) && ${MAKE}
 
+	./mesa-quilt push -a
 	cd nx-X11 && ${MAKE} World USRLIBDIR=$(USRLIBDIR) SHLIBDIR=$(SHLIBDIR)
 
 	cd nxproxy && autoconf && (${CONFIGURE}) && ${MAKE}

--- a/mesa-quilt
+++ b/mesa-quilt
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (C) 2017 by Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+d=. ; while [ ! -d "$d/nx-X11/extras" ] && [ "$(readlink -e "$d")" != "/" ]; do d="$d/.."; done
+if [ -d "$d/nx-X11/extras" ] && [ -z "$QUILT_PATCHES" ]; then
+    # if in nx-libs tree with unset $QUILT_PATCHES
+    export QUILT_PATCHES="../Mesa.patches"
+    export QUILT_PATCH_OPTS="--reject-format=unified"
+    export QUILT_DIFF_ARGS="-p ab --no-timestamps --no-index --color=auto"
+    export QUILT_REFRESH_ARGS="-p ab --no-timestamps --no-index"
+    export QUILT_COLORS="diff_hdr=1;32:diff_add=1;34:diff_rem=1;31:diff_hunk=1;33:diff_ctx=35:diff_cctx=33"
+    if ! [ -d "$d/nx-X11/extras/Mesa.patches" ]; then mkdir "$d/nx-X11/extras/Mesa.patches"; fi
+    cd "$d/nx-X11/extras/Mesa/"
+fi
+
+quilt "$@"
+
+cd - 1> /dev/null


### PR DESCRIPTION
Explanation: The Mesa subtree is a pulled-in (bundled) Mesa 6.4.1. We see many compiler warnings that should get amended, may it only be for the readability of the build logs.

Furthermore, the CreatePixmap() ABI changed in X.org, too. A backport is pending on my local working copy. The CreatePixmap() ABI change will also require a tiny adaptation in Mesa as we ship it.

Later on, the plan is to pull-in Mesa (version 6.4.1 for now, later on possibly newer versions) as a git subtree or submodule. Again, then we won't have our patches for Mesa in the Git log somewhere. The cleaner approach for now is to maintain a separate Mesa-for-NX-patchset IMHO.

This PR provides the foundation for this. The patch system for Mesa will use quilt. 