### PR TITLE
nxcomp: Use Cygwin un.h & remove EMX code

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -102,15 +102,6 @@ typedef int socklen_t;
 // System specific defines.
 //
 
-#if defined(__EMX__)
-
-struct sockaddr_un
-{
-  u_short sun_family;
-  char sun_path[108];
-};
-
-#endif
 
 //
 // HP-UX hides this define.

--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -75,7 +75,6 @@ typedef int socklen_t;
 
 #ifndef __CYGWIN32__
 #include <netinet/tcp.h>
-#include <sys/un.h>
 #endif
 
 //
@@ -103,7 +102,7 @@ typedef int socklen_t;
 // System specific defines.
 //
 
-#if defined(__EMX__) || defined(__CYGWIN32__)
+#if defined(__EMX__)
 
 struct sockaddr_un
 {

--- a/nxcomp/Proxy.cpp
+++ b/nxcomp/Proxy.cpp
@@ -43,17 +43,13 @@
 #include <netinet/in_systm.h>
 #endif
 
-#ifndef __CYGWIN32__
-#include <sys/un.h>
-#endif
-
 #ifndef ANDROID
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #endif
 
-#if defined(__EMX__ ) || defined(__CYGWIN32__)
+#if defined(__EMX__ )
 
 struct sockaddr_un
 {

--- a/nxcomp/Proxy.cpp
+++ b/nxcomp/Proxy.cpp
@@ -49,16 +49,6 @@
 #include <netinet/tcp.h>
 #endif
 
-#if defined(__EMX__ )
-
-struct sockaddr_un
-{
-  u_short sun_family;
-  char sun_path[108];
-};
-
-#endif
-
 #include "NXalert.h"
 #include "NXvars.h"
 


### PR DESCRIPTION
Cygwin has modified it over the years.
Fixes FTBFS #394 

Note that Loop.cpp now has this line defined outside of the #ifndef 
#include <sys/un.h>