### PR TITLE
Makefile: only call build on make all (and some minor changes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ SHELL:=/bin/bash
 	    if test -f nx-X11/Makefile; then ${MAKE} -C nx-X11 $@; fi; \
 	fi
 
-	# clean auto-generated nxversion.def file \
+	# clean auto-generated files
 	if [ "x$@" == "xclean" ] || [ "x$@" = "xdistclean" ]; then \
 	    ./mesa-quilt pop -a; \
 	    rm -Rf nx-X11/extras/Mesa/.pc/; \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ SHELL:=/bin/bash
 	    ./mesa-quilt pop -a; \
 	    rm -Rf nx-X11/extras/Mesa/.pc/; \
 	    rm -f nx-X11/config/cf/nxversion.def; \
+	    rm -f nx-X11/config/cf/date.def; \
 	    rm -f bin/nxagent; \
 	    rm -f bin/nxproxy; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ SHELL:=/bin/bash
 	    rm -f bin/nxproxy; \
 	fi
 
-all: build
+all:
+	${MAKE} build
 
 test:
 	echo "No testing for NX (redistributed)"


### PR DESCRIPTION
While testing nx-libs builds on various Debian platforms, I noticed that our main Makefile behaves awkward on "make all".

The current state is: 

  make all -> make build and then the '%:' ruleset

The new state is:

  make all -> make build

See https://buildd.debian.org/status/fetch.php?pkg=nx-libs&arch=hurd-i386&ver=2%3A3.5.99.5-3&stamp=1492088656&raw=0 for reference.