### PR TITLE
Enhance -displayfd code path and display number auto detection

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -180,8 +180,23 @@ causes the server to generate a core dump on fatal errors.
 specifies a file descriptor in the launching process.  Rather than specifying
 a display number, the X server will attempt to listen on successively higher
 display numbers, and upon finding a free one, will write the port number back
-on this file descriptor as a newline-terminated string.  The \-pn option is
-ignored when using \-displayfd.
+on this file descriptor as a newline-terminated string.  The \fB\-pn\fR option is
+ignored when using \fB\-displayfd\fR.
+
+nxagent specific:
+
+(1) Other than in X.org's Xserver, you can use \fB\-displayfd\fR in
+conjunction with an explicit display number. If the explicit display number
+is not available (i.e., already in use), nxagent tries to figure out the next
+available display number,
+
+e.g.:
+
+   \fBnxagent\fR \fI\-displayfd 2 :50\fR
+
+(2) If -displayfd <X> is given with <X> equaling 2 (STDERR), then the
+display number string written to STDERR is beautified with some human-readable
+(machine-parseable) text.
 .TP 8
 .B \-deferglyphs \fIwhichfonts\fP
 specifies the types of fonts for which the server should attempt to use

--- a/nx-X11/programs/Xserver/os/connection.c
+++ b/nx-X11/programs/Xserver/os/connection.c
@@ -427,7 +427,11 @@ CreateWellKnownSockets(void)
     if (NoListenAll) {
 	ListenTransCount = 0;
     }
+#ifndef NXAGENT_SERVER
     else if ((displayfd < 0) || explicit_display) {
+#else
+    else if (displayfd < 0) {
+#endif /* ! NXAGENT_SERVER */
         if (TryCreateSocket(atoi(display), &partial) &&
             ListenTransCount >= 1)
             if (!PartialNetwork && partial)
@@ -435,7 +439,14 @@ CreateWellKnownSockets(void)
     }
     else { /* -displayfd and no explicit display number */
 	Bool found = 0;
+#ifdef NXAGENT_SERVER
+	int i_offset = 0;
+	if (explicit_display)
+	     i_offset = atoi(display);
+	for (i = i_offset; i < 65536 - X_TCP_PORT; i++) {
+#else
 	for (i = 0; i < 65536 - X_TCP_PORT; i++) {
+#endif /* NXAGENT_SERVER */
 	    if (TryCreateSocket(i, &partial) && !partial) {
 		found = 1;
 		break;

--- a/nx-X11/programs/Xserver/os/connection.c
+++ b/nx-X11/programs/Xserver/os/connection.c
@@ -79,6 +79,7 @@ SOFTWARE.
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #ifndef WIN32
 #include <sys/socket.h>
@@ -364,6 +365,14 @@ NotifyParentProcess(void)
 {
 #if !defined(WIN32)
     if (displayfd >= 0) {
+#ifdef NXAGENT_SERVER
+	if (displayfd == STDERR_FILENO)
+	{
+	    const char *msg = "Auto-detected display number is: DISPLAY=:";
+	    if (write(displayfd, msg, strlen(msg)) != strlen(msg))
+		FatalError("Cannot write display number to fd %d\n", displayfd);
+	}
+#endif
 	if (write(displayfd, display, strlen(display)) != strlen(display))
 	    FatalError("Cannot write display number to fd %d\n", displayfd);
 	if (write(displayfd, "\n", 1) != 1)


### PR DESCRIPTION
This PR fixes #418. It slightly modifies the behaviour of the new -displayfd cmdline option for nxagent:

  * -displayfd 2 -> this will pipe the display number to stderr and add some beautiful text around it.
  * -displayfd <X> : 50 -> this will let the nxagent auto-detect a free display number, starting at :50

