### PR TITLE
Revert "Switch from using libNX_X11's deprecated XKeycodeToKeysym() f…

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -934,7 +934,7 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
       {
         enum HandleEventResult result;
 
-        XlibKeySym *keysym;
+        KeySym keysym;
 
         #ifdef TEST
         fprintf(stderr, "nxagentDispatchEvents: Going to handle new KeyPress event.\n");
@@ -1101,17 +1101,12 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
          * sive delay.
          */
 
-        int keysyms_per_keycode_return;
-        keysym = XGetKeyboardMapping(nxagentDisplay,
-                                     X.xkey.keycode,
-                                     1,
-                                     &keysyms_per_keycode_return);
+        keysym = XKeycodeToKeysym(nxagentDisplay, X.xkey.keycode, 0);
 
-        if (nxagentMonitoredDuplicate(keysym[0]) == 1)
+        if (nxagentMonitoredDuplicate(keysym) == 1)
         {
           nxagentRemoveDuplicatedKeys(&X);
         }
-        free(keysym);
 
         if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow) == 1 && result == doNothing)
         {
@@ -4657,16 +4652,8 @@ void nxagentDumpInputDevicesState(void)
       {
         if (val & (mask << k))
         {
-          int keysyms_per_keycode_return;
-          XlibKeySym *keysym = XGetKeyboardMapping(nxagentDisplay,
-                                                     i * 8 + k,
-                                                     1,
-                                                     &keysyms_per_keycode_return);
-
-
           fprintf(stderr, "\n\t[%d] [%s]", i * 8 + k,
-                      XKeysymToString(keysym[0]));
-          free(keysym);
+                      XKeysymToString(XKeycodeToKeysym(nxagentDisplay, i * 8 + k, 0)));
         }
       }
     }

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
@@ -480,30 +480,25 @@ void nxagentDumpKeystrokes(void)
 static enum nxagentSpecialKeystroke find_keystroke(XKeyEvent *X)
 {
   enum nxagentSpecialKeystroke ret = KEYSTROKE_NOTHING;
-  int keysyms_per_keycode_return;
 
-  XlibKeySym *keysym = XGetKeyboardMapping(nxagentDisplay,
-                                           X->keycode,
-                                           1,
-                                           &keysyms_per_keycode_return);
+  KeySym keysym = XKeycodeToKeysym(nxagentDisplay, X->keycode, 0);
+
 
   #ifdef DEBUG
-  fprintf(stderr, "%s: got keysym '%c' (%d)\n", __func__, keysym[0], keysym[0]);
+  fprintf(stderr, "%s: got keysym '%c' (%d)\n", __func__, keysym, keysym);
   #endif
   for (struct nxagentSpecialKeystrokeMap *cur = map; cur->stroke != KEYSTROKE_END_MARKER; cur++) {
     #ifdef DEBUG
     fprintf(stderr, "%s: checking keysym '%c' (%d)\n", __func__, cur->keysym, cur->keysym);
     #endif
-    if (cur->keysym == keysym[0] && modifier_matches(cur->modifierMask, cur->modifierAltMeta, X->state)) {
+    if (cur->keysym == keysym && modifier_matches(cur->modifierMask, cur->modifierAltMeta, X->state)) {
       #ifdef DEBUG
       fprintf(stderr, "%s: match including modifiers for keysym '%c' (%d), stroke %d (%s)\n", __func__, cur->keysym, cur->keysym, cur->stroke, nxagentSpecialKeystrokeNames[cur->stroke]);
       #endif
-      free(keysym);
       return cur->stroke;
     }
   }
 
-  free(keysym);
   return ret;
 }
 


### PR DESCRIPTION
…unction to using XGetKeyboardMapping()."

This reverts commit efc0dae0519aa0ef1fabea6a64919475fd916347.

Recent test revealed keyboard hangs on high latency connections. These
hangs are not happening in 3.5.0 releases if the nx-libs.

The commit above is responsible for them so we take that back.

Interestingly nxcomp has special treatment for XGetKeyboardMapping()
so it should normally speed up things but it results in the opposite
for us. Needs further examination.

This fixes ArcticaProject/nx-libs#450