### PR TITLE
xserver: remove index from CloseScreen (API/ABI breakage)

### DIFF
--- a/nx-X11/programs/Xserver/Xext/panoramiX.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiX.c
@@ -149,7 +149,7 @@ GCFuncs XineramaGCFuncs = {
 
 
 static Bool
-XineramaCloseScreen (int i, ScreenPtr pScreen)
+XineramaCloseScreen (ScreenPtr pScreen)
 {
     PanoramiXScreenPtr pScreenPriv = 
         (PanoramiXScreenPtr) pScreen->devPrivates[PanoramiXScreenIndex].ptr;
@@ -163,7 +163,7 @@ XineramaCloseScreen (int i, ScreenPtr pScreen)
 
     free ((void *) pScreenPriv);
 
-    return (*pScreen->CloseScreen) (i, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 Bool

--- a/nx-X11/programs/Xserver/Xext/xvdix.h
+++ b/nx-X11/programs/Xserver/Xext/xvdix.h
@@ -219,7 +219,7 @@ typedef struct {
   DestroyWindowProcPtr DestroyWindow;
   DestroyPixmapProcPtr DestroyPixmap;
   CloseScreenProcPtr CloseScreen;
-  Bool (* ddCloseScreen)(int, ScreenPtr);
+  Bool (* ddCloseScreen)(ScreenPtr);
   int (* ddQueryAdaptors)(ScreenPtr, XvAdaptorPtr*, int*);
   DevUnion devPriv;
 } XvScreenRec, *XvScreenPtr;

--- a/nx-X11/programs/Xserver/Xext/xvmain.c
+++ b/nx-X11/programs/Xserver/Xext/xvmain.c
@@ -131,7 +131,7 @@ static void WriteSwappedVideoNotifyEvent(xvEvent *, xvEvent *);
 static void WriteSwappedPortNotifyEvent(xvEvent *, xvEvent *);
 static Bool CreateResourceTypes(void);
 
-static Bool XvCloseScreen(int, ScreenPtr);
+static Bool XvCloseScreen(ScreenPtr);
 static Bool XvDestroyPixmap(PixmapPtr);
 static Bool XvDestroyWindow(WindowPtr);
 static void XvResetProc(ExtensionEntry*);
@@ -307,7 +307,6 @@ XvScreenInit(ScreenPtr pScreen)
 
 static Bool
 XvCloseScreen(
-  int ii,
   ScreenPtr pScreen
 ){
 
@@ -319,13 +318,13 @@ XvCloseScreen(
   pScreen->DestroyWindow = pxvs->DestroyWindow;
   pScreen->CloseScreen = pxvs->CloseScreen;
 
-  (* pxvs->ddCloseScreen)(ii, pScreen); 
+  (* pxvs->ddCloseScreen)(pScreen);
 
   free(pxvs);
 
   pScreen->devPrivates[XvScreenIndex].ptr = (void *)NULL;
 
-  return (*pScreen->CloseScreen)(ii, pScreen);
+  return (*pScreen->CloseScreen)(pScreen);
 
 }
 

--- a/nx-X11/programs/Xserver/Xext/xvmc.c
+++ b/nx-X11/programs/Xserver/Xext/xvmc.c
@@ -696,7 +696,7 @@ XvMCExtensionInit()
 }
 
 static Bool
-XvMCCloseScreen (int i, ScreenPtr pScreen)
+XvMCCloseScreen (ScreenPtr pScreen)
 {
     XvMCScreenPtr pScreenPriv = XVMC_GET_PRIVATE(pScreen);
 
@@ -704,7 +704,7 @@ XvMCCloseScreen (int i, ScreenPtr pScreen)
 
     free(pScreenPriv);
 
-    return (*pScreen->CloseScreen)(i, pScreen);
+    return (*pScreen->CloseScreen)(pScreen);
 }
 
 

--- a/nx-X11/programs/Xserver/composite/compinit.c
+++ b/nx-X11/programs/Xserver/composite/compinit.c
@@ -40,7 +40,7 @@ int CompSubwindowsPrivIndex = -1;
 #endif
 
 static Bool
-compCloseScreen (int index, ScreenPtr pScreen)
+compCloseScreen (ScreenPtr pScreen)
 {
     CompScreenPtr   cs = GetCompScreen (pScreen);
     Bool	    ret;
@@ -78,7 +78,7 @@ compCloseScreen (int index, ScreenPtr pScreen)
 
     free (cs);
     FAKE_DIX_SET_SCREEN_PRIVATE(pScreen, NULL);
-    ret = (*pScreen->CloseScreen) (index, pScreen);
+    ret = (*pScreen->CloseScreen) (pScreen);
     return ret;
 }
 

--- a/nx-X11/programs/Xserver/dix/main.c
+++ b/nx-X11/programs/Xserver/dix/main.c
@@ -372,7 +372,7 @@ main(int argc, char *argv[], char *envp[])
 	    FreeScratchPixmapsForScreen(i);
 	    FreeGCperDepth(i);
 	    FreeDefaultStipple(i);
-	    (* screenInfo.screens[i]->CloseScreen)(i, screenInfo.screens[i]);
+	    (* screenInfo.screens[i]->CloseScreen)(screenInfo.screens[i]);
 	    FreeScreen(screenInfo.screens[i]);
 	    screenInfo.numScreens = i;
 	}

--- a/nx-X11/programs/Xserver/fb/fb.h
+++ b/nx-X11/programs/Xserver/fb/fb.h
@@ -1703,7 +1703,7 @@ fbPushPixels (GCPtr	    pGC,
  */
 
 Bool
-fbCloseScreen (int indx, ScreenPtr pScreen);
+fbCloseScreen (ScreenPtr pScreen);
 
 Bool
 fbRealizeFont(ScreenPtr pScreen, FontPtr pFont);

--- a/nx-X11/programs/Xserver/fb/fboverlay.c
+++ b/nx-X11/programs/Xserver/fb/fboverlay.c
@@ -88,7 +88,7 @@ fbOverlayCreateWindow(WindowPtr pWin)
 }
 
 Bool
-fbOverlayCloseScreen (int iScreen, ScreenPtr pScreen)
+fbOverlayCloseScreen (ScreenPtr pScreen)
 {
     FbOverlayScrPrivPtr	pScrPriv = fbOverlayGetScrPriv(pScreen);
     int			i;

--- a/nx-X11/programs/Xserver/fb/fboverlay.h
+++ b/nx-X11/programs/Xserver/fb/fboverlay.h
@@ -65,7 +65,7 @@ Bool
 fbOverlayCreateWindow(WindowPtr pWin);
 
 Bool
-fbOverlayCloseScreen (int iScreen, ScreenPtr pScreen);
+fbOverlayCloseScreen (ScreenPtr pScreen);
 
 int
 fbOverlayWindowLayer(WindowPtr pWin);

--- a/nx-X11/programs/Xserver/fb/fbscreen.c
+++ b/nx-X11/programs/Xserver/fb/fbscreen.c
@@ -29,7 +29,7 @@
 #include "fb.h"
 
 Bool
-fbCloseScreen (int index, ScreenPtr pScreen)
+fbCloseScreen (ScreenPtr pScreen)
 {
     int	    d;
     DepthPtr	depths = pScreen->allowedDepths;

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -820,7 +820,7 @@ static int nxagentColorOffset(unsigned long mask)
   return count;
 }
 
-Bool nxagentOpenScreen(int index, ScreenPtr pScreen,
+Bool nxagentOpenScreen(ScreenPtr pScreen,
                            int argc, char *argv[])
 {
   VisualPtr visuals;
@@ -846,7 +846,7 @@ Bool nxagentOpenScreen(int index, ScreenPtr pScreen,
 
   #ifdef TEST
   fprintf(stderr, "nxagentOpenScreen: Called for screen index [%d].\n",
-              index);
+              pScreen->myNum);
   #endif
 
   if (nxagentRenderEnable && nxagentReconnectTrap == False)
@@ -2075,7 +2075,7 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
   return True;
 }
 
-Bool nxagentCloseScreen(int index, ScreenPtr pScreen)
+Bool nxagentCloseScreen(ScreenPtr pScreen)
 {
   int i;
 
@@ -3552,7 +3552,7 @@ Bool nxagentReconnectScreen(void *p0)
   fprintf(stderr, "nxagentReconnectScreen\n");
 #endif
 
-  if (!nxagentOpenScreen(0, nxagentDefaultScreen, nxagentArgc, nxagentArgv))
+  if (!nxagentOpenScreen(nxagentDefaultScreen, nxagentArgc, nxagentArgv))
   {
     return False;
   }

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.h
@@ -88,10 +88,10 @@ void nxagentInitViewportFrame(ScreenPtr pScreen, WindowPtr pRootWin);
 
 #endif /* #ifdef VIEWPORT_FRAME */
 
-Bool nxagentOpenScreen(int index, ScreenPtr pScreen,
+Bool nxagentOpenScreen(ScreenPtr pScreen,
                            int argc, char *argv[]);
 
-Bool nxagentCloseScreen(int index, ScreenPtr pScreen);
+Bool nxagentCloseScreen(ScreenPtr pScreen);
 
 #define nxagentScreen(window) nxagentDefaultScreen
 

--- a/nx-X11/programs/Xserver/include/screenint.h
+++ b/nx-X11/programs/Xserver/include/screenint.h
@@ -79,7 +79,6 @@ extern Bool AllocateGCPrivate(
 
 extern int AddScreen(
     Bool (* /*pfnInit*/)(
-	int /*index*/,
 	ScreenPtr /*pScreen*/,
 	int /*argc*/,
 	char ** /*argv*/),

--- a/nx-X11/programs/Xserver/include/scrnintstr.h
+++ b/nx-X11/programs/Xserver/include/scrnintstr.h
@@ -89,7 +89,6 @@ typedef struct _Depth {
  */
 
 typedef    Bool (* CloseScreenProcPtr)(
-	int /*index*/,
 	ScreenPtr /*pScreen*/);
 
 typedef    void (* QueryBestSizeProcPtr)(

--- a/nx-X11/programs/Xserver/mi/mi.h
+++ b/nx-X11/programs/Xserver/mi/mi.h
@@ -437,7 +437,6 @@ extern Bool miModifyPixmapHeader(
 );
 
 extern Bool miCloseScreen(
-    int /*index*/,
     ScreenPtr /*pScreen*/
 );
 

--- a/nx-X11/programs/Xserver/mi/mibstore.c
+++ b/nx-X11/programs/Xserver/mi/mibstore.c
@@ -183,7 +183,7 @@ else \
 static int  miBSScreenIndex;
 static unsigned long miBSGeneration = 0;
 
-static Bool	    miBSCloseScreen(int i, ScreenPtr pScreen);
+static Bool	    miBSCloseScreen(ScreenPtr pScreen);
 static void	    miBSGetImage(DrawablePtr pDrawable, int sx, int sy,
 				 int w, int h, unsigned int format,
 				 unsigned long planemask, char *pdstLine);
@@ -416,8 +416,7 @@ miInitializeBackingStore (pScreen)
  */
 
 static Bool
-miBSCloseScreen (i, pScreen)
-    int		i;
+miBSCloseScreen (pScreen)
     ScreenPtr	pScreen;
 {
     miBSScreenPtr   pScreenPriv;
@@ -432,7 +431,7 @@ miBSCloseScreen (i, pScreen)
 
     free ((void *) pScreenPriv);
 
-    return (*pScreen->CloseScreen) (i, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 static void miBSFillVirtualBits(DrawablePtr pDrawable, GCPtr pGC,

--- a/nx-X11/programs/Xserver/mi/midispcur.c
+++ b/nx-X11/programs/Xserver/mi/midispcur.c
@@ -56,7 +56,7 @@ in this Software without prior written authorization from The Open Group.
 static int	miDCScreenIndex;
 static unsigned long miDCGeneration = 0;
 
-static Bool	miDCCloseScreen(int index, ScreenPtr pScreen);
+static Bool	miDCCloseScreen(ScreenPtr pScreen);
 
 typedef struct {
     GCPtr	    pSourceGC, pMaskGC;
@@ -163,8 +163,7 @@ miDCInitialize (pScreen, screenFuncs)
 #define tossPict(pict)	(pict ? FreePicture (pict, 0) : 0)
 
 static Bool
-miDCCloseScreen (index, pScreen)
-    int		index;
+miDCCloseScreen (pScreen)
     ScreenPtr	pScreen;
 {
     miDCScreenPtr   pScreenPriv;
@@ -185,7 +184,7 @@ miDCCloseScreen (index, pScreen)
     tossPict (pScreenPriv->pTempPicture);
 #endif
     free ((void *) pScreenPriv);
-    return (*pScreen->CloseScreen) (index, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 static Bool

--- a/nx-X11/programs/Xserver/mi/mioverlay.c
+++ b/nx-X11/programs/Xserver/mi/mioverlay.c
@@ -62,7 +62,7 @@ static Bool HasUnderlayChildren(WindowPtr);
 static void MarkUnderlayWindow(WindowPtr);
 static Bool CollectUnderlayChildrenRegions(WindowPtr, RegionPtr);
 
-static Bool miOverlayCloseScreen(int, ScreenPtr);
+static Bool miOverlayCloseScreen(ScreenPtr);
 static Bool miOverlayCreateWindow(WindowPtr);
 static Bool miOverlayDestroyWindow(WindowPtr);
 static Bool miOverlayUnrealizeWindow(WindowPtr);
@@ -167,7 +167,7 @@ miInitOverlay(
 
 
 static Bool 
-miOverlayCloseScreen(int i, ScreenPtr pScreen)
+miOverlayCloseScreen(ScreenPtr pScreen)
 {
    miOverlayScreenPtr pScreenPriv = MIOVERLAY_GET_SCREEN_PRIVATE(pScreen);
 
@@ -179,7 +179,7 @@ miOverlayCloseScreen(int i, ScreenPtr pScreen)
 
    free(pScreenPriv);
 
-   return (*pScreen->CloseScreen)(i, pScreen);
+   return (*pScreen->CloseScreen)(pScreen);
 }
 
 

--- a/nx-X11/programs/Xserver/mi/mipointer.c
+++ b/nx-X11/programs/Xserver/mi/mipointer.c
@@ -66,7 +66,7 @@ static void miPointerCursorLimits(ScreenPtr pScreen, CursorPtr pCursor,
 				  BoxPtr pHotBox, BoxPtr pTopLeftBox);
 static Bool miPointerSetCursorPosition(ScreenPtr pScreen, int x, int y,
 				       Bool generateEvent);
-static Bool miPointerCloseScreen(int index, ScreenPtr pScreen);
+static Bool miPointerCloseScreen(ScreenPtr pScreen);
 static void miPointerMove(ScreenPtr pScreen, int x, int y, unsigned long time);
 
 Bool
@@ -132,8 +132,7 @@ miPointerInitialize (pScreen, spriteFuncs, screenFuncs, waitForUpdate)
 }
 
 static Bool
-miPointerCloseScreen (index, pScreen)
-    int		index;
+miPointerCloseScreen (pScreen)
     ScreenPtr	pScreen;
 {
     SetupScreen(pScreen);
@@ -144,7 +143,7 @@ miPointerCloseScreen (index, pScreen)
 	miPointer.pSpriteScreen = 0;
     pScreen->CloseScreen = pScreenPriv->CloseScreen;
     free ((void *) pScreenPriv);
-    return (*pScreen->CloseScreen) (index, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 /*

--- a/nx-X11/programs/Xserver/mi/miscrinit.c
+++ b/nx-X11/programs/Xserver/mi/miscrinit.c
@@ -128,8 +128,7 @@ miModifyPixmapHeader(pPixmap, width, height, depth, bitsPerPixel, devKind,
 
 /*ARGSUSED*/
 Bool
-miCloseScreen (iScreen, pScreen)
-    int		iScreen;
+miCloseScreen (pScreen)
     ScreenPtr	pScreen;
 {
     return ((*pScreen->DestroyPixmap)((PixmapPtr)pScreen->devPrivate));

--- a/nx-X11/programs/Xserver/mi/misprite.c
+++ b/nx-X11/programs/Xserver/mi/misprite.c
@@ -70,7 +70,7 @@ in this Software without prior written authorization from The Open Group.
 static int  miSpriteScreenIndex;
 static unsigned long miSpriteGeneration = 0;
 
-static Bool	    miSpriteCloseScreen(int i, ScreenPtr pScreen);
+static Bool	    miSpriteCloseScreen(ScreenPtr pScreen);
 static void	    miSpriteGetImage(DrawablePtr pDrawable, int sx, int sy,
 				     int w, int h, unsigned int format,
 				     unsigned long planemask, char *pdstLine);
@@ -248,8 +248,7 @@ miSpriteInitialize (pScreen, cursorFuncs, screenFuncs)
  */
 
 static Bool
-miSpriteCloseScreen (i, pScreen)
-    int i;
+miSpriteCloseScreen (pScreen)
     ScreenPtr	pScreen;
 {
     miSpriteScreenPtr   pScreenPriv;
@@ -270,7 +269,7 @@ miSpriteCloseScreen (i, pScreen)
     
     free ((void *) pScreenPriv);
 
-    return (*pScreen->CloseScreen) (i, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 static void

--- a/nx-X11/programs/Xserver/miext/cw/cw.c
+++ b/nx-X11/programs/Xserver/miext/cw/cw.c
@@ -55,7 +55,7 @@ static unsigned long cwGeneration = 0;
 extern GCOps cwGCOps;
 
 static Bool
-cwCloseScreen (int i, ScreenPtr pScreen);
+cwCloseScreen (ScreenPtr pScreen);
 
 static void
 cwValidateGC(GCPtr pGC, unsigned long stateChanges, DrawablePtr pDrawable);
@@ -673,7 +673,7 @@ miDisableCompositeWrapper(ScreenPtr pScreen)
 }
 
 static Bool
-cwCloseScreen (int i, ScreenPtr pScreen)
+cwCloseScreen (ScreenPtr pScreen)
 {
     cwScreenPtr   pScreenPriv;
 #ifdef RENDER
@@ -697,5 +697,5 @@ cwCloseScreen (int i, ScreenPtr pScreen)
 
     free((void *)pScreenPriv);
 
-    return (*pScreen->CloseScreen)(i, pScreen);
+    return (*pScreen->CloseScreen)(pScreen);
 }

--- a/nx-X11/programs/Xserver/miext/damage/damage.c
+++ b/nx-X11/programs/Xserver/miext/damage/damage.c
@@ -1717,7 +1717,7 @@ damageDestroyWindow (WindowPtr pWindow)
 }
 
 static Bool
-damageCloseScreen (int i, ScreenPtr pScreen)
+damageCloseScreen (ScreenPtr pScreen)
 {
     damageScrPriv(pScreen);
 
@@ -1729,7 +1729,7 @@ damageCloseScreen (int i, ScreenPtr pScreen)
     unwrap (pScrPriv, pScreen, CloseScreen);
     unwrap (pScrPriv, pScreen, BackingStoreFuncs.RestoreAreas);
     free (pScrPriv);
-    return (*pScreen->CloseScreen) (i, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 int damageScrPrivateIndex;

--- a/nx-X11/programs/Xserver/randr/randr.c
+++ b/nx-X11/programs/Xserver/randr/randr.c
@@ -118,9 +118,6 @@ RRClientCallback(CallbackListPtr *list, void *closure, void *data)
 
 static Bool
 RRCloseScreen(
-#ifdef NXAGENT_SERVER
-              int i,
-#endif
               ScreenPtr pScreen)
 {
     rrScrPriv(pScreen);
@@ -141,7 +138,7 @@ RRCloseScreen(
     free(pScrPriv->outputs);
     free(pScrPriv);
     RRNScreens -= 1;            /* ok, one fewer screen with RandR running */
-    return (*pScreen->CloseScreen) (i, pScreen);
+    return (*pScreen->CloseScreen) (pScreen);
 }
 
 static void

--- a/nx-X11/programs/Xserver/render/animcur.c
+++ b/nx-X11/programs/Xserver/render/animcur.c
@@ -111,7 +111,7 @@ AnimCurSetCursorPosition (ScreenPtr pScreen,
 			  Bool generateEvent);
 
 static Bool
-AnimCurCloseScreen (int index, ScreenPtr pScreen)
+AnimCurCloseScreen (ScreenPtr pScreen)
 {
     AnimCurScreenPtr    as = GetAnimCurScreen(pScreen);
     Bool                ret;
@@ -127,10 +127,10 @@ AnimCurCloseScreen (int index, ScreenPtr pScreen)
     Unwrap(as, pScreen, UnrealizeCursor);
     Unwrap(as, pScreen, RecolorCursor);
     SetAnimCurScreen(pScreen,0);
-    ret = (*pScreen->CloseScreen) (index, pScreen);
+    ret = (*pScreen->CloseScreen) (pScreen);
     free (as);
-    if (index == 0)
-	AnimCurScreenPrivateIndex = -1;
+    if (screenInfo.numScreens <= 1)
+      AnimCurScreenPrivateIndex = -1;
     return ret;
 }
 

--- a/nx-X11/programs/Xserver/render/picture.c
+++ b/nx-X11/programs/Xserver/render/picture.c
@@ -127,14 +127,14 @@ PictureDestroyWindow (WindowPtr pWindow)
 }
 
 Bool
-PictureCloseScreen (int index, ScreenPtr pScreen)
+PictureCloseScreen (ScreenPtr pScreen)
 {
     PictureScreenPtr    ps = GetPictureScreen(pScreen);
     Bool                ret;
     int			n;
 
     pScreen->CloseScreen = ps->CloseScreen;
-    ret = (*pScreen->CloseScreen) (index, pScreen);
+    ret = (*pScreen->CloseScreen) (pScreen);
     PictureResetFilters (pScreen);
     for (n = 0; n < ps->nformats; n++)
 	if (ps->formats[n].type == PictTypeIndexed)

--- a/nx-X11/programs/Xserver/render/picturestr.h
+++ b/nx-X11/programs/Xserver/render/picturestr.h
@@ -406,7 +406,7 @@ Bool
 PictureDestroyWindow (WindowPtr pWindow);
 
 Bool
-PictureCloseScreen (int Index, ScreenPtr pScreen);
+PictureCloseScreen (ScreenPtr pScreen);
 
 void
 PictureStoreColors (ColormapPtr pColormap, int ndef, xColorItem *pdef);

--- a/nx-X11/programs/Xserver/xfixes/cursor.c
+++ b/nx-X11/programs/Xserver/xfixes/cursor.c
@@ -114,17 +114,17 @@ CursorDisplayCursor (ScreenPtr pScreen,
 }
 
 static Bool
-CursorCloseScreen (int index, ScreenPtr pScreen)
+CursorCloseScreen (ScreenPtr pScreen)
 {
     CursorScreenPtr	cs = GetCursorScreen (pScreen);
     Bool		ret;
 
     Unwrap (cs, pScreen, CloseScreen);
     Unwrap (cs, pScreen, DisplayCursor);
-    ret = (*pScreen->CloseScreen) (index, pScreen);
+    ret = (*pScreen->CloseScreen) (pScreen);
     free (cs);
-    if (index == 0)
-	CursorScreenPrivateIndex = -1;
+    if (screenInfo.numScreens <= 1)
+       CursorScreenPrivateIndex = -1;
     return ret;
 }
 


### PR DESCRIPTION
 Extracted from X.org bulk commit:

 commit 1f0e8bd5eb1a5539689cfc4f5a6b86b530907ec5
 Author: Dave Airlie <airlied@redhat.com>
 Date:   Tue Jun 5 13:22:18 2012 +0100

    api: rework the X server driver API to avoid global arrays.

    This is a squash merge containing all the API changes, as
    well as the video ABI bump.

    Its been squashed to make bisection easier.

    Full patch log below:

    [...]

    commit 06729dbbc804a20242e6499f446acb5d94023c3c
    Author: Dave Airlie <airlied@gmail.com>
    Date:   Tue Apr 10 14:04:59 2012 +0100

        xserver: remove index from CloseScreen (API/ABI breakage)

        This drops the index from the CloseScreen callback,
        its always been useless really, since the pScreen contains it.

        Reviewed-by: Alan Coopersmith <alan.coopersmith@oracle.com>
        Acked-by: Aaron Plattner <aplattner@nvidia.com>
        Reviewed-by: Adam Jackson <ajax@redhat.com>
        Signed-off-by: Dave Airlie <airlied@redhat.com>