### PR TITLE
Fix FTBFS on mips64el architecture due to missing definition of the _…

### DIFF
--- a/nx-X11/config/cf/Imake.cf
+++ b/nx-X11/config/cf/Imake.cf
@@ -883,6 +883,9 @@ XCOMM Keep cpp from replacing path elements containing i486/i586/i686
 #  undef __mips__
 #  if defined(MIPSEL) || defined(_MIPSEL)
 #   define MipselArchitecture
+#   if (_MIPS_SIM == _ABI64)
+#    define Mips64elArchitecture
+#   endif
 #  endif
 #  undef MIPSEL
 #  undef _MIPSEL

--- a/nx-X11/config/cf/linux.cf
+++ b/nx-X11/config/cf/linux.cf
@@ -790,10 +790,8 @@ XCOMM binutils:	(LinuxBinUtilsMajorVersion)
 # define ServerOSDefines	XFree86ServerOSDefines -DDDXTIME
 # define AsVISOption		-Av9a
 # ifdef Sparc64Architecture
-#  define AsOutputArchSize	64
 #  define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines -D_XSERVER64
 # else
-#  define AsOutputArchSize	32
 #  define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines
 # endif
 #endif

--- a/nx-X11/config/cf/linux.cf
+++ b/nx-X11/config/cf/linux.cf
@@ -723,13 +723,26 @@ XCOMM binutils:	(LinuxBinUtilsMajorVersion)
 # define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines
 #endif /* Mc68020Architecture */
 
-#ifdef MipsArchitecture
+#if defined(MipsArchitecture) && !defined(MipselArchitecture)
 # ifndef OptimizedCDebugFlags
 #  define OptimizedCDebugFlags	DefaultGcc2MipsOpt
 # endif
 # define LinuxMachineDefines	-D__mips__
 # define ServerOSDefines	XFree86ServerOSDefines -DDDXTIME
 # define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines
+#endif
+
+#ifdef MipselArchitecture
+# ifndef OptimizedCDebugFlags
+#  define OptimizedCDebugFlags	DefaultGcc2MipsOpt
+# endif
+# define LinuxMachineDefines	-D__MIPSEL__
+# define ServerOSDefines	XFree86ServerOSDefines -DDDXTIME
+# ifdef Mips64elArchitecture
+#  define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines -D_XSERVER64
+# else
+#  define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines
+# endif
 #endif
 
 #ifdef Ppc64Architecture


### PR DESCRIPTION
…XSERVER64 macro.