### PR TITLE
Pr/improve keyboard

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -815,6 +815,13 @@ int ddxProcessArgument(int argc, char *argv[], int i)
     return 1;
   }
 
+  if (!strcmp(argv[i], "-xkblock"))
+  {
+    nxagentChangeOption(InhibitXkb, 2);
+
+    return 1;
+  }
+
   /*
    * Enable pseudo-rootless mode.
    */
@@ -2141,6 +2148,7 @@ void ddxUseMsg(void)
   ErrorF("-noignore              don't ignore pointer and keyboard configuration changes mandated by clients\n");
   ErrorF("-nokbreset             don't reset keyboard device if the session is resumed\n");
   ErrorF("-noxkblock             always allow applications to change layout through XKEYBOARD\n");
+  ErrorF("-xkblock               always disallow applications to change layout through XKEYBOARD\n");
   ErrorF("-tile WxH              size of image tiles (minimum allowed: 32x32)\n");
   ErrorF("-keystrokefile file    file with keyboard shortcut definitions\n");
   ErrorF("-verbose               print more warning and error messages\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -937,7 +937,9 @@ XkbError:
           layout.
         */
 
-        if (nxagentKeyboard && (strcmp(nxagentKeyboard, "query") != 0))
+        if (nxagentKeyboard &&
+            (strcmp(nxagentKeyboard, "query") != 0) &&
+            (strcmp(nxagentKeyboard, "clone") != 0))
         {
           for (i = 0; nxagentKeyboard[i] != '/' && nxagentKeyboard[i] != 0; i++);
 
@@ -1043,7 +1045,20 @@ XkbError:
           #endif
 
           nxagentWriteKeyboardFile(drulesLen, drules, dmodel, dlayout, dvariant, doptions);
-          nxagentKeycodeConversionSetup(drules, dmodel);
+          if (nxagentKeyboard && (strcmp(nxagentKeyboard, "clone") != 0))
+          {
+            /* Keycode conversion is not of use in clone mode */
+            nxagentKeycodeConversionSetup(drules, dmodel);
+          }
+
+          if (drules && nxagentKeyboard && (strcmp(nxagentKeyboard, "clone") == 0))
+          {
+            update_string(&rules, drules, 0);
+            update_string(&model, dmodel, 0);
+            update_string(&layout, dlayout, 0);
+            update_string(&variants, dvariant, 0);
+            update_string(&options, doptions, 0);
+          }
 
           if (drules)
           {
@@ -1784,7 +1799,9 @@ void nxagentTuneXkbWrapper(void)
     return;
   }
 
-  if (nxagentKeyboard && strcmp(nxagentKeyboard, "query") == 0)
+  if (nxagentKeyboard &&
+      (strcmp(nxagentKeyboard, "query") == 0 ||
+       strcmp(nxagentKeyboard, "clone") == 0))
   {
     nxagentDisableXkbExtension();
   }

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -923,6 +923,14 @@ XkbError:
         fprintf(stderr, "nxagentKeyboardProc: nxagentKeyboard is [%s].\n", nxagentKeyboard ? nxagentKeyboard : "NULL");
         #endif
 
+        if (nxagentKeyboard && (strcmp(nxagentKeyboard, "null/null") == 0))
+        {
+          #ifdef TEST
+          fprintf(stderr, "nxagentKeyboardProc: changing nxagentKeyboard from [null/null] to [clone].\n");
+          #endif
+          free(nxagentKeyboard);
+          nxagentKeyboard = strdup("clone");
+        }
 
         update_string(&rules, nxagentXkbGetRules(), 0);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -159,7 +159,7 @@ extern        Status        XkbGetControls(
 #define XKB_CONFIG_FILE_X2GO "/etc/x2go/x2goagent.keyboard"
 #endif
 #ifndef XKB_DFLT_RULES_FILE
-#define XKB_DFLT_RULES_FILE  "xfree86"
+#define XKB_DFLT_RULES_FILE  "base"
 #endif
 #ifndef XKB_ALTS_RULES_FILE
 #define XKB_ALTS_RULES_FILE  "xorg"

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -1105,15 +1105,7 @@ XkbError:
         if (xkb == NULL || xkb->geom == NULL)
         {
           #ifdef TEST
-          fprintf(stderr, "nxagentKeyboardProc: No current keyboard.\n");
-          if (xkb == NULL)
-          {
-            fprintf(stderr, "nxagentKeyboardProc: xkb is null.\n");
-          }
-          else
-          {
-            fprintf(stderr, "nxagentKeyboardProc: xkb->geom is null.\n");
-          }
+          fprintf(stderr, "%s: No current keyboard: xkb%s is null.\n", __func__, xkb ? "->geom" : "");
           fprintf(stderr, "nxagentKeyboardProc: Going to set rules and init device.\n");
           #endif
           #ifdef DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -88,7 +88,7 @@ is" without express or implied warranty.
 static int nxagentXkbGetNames(char **rules, char **model, char **layout,
                                   char **variant, char **options);
 
-static void nxagentKeycodeConversionSetup(void);
+static void nxagentKeycodeConversionSetup(char *rules, char *model);
 
 void nxagentWriteKeyboardFile(unsigned int ruleslen, char *rules, char *model, char *layout, char *variant, char *options);
 
@@ -999,9 +999,41 @@ XkbError:
           goto XkbError;
         }
 
-        xkb = XkbGetKeyboard(nxagentDisplay, XkbGBN_AllComponentsMask, XkbUseCoreKbd);
+        {
+          char *drules = NULL;
+          char *dmodel = NULL;
+          char *dlayout = NULL;
+          char *dvariant = NULL;
+          char *doptions = NULL;
 
-        nxagentKeycodeConversionSetup();
+          #ifdef DEBUG
+          unsigned int drulesLen =
+          #endif
+          nxagentXkbGetNames(&drules, &dmodel, &dlayout,
+                             &dvariant, &doptions);
+
+          #ifdef DEBUG
+          if (drulesLen && drules && dmodel)
+          {
+            fprintf(stderr, "%s: Remote: [rules='%s',model='%s',layout='%s',variant='%s',options='%s'].\n",
+                    __func__, drules, dmodel, dlayout, dvariant, doptions);
+          }
+          else
+          {
+            fprintf(stderr, "%s: Failed to retrieve remote rules.\n", __func__);
+          }
+          #endif
+
+          nxagentWriteKeyboardFile(drulesLen, drules, dmodel, dlayout, dvariant, doptions);
+          nxagentKeycodeConversionSetup(drules, dmodel);
+
+          if (drules)
+          {
+            XFree(drules);
+          }
+        }
+
+        xkb = XkbGetKeyboard(nxagentDisplay, XkbGBN_AllComponentsMask, XkbUseCoreKbd);
 
         if (xkb == NULL || xkb->geom == NULL)
         {
@@ -1901,15 +1933,8 @@ void nxagentWriteKeyboardFile(unsigned int ruleslen, char *rules, char *model, c
   }
 }
 
-void nxagentKeycodeConversionSetup(void)
+void nxagentKeycodeConversionSetup(char * rules, char * model)
 {
-  char *drules = NULL;
-  char *dmodel = NULL;
-  char *dlayout = NULL;
-  char *dvariant = NULL;
-  char *doptions = NULL;
-  unsigned int drulesLen;
-
   if (nxagentOption(KeycodeConversion) == KeycodeConversionOff)
   {
     fprintf(stderr, "Info: Keycode conversion is off\n");
@@ -1923,28 +1948,9 @@ void nxagentKeycodeConversionSetup(void)
     return;
   }
 
-  nxagentKeycodeConversion = False;
-
-  drulesLen = nxagentXkbGetNames(&drules, &dmodel, &dlayout,
-                                     &dvariant, &doptions);
-
-  #ifdef DEBUG
-  if (drulesLen != 0 && drules && dmodel)
-  {
-    fprintf(stderr, "%s: Remote: [rules='%s',model='%s',layout='%s',variant='%s',options='%s'].\n",
-	    __func__, drules, dmodel, dlayout, dvariant, doptions);
-  }
-  else
-  {
-    fprintf(stderr, "%s: Failed to retrieve remote rules.\n", __func__);
-  }
-  #endif
-
-  nxagentWriteKeyboardFile(drulesLen, drules, dmodel, dlayout, dvariant, doptions);
-
-  if (drules && dmodel &&
-      (strcmp(drules, "evdev") == 0 ||
-       strcmp(dmodel, "evdev") == 0))
+  if (rules && model &&
+      (strcmp(rules, "evdev") == 0 ||
+       strcmp(model, "evdev") == 0))
   {
     #ifdef DEBUG
     fprintf(stderr, "%s: Activating KeyCode conversion.\n", __func__);
@@ -1955,12 +1961,13 @@ void nxagentKeycodeConversionSetup(void)
   }
   else
   {
-    fprintf(stderr, "Info: Keycode conversion auto-determined as off\n");
-  }
+    #ifdef DEBUG
+    fprintf(stderr, "%s: Deactivating KeyCode conversion.\n", __func__);
+    #endif
 
-  if (drules)
-  {
-    XFree(drules);
+    fprintf(stderr, "Info: Keycode conversion auto-determined as off\n");
+
+    nxagentKeycodeConversion = False;
   }
 }
 
@@ -1975,7 +1982,21 @@ void nxagentResetKeycodeConversion(void)
 
   if (result != 0)
   {
-    nxagentKeycodeConversionSetup();
+    char *drules = NULL;
+    char *dmodel = NULL;
+    char *dlayout = NULL;
+    char *dvariant = NULL;
+    char *doptions = NULL;
+    unsigned int drulesLen;
+
+    drulesLen = nxagentXkbGetNames(&drules, &dmodel, &dlayout,
+                                   &dvariant, &doptions);
+
+    if (drulesLen && drules && dmodel)
+      nxagentKeycodeConversionSetup(drules, dmodel);
+
+    if (drules)
+      XFree(drules);
   }
   else
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -1680,7 +1680,7 @@ void nxagentInitXkbWrapper(void)
   fprintf(stderr, "nxagentInitXkbWrapper: Called.\n");
   #endif
 
-  if (!nxagentOption(InhibitXkb))
+  if (nxagentOption(InhibitXkb) == 0)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentInitXkbWrapper: Nothing to do.\n");
@@ -1798,7 +1798,7 @@ void nxagentEnableXkbExtension(void)
 */
 void nxagentTuneXkbWrapper(void)
 {
-  if (!nxagentOption(InhibitXkb))
+  if (nxagentOption(InhibitXkb) == 0)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentTuneXkbWrapper: Nothing to do.\n");
@@ -1807,9 +1807,10 @@ void nxagentTuneXkbWrapper(void)
     return;
   }
 
-  if (nxagentKeyboard &&
-      (strcmp(nxagentKeyboard, "query") == 0 ||
-       strcmp(nxagentKeyboard, "clone") == 0))
+  if (nxagentOption(InhibitXkb) == 2 ||
+      (nxagentKeyboard &&
+       (strcmp(nxagentKeyboard, "query") == 0 ||
+	strcmp(nxagentKeyboard, "clone") == 0)))
   {
     nxagentDisableXkbExtension();
   }

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -398,7 +398,11 @@ typedef struct _AgentOptions
   int ClientOs;
 
   /*
-   * Inhibit some XKEYBOARD requests.
+   * Control XKEYBOARD request handling:
+   * 0 = allow all XKEYBOARD requests
+   * 1 = disallow all XKEYBOARD requests that would change the keyboard
+   *     (make them fail)
+   * 2 = if keyboard=clone or keyboard=query this is like 1, else like 0
    */
 
   int InhibitXkb;

--- a/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
@@ -587,7 +587,8 @@ Bool nxagentReconnectSession(void)
   if (nxagentOption(ResetKeyboardAtResume) == 1 &&
          (nxagentKeyboard  == NULL || nxagentOldKeyboard == NULL ||
              strcmp(nxagentKeyboard, nxagentOldKeyboard) != 0 ||
-                 strcmp(nxagentKeyboard, "query") == 0))
+                 strcmp(nxagentKeyboard, "query") == 0 ||
+                     strcmp(nxagentKeyboard, "clone") == 0))
   {
     if (nxagentResetKeyboard() == 0)
     {

--- a/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
@@ -458,6 +458,16 @@ Bool nxagentReconnectSession(void)
 
   nxagentProcessOptions(nxagentOptionsFilenameOrString);
 
+  if (nxagentKeyboard && (strcmp(nxagentKeyboard, "null/null") == 0))
+  {
+    #ifdef TEST
+    fprintf(stderr, "nxagentReconnect: changing nxagentKeyboard from [null/null] to [clone].\n");
+    #endif
+
+    free(nxagentKeyboard);
+    nxagentKeyboard = strdup("clone");
+  }
+
   if (nxagentReconnectDisplay(reconnectLossyLevel[DISPLAY_STEP]) == 0)
   {
     failedStep = DISPLAY_STEP;

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -523,7 +523,8 @@ protocol functions and clone them. This is the recommended setting. For
 compatibility reasons it is not the default.
 .TP 8
 .I <model>/<layout>
-use the given model and layout. You can not modify keyboard rules,
+use the given model and layout. A value of \fInull/null\fR is equivalent to
+\fIclone\fR. You can not modify keyboard rules,
 variant or options. Instead preset values are used. These are
 \fIbase\fR for rules and empty strings for variant and options.
 .RE

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -503,7 +503,7 @@ start or resume a session in fullscreen mode (default: off)
 .TP 8
 .B keyboard=<string> or kbtype=<string>
 
-.BR query | <model>/<layout>
+.BR query | clone | <model>/<layout>
 
 .RS 8
 .TP 8
@@ -516,6 +516,11 @@ MacOS X clients to handle some keyboard problems that are special for
 this platform.  Note that in this case XKEYBOARD will always report
 the default layout which will most likely not match the experienced
 settings.
+.TP 8
+.I clone
+ask the real X server for the keyboard settings using XKEYBOARD
+protocol functions and clone them. This is the recommended setting. For
+compatibility reasons it is not the default.
 .TP 8
 .I <model>/<layout>
 use the given model and layout. You can not modify keyboard rules,

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -525,12 +525,12 @@ compatibility reasons it is not the default.
 .I <model>/<layout>
 use the given model and layout. You can not modify keyboard rules,
 variant or options. Instead preset values are used. These are
-\fIxfree86\fR for rules and empty strings for variant and options.
+\fIbase\fR for rules and empty strings for variant and options.
 .RE
 .TP 8
 
 .PP
-If \fIkeyboard\fR is omitted the internal defaults of \fBnxagent\fR will be used (rules: \fIxfree86\fR, layout: \fIus\fR, model: \fIpc102\fR, empty variant and options).
+If \fIkeyboard\fR is omitted the internal defaults of \fBnxagent\fR will be used (rules: \fIbase\fR, layout: \fIus\fR, model: \fIpc102\fR, empty variant and options).
 
 .TP 8
 .B keyconv=<string>

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -426,12 +426,16 @@ keyboard bell (xset -b) will also affect the real X server.
 .B \-nokbreset
 don't reset keyboard device if the session is resumed
 .TP 8
-.B \-noxkblock
-this is only relevant if you also specify \-keyboard=query. In that
-case \fBnxagent\fR will lock the keyboard settings and clients will
-get an error when trying to change keyboard settings via
-XKEYBOARD. With \-noxkblock the lock is not applied and clients can
-change the keyboard settings through XKEYBOARD.
+.B \-(no)xkblock
+normally clients can change the keyboard via XKEYBOARD which is often
+done by desktop environments. But those desktop environments cannot
+know about the remote keyboard of an nx connection which can lead to
+various keyboard problems. With \-xkblock the keyboard can be
+locked. This prevents any client from changing the keyboard. For some
+special values of the \-keyboard option (\-keyboard=query or
+\-keyboard=clone) locking is implicitely activated and can be switched
+off with \-noxkblock. If locking is effective clients will get an
+error when trying to change keyboard settings via XKEYBOARD.
 .TP 8
 .B \-tile WxH
 size of image tiles (minimum allowed: 32x32)
@@ -509,18 +513,18 @@ start or resume a session in fullscreen mode (default: off)
 .TP 8
 .I query
 use the default XKB keyboard layout (see below) and only allow clients
-to query the settings but prevent any changes. \fIquery\fR is
-especially helpful for setups where you need to set/modify the actual
-keyboard layout using core X protocol functions (e.g. via \fBxmodmap\fR). It is used for
-MacOS X clients to handle some keyboard problems that are special for
-this platform.  Note that in this case XKEYBOARD will always report
-the default layout which will most likely not match the experienced
-settings.
+to query the settings but prevent any changes (same as
+\-xkblock). \fIquery\fR is especially helpful for setups where you
+need to set/modify the actual keyboard layout using core X protocol functions (e.g. via
+\fBxmodmap\fR). It is used for MacOS X clients to handle some keyboard
+problems that are special for this platform.  Note that in this case
+XKEYBOARD will always report the default layout which will most likely
+not match the experienced settings.
 .TP 8
 .I clone
 ask the real X server for the keyboard settings using XKEYBOARD
 protocol functions and clone them. This is the recommended setting. For
-compatibility reasons it is not the default.
+compatibility reasons it is not the default. This implies \-xkblock.
 .TP 8
 .I <model>/<layout>
 use the given model and layout. A value of \fInull/null\fR is equivalent to

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -507,7 +507,7 @@ start or resume a session in fullscreen mode (default: off)
 .TP 8
 .B keyboard=<string> or kbtype=<string>
 
-.BR query | clone | <model>/<layout>
+.BR query | clone | <model>/<layout> | rmlvo/<rules>#<model>#<layout>#<variant>#<options>
 
 .RS 8
 .TP 8
@@ -531,6 +531,13 @@ use the given model and layout. A value of \fInull/null\fR is equivalent to
 \fIclone\fR. You can not modify keyboard rules,
 variant or options. Instead preset values are used. These are
 \fIbase\fR for rules and empty strings for variant and options.
+.TP 8
+.I rmlvo/<rules>#<model>#<layout>#<variant>#<options>
+configure the keyboard according to the rmlvo
+(Rules+Model+Layout+Variant+Options) description given after the / and
+separated by #. This can be used to fully pass the keyboard
+configuration of \fBnxagent\fR right after the start. Example:
+rmlvo/base#pc105#de,us#nodeadkeys#lv3:rwin_switch
 .RE
 .TP 8
 


### PR DESCRIPTION
I have done lots of changes to the keyboard stuff:
1. fix keyboard file creation once again
2. add keyboard=clone (clone xkb configuration of remote side). Also accept x2goclient's null/null keyboard as a synonym for clone
3. extend manpage for keyboard stuff (options keyboard, noignore, noxkblock)
4. add new -xkblock option
5. switch from old 'xfree86' rules file to 'base'
6. code cleanups and simplifications

Many of my commits affect multiple Issues, simply because we have overlapping Issues for the keyboard stuff.

If "clone" proves stable I would like to make that the default. What so you think?