### PR TITLE
Install as non root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHLIBDIR        ?= $(LIBDIR)
 NXLIBDIR        ?= $(SHLIBDIR)/nx
 USRLIBDIR       ?= $(NXLIBDIR)/X11
 INCLUDEDIR      ?= $(PREFIX)/include
-CONFIGURE       ?= ./configure
+CONFIGURE       ?= ./configure --prefix=$(DESTDIR)$(PREFIX)
 
 # use Xfont2 if available in the build env
 FONT_DEFINES	?= $(shell pkg-config --modversion xfont2 1>/dev/null 2>/dev/null && echo "-DHAS_XFONT2")

--- a/nxcompshad/Makefile.in
+++ b/nxcompshad/Makefile.in
@@ -91,7 +91,7 @@ includedir   = @includedir@
 pkgconfigdir = @pkgconfigdir@
 
 INSTALL         = @INSTALL@
-INSTALL_DIR     = $(INSTALL) -d -o root -g root -m 0755 
+INSTALL_DIR     = $(INSTALL) -d -m 0755
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
 INSTALL_DATA    = @INSTALL_DATA@
 INSTALL_LINK    = cp -av


### PR DESCRIPTION
A couple of patches allowing installation of nx-libs by non root users in custom directories.

For instance:

    DESTDIR=/home/mondo/nx-libs make
    DESTDIR=/home/mondo/nx-libs make install