### PR TITLE
Report Xlib-side window IDs to session.log in machine readable form. …

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -145,6 +145,8 @@ Bool nxagentUserDefaultDepth = False;
 struct UserGeometry nxagentUserGeometry = {0, 0, 0, 0, 0};
 Bool nxagentUserBorderWidth = False;
 int nxagentNumScreens = 0;
+Bool nxagentReportWindowIds = False;
+Bool nxagentReportPrivateWindowIds = False;
 Bool nxagentDoDirectColormaps = False;
 Window nxagentParentWindow = 0;
 Bool nxagentIpaq = False;
@@ -407,6 +409,16 @@ int ddxProcessArgument(int argc, char *argv[], int i)
 
   if (!strcmp(argv[i], "-nxrealwindowprop")) {
     nxagentRealWindowProp = True;
+    return 1;
+  }
+
+  if (!strcmp(argv[i], "-reportwids")) {
+    nxagentReportWindowIds = True;
+    return 1;
+  }
+
+  if (!strcmp(argv[i], "-reportprivatewids")) {
+    nxagentReportPrivateWindowIds = True;
     return 1;
   }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -198,6 +198,7 @@ unsigned long startTime;
  */
 
 extern void RejectWellKnownSockets(void);
+extern Bool nxagentReportWindowIds;
 
 int nxagentServerOrder()
 {
@@ -1334,8 +1335,12 @@ FIXME: Use of nxagentParentWindow is strongly deprecated.
                                        CopyFromParent,
                                        0L, NULL);
 
+  if (nxagentReportWindowIds) {
+    fprintf(stderr, "NXAGENT_WINDOW_ID: CONFINEMENT_WINDOW,WID:[0x%x]\n",
+              nxagentConfineWindow);
+  }
   #ifdef TEST
-  fprintf(stderr, "nxagentOpenDisplay: Created agent's confine window with id [%ld].\n",
+  fprintf(stderr, "nxagentOpenDisplay: Created agent's confine window with id [0x%x].\n",
               nxagentConfineWindow);
   #endif
 
@@ -2842,8 +2847,12 @@ Bool nxagentReconnectDisplay(void *p0)
                                      CopyFromParent,
                                      0L, NULL);
 
+  if (nxagentReportWindowIds) {
+    fprintf(stderr, "NXAGENT_WINDOW_ID: CONFINEMENT_WINDOW,WID:[0x%x]\n",
+              nxagentConfineWindow);
+  }
   #ifdef TEST
-  fprintf(stderr, "nxagentReconnectDisplay: Created agent's confine window with id [%ld].\n",
+  fprintf(stderr, "nxagentReconnectDisplay: Created agent's confine window with id [0x%x].\n",
               nxagentConfineWindow);
   #endif
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -139,6 +139,8 @@ extern Pixmap nxagentIconPixmap;
 extern Pixmap nxagentIconShape;
 extern Bool useXpmIcon;
 
+extern Bool nxagentReportWindowIds;
+
 Window nxagentDefaultWindows[MAXSCREENS];
 Window nxagentInputWindows[MAXSCREENS];
 Window nxagentScreenSaverWindows[MAXSCREENS];
@@ -396,9 +398,13 @@ Window nxagentCreateIconWindow()
                                     DefaultVisual(nxagentDisplay, DefaultScreen(nxagentDisplay)),
                                         valuemask, &attributes);
 
+  if (nxagentReportWindowIds)
+  {
+    fprintf (stderr, "NXAGENT_WINDOW_ID: ICON_WINDOW,WID:[0x%x]\n", nxagentIconWindow);
+  }
   #ifdef TEST
-  fprintf(stderr, "nxagentCreateIconWindow: Created new icon window with id [%lu].\n",
-              (long unsigned int)nxagentIconWindow);
+  fprintf(stderr, "nxagentCreateIconWindow: Created new icon window with id [0x%x].\n",
+              nxagentIconWindow);
   #endif
 
   /*
@@ -1760,9 +1766,13 @@ N/A
                            valuemask , &attributes);
       }
 
+      if (nxagentReportWindowIds)
+      {
+        fprintf (stderr, "NXAGENT_WINDOW_ID: SCREEN_WINDOW:[%d],WID:[0x%x]\n", pScreen -> myNum, nxagentInputWindows[pScreen->myNum]);
+      }
       #ifdef TEST
-      fprintf(stderr, "nxagentOpenScreen: Created new default window with id [%ld].\n",
-                  (long int)nxagentDefaultWindows[pScreen->myNum]);
+      fprintf(stderr, "nxagentOpenScreen: Created new default window with id [0x%x].\n",
+              nxagentDefaultWindows[pScreen->myNum]);
       #endif
 
       /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -116,6 +116,8 @@ extern WindowPtr nxagentViewportFrameBelow;
 
 extern WindowPtr nxagentRootTileWindow;
 
+extern Bool nxagentReportPrivateWindowIds;
+
 /*
  * Also referenced in Events.c.
  */
@@ -433,8 +435,12 @@ FIXME: We need to set save under on the real display?
     }
   }
 
+  if (nxagentReportPrivateWindowIds)
+  {
+    fprintf (stderr, "NXAGENT_WINDOW_ID: PRIVATE_WINDOW,WID:[0x%x]\n", nxagentWindowPriv(pWin)->window);
+  }
   #ifdef TEST
-  fprintf(stderr, "nxagentCreateWindow: Created new window with id [%ld].\n",
+  fprintf(stderr, "nxagentCreateWindow: Created new window with id [0x%x].\n",
               nxagentWindowPriv(pWin)->window);
   #endif
 
@@ -3016,8 +3022,12 @@ FIXME: Do we need to set save unders attribute here?
                                       mask,
                                       &attributes);
 
+  if (nxagentReportPrivateWindowIds)
+  {
+    fprintf (stderr, "NXAGENT_WINDOW_ID: PRIVATE_WINDOW,WID:[0x%x]\n", nxagentWindowPriv(pWin)->window);
+  }
   #ifdef TEST
-  fprintf(stderr, "nxagentReconnectWindow: Created new window with id [%ld].\n",
+  fprintf(stderr, "nxagentReconnectWindow: Created new window with id [0x%x].\n",
               nxagentWindowPriv(pWin)->window);
   #endif
 

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -372,6 +372,12 @@ force use of NX protocol messages assuming communication through nxproxy
 .B \-nxrealwindowprop
 set property NX_REAL_WINDOW for each X11 client inside NX Agent, providing the window XID of the corresponding window object on the X server that NX Agent runs on
 .TP 8
+.B \-reportwids
+explicitly tell NX Agent to report its externally exposed X11 window IDs to the session log (in machine readable form), so that external parsers can obtain that information from there
+.TP 8
+.B \-reportprivatewids
+explicitly tell NX Agent to report X11 window IDs of internally created window objects to the session log (in machine readable form), so that external parsers can obtain that information from there; this creates a lot of output and may affect performance
+.TP 8
 .B \-timeout \fIint\fP
 auto-disconnect timeout in seconds (minimum allowed: 60)
 .TP 8


### PR DESCRIPTION
…This feature can be enabled by the cmdline options -reportwids and -reportprivatewids.