### PR TITLE
Mesa.patches: Define USE_IEEE for __aarch64__ and __mc68000__, as well.

### DIFF
--- a/nx-X11/extras/Mesa.patches/4002_define-USE_IEEE-macro-for-more-platforms.patch
+++ b/nx-X11/extras/Mesa.patches/4002_define-USE_IEEE-macro-for-more-platforms.patch
@@ -1,0 +1,16 @@
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Description: define USE_IEEE for __aarch64__ and __mc68000__, as well
+
+Index: Mesa/src/mesa/main/imports.h
+===================================================================
+--- Mesa.orig/src/mesa/main/imports.h
++++ Mesa/src/mesa/main/imports.h
+@@ -204,6 +204,8 @@ typedef union { GLfloat f; GLint i; } fi
+     defined(ia64) || defined(__ia64__) || \
+     defined(__mips) || defined(_MIPS_ARCH) || \
+     defined(__arm__) || \
++    defined(__aarch64__) || \
++    defined(__mc68000__) || \
+     defined(__sh__) || \
+     (defined(__alpha__) && (defined(__IEEE_FLOAT) || !defined(VMS)))
+ #define USE_IEEE

--- a/nx-X11/extras/Mesa.patches/series
+++ b/nx-X11/extras/Mesa.patches/series
@@ -1,1 +1,2 @@
 4001_CreatePixmap-AllocationHints.patch
+4002_define-USE_IEEE-macro-for-more-platforms.patch


### PR DESCRIPTION
Fixes an FTBFS in Mesa on arm64 and m68k Linux.