### PR TITLE
hw/nxagent/Window.c: Introduce NX_REAL_WINDOW window property.

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -128,6 +128,7 @@ extern const char *__progname;
 
 char nxagentDisplayName[1024];
 Bool nxagentSynchronize = False;
+Bool nxagentRealWindowProp = False;
 
 char nxagentShadowDisplayName[1024] = {0};
 
@@ -401,6 +402,11 @@ int ddxProcessArgument(int argc, char *argv[], int i)
 
   if (!strcmp(argv[i], "-sync")) {
     nxagentSynchronize = True;
+    return 1;
+  }
+
+  if (!strcmp(argv[i], "-nxrealwindowprop")) {
+    nxagentRealWindowProp = True;
     return 1;
   }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.h
@@ -59,6 +59,7 @@ extern char nxagentWindowName[];
 extern char nxagentDialogName[];
 
 extern Bool nxagentSynchronize;
+extern Bool nxagentRealWindowProp;
 extern Bool nxagentFullGeneration;
 extern int nxagentDefaultClass;
 extern Bool nxagentUserDefaultClass;

--- a/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
@@ -53,6 +53,11 @@
 #undef  TEST
 #undef  DEBUG
 
+#ifdef DEBUG
+/* for validateString() */
+#include "Utils.h"
+#endif
+
 /*
  * These values should be moved in
  * the option repository.

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -466,6 +466,18 @@ FIXME: Do all the windows for which nxagentWindowTopLevel(pWin)
     nxagentRedirectWindow(pWin);
   }
 
+  if ((nxagentRealWindowProp) && (!nxagentWindowTopLevel(pWin)))
+  {
+    Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
+
+    if (ChangeWindowProperty(pWin, prop, XA_WINDOW, 32, PropModeReplace, 1, nxagentWindowPriv(pWin), 1) != Success)
+        fprintf(stderr, "nxagentCreateWindow: Adding NX_REAL_WINDOW failed.\n");
+#ifdef DEBUG
+    else
+        fprintf(stderr, "nxagentCreateWindow: Added NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+#endif
+  }
+
   nxagentWindowPriv(pWin)->x = pWin->origin.x - wBorderWidth(pWin);
   nxagentWindowPriv(pWin)->y = pWin->origin.y - wBorderWidth(pWin);
   nxagentWindowPriv(pWin)->width = pWin->drawable.width;
@@ -2674,6 +2686,18 @@ void nxagentDisconnectWindow(void * p0, XID x1, void * p2)
   }
   #endif
 
+  if ((nxagentRealWindowProp) && (!nxagentWindowTopLevel(pWin)))
+  {
+    Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
+
+    if (DeleteProperty(pWin, prop) != Success)
+        fprintf(stderr, "nxagentDisconnectWindow: Deleting NX_REAL_WINDOW failed.\n");
+#ifdef DEBUG
+    else
+        fprintf(stderr, "nxagentDisconnectWindow: Deleting NX_REAL_WINDOW from Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+#endif
+  }
+
   nxagentWindow(pWin) = None;
 
   if (nxagentDrawableStatus((DrawablePtr) pWin) == NotSynchronized)
@@ -3109,6 +3133,18 @@ FIXME: Do we need to set save unders attribute here?
 
       #endif
     }
+  }
+
+  if ((nxagentRealWindowProp) && (!nxagentWindowTopLevel(pWin)))
+  {
+    Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
+
+    if (ChangeWindowProperty(pWin, prop, XA_WINDOW, 32, PropModeReplace, 1, nxagentWindowPriv(pWin), 1) != Success)
+        fprintf(stderr, "nxagentReconnectWindow: Updating NX_REAL_WINDOW failed.\n");
+#ifdef DEBUG
+    else
+        fprintf(stderr, "nxagentReconnectWindow: Updated NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+#endif
   }
 
   if (nxagentDrawableStatus((DrawablePtr) pWin) == NotSynchronized)

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -368,6 +368,8 @@ The nx-X11 system adds the following command line arguments:
 .TP 8
 .B \-forcenx
 force use of NX protocol messages assuming communication through nxproxy
+.B \-nxrealwindowprop
+set property NX_REAL_WINDOW for each X11 client inside NX Agent, providing the window XID of the corresponding window object on the X server that NX Agent runs on
 .TP 8
 .B \-timeout \fIint\fP
 auto-disconnect timeout in seconds (minimum allowed: 60)


### PR DESCRIPTION
In nxagent sessions, all X11 clients have a representation of their NX session-side window object on the real X-Server side.
    
The window object gets stored in the new NX_REAL_WINDOW window property immediately after window creation. This mapping is created in nxagentCreateWindow().
    
On session resumption, the client side window IDs normally change. Thus, during session resumption, all NX_REAL_WINDOW properties require being updated. This happens in nxagentReconnectWindow().
    
While a session is suspended, the NX_REAL_WINDOW property does not exist. It gets removed during nxagentDisconnectWindow().