### PR TITLE
nxcomp: Set TokenSize to 1536 for link type ADSL and WAN. Improving n…

### DIFF
--- a/nxcomp/Loop.cpp
+++ b/nxcomp/Loop.cpp
@@ -12942,7 +12942,7 @@ int SetLinkAdsl()
 
   control -> LinkMode = LINK_TYPE_ADSL;
 
-  control -> TokenSize  = 512;
+  control -> TokenSize  = 1536;
   control -> TokenLimit = 24;
 
   control -> SplitMode             = 1;
@@ -12972,7 +12972,7 @@ int SetLinkWan()
 
   control -> LinkMode = LINK_TYPE_WAN;
 
-  control -> TokenSize  = 768;
+  control -> TokenSize  = 1536;
   control -> TokenLimit = 24;
 
   control -> SplitMode             = 1;


### PR DESCRIPTION
…on-xrender based  browser scrolling behaviour when link type is set to ADSL or WAN.

 Fixes ArcticaProject/nx-libs#443.

@Ionic: Assigning you as reviewer, as it might make sense to backport this patch to 3.5.x.