### PR TITLE
autograb (without inputlock, for now)

### DIFF
--- a/doc/nxagent/README.keystrokes
+++ b/doc/nxagent/README.keystrokes
@@ -126,6 +126,9 @@ reread_keystrokes
   Forces nxagent to re-read the keystroke configuration. Useful to
   add/change keystrokes to a running session.
 
+autograb
+  Toggles autograb mode
+
 force_synchronization
   Forces immediate drawing of elements to be synchronized which can
   fix some visual bugs.

--- a/etc/keystrokes.cfg
+++ b/etc/keystrokes.cfg
@@ -24,4 +24,5 @@
 <keystroke action="viewport_scroll_down" Control="1" AltMeta="1" key="Down" />
 <keystroke action="viewport_scroll_down" Control="1" AltMeta="1" key="KP_Down" />
 <keystroke action="reread_keystrokes" Control="1" AltMeta="1" key="k" />
+<keystroke action="autograb" Control="1" AltMeta="1" key="g" />
 </keystrokes>

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1050,6 +1050,14 @@ int ddxProcessArgument(int argc, char *argv[], int i)
     return 0;
   }
 
+  if (!strcmp(argv[i], "-autograb"))
+  {
+    nxagentChangeOption(AutoGrab, True);
+
+    return 1;
+  }
+
+
   /*
    * Disable Xinerama (i.e. fake it in Screen.c) if somehow Xinerama support
    * has been disabled on the cmdline.
@@ -2206,6 +2214,7 @@ void ddxUseMsg(void)
   ErrorF("-noignore              don't ignore pointer and keyboard configuration changes mandated by clients\n");
   ErrorF("-nokbreset             don't reset keyboard device if the session is resumed\n");
   ErrorF("-noxkblock             always allow applications to change layout through XKEYBOARD\n");
+  ErrorF("-autograb              enable autograb\n");
   ErrorF("-tile WxH              size of image tiles (minimum allowed: 32x32)\n");
   ErrorF("-keystrokefile file    file with keyboard shortcut definitions\n");
   ErrorF("-verbose               print more warning and error messages\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1558,6 +1558,19 @@ static void nxagentParseSingleOption(char *name, char *value)
 
     return;
   }
+  else if (!strcmp(name, "autograb"))
+  {
+    if (!strcmp(value, "0"))
+    {
+      nxagentChangeOption(AutoGrab, False);
+    }
+    else
+    {
+      nxagentChangeOption(AutoGrab, True);
+    }
+
+    return;
+  }
   else
   {
     #ifdef DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
@@ -63,6 +63,8 @@ int nxagentEnableRandRModeDialogPid = 0;
 int nxagentDisableRandRModeDialogPid = 0;
 int nxagentEnableDeferModePid = 0;
 int nxagentDisableDeferModePid = 0;
+int nxagentEnableAutograbModePid = 0;
+int nxagentDisableAutograbModePid = 0;
 
 static int nxagentFailedReconnectionDialogPid = 0;
 
@@ -157,6 +159,24 @@ void nxagentResetDialog(int pid)
     #endif
 
     nxagentDisableDeferModePid = 0;
+  }
+  else if (pid == nxagentEnableAutograbModePid)
+  {
+    #ifdef TEST
+    fprintf(stderr, "nxagentResetDialog: Resetting enable autograb mode dialog pid [%d].\n",
+                nxagentEnableAutograbModePid);
+    #endif
+
+    nxagentEnableAutograbModePid = 0;
+  }
+  else if (pid == nxagentDisableAutograbModePid)
+  {
+    #ifdef TEST
+    fprintf(stderr, "nxagentResetDialog: Resetting disable autograb mode dialog pid [%d].\n",
+                nxagentDisableAutograbModePid);
+    #endif
+
+    nxagentDisableAutograbModePid = 0;
   }
 }
 
@@ -260,6 +280,24 @@ void nxagentLaunchDialog(DialogType dialogType)
       type = DIALOG_DISABLE_DEFER_MODE_TYPE;
       local = DIALOG_DISABLE_DEFER_MODE_LOCAL;
       pid = &nxagentDisableDeferModePid;
+
+      break;
+    }
+    case DIALOG_ENABLE_AUTOGRAB_MODE:
+    {
+      message = DIALOG_ENABLE_AUTOGRAB_MODE_MESSAGE;
+      type = DIALOG_ENABLE_AUTOGRAB_MODE_TYPE;
+      local = DIALOG_ENABLE_AUTOGRAB_MODE_LOCAL;
+      pid = &nxagentEnableAutograbModePid;
+
+      break;
+    }
+    case DIALOG_DISABLE_AUTOGRAB_MODE:
+    {
+      message = DIALOG_DISABLE_AUTOGRAB_MODE_MESSAGE;
+      type = DIALOG_DISABLE_AUTOGRAB_MODE_TYPE;
+      local = DIALOG_DISABLE_AUTOGRAB_MODE_LOCAL;
+      pid = &nxagentDisableAutograbModePid;
 
       break;
     }
@@ -493,6 +531,18 @@ void nxagentTerminateDialog(DialogType type)
     case DIALOG_DISABLE_DEFER_MODE:
     {
       pid = nxagentDisableDeferModePid;
+
+      break;
+    }
+    case DIALOG_ENABLE_AUTOGRAB_MODE:
+    {
+      pid = nxagentEnableAutograbModePid;
+
+      break;
+    }
+    case DIALOG_DISABLE_AUTOGRAB_MODE:
+    {
+      pid = nxagentDisableAutograbModePid;
 
       break;
     }

--- a/nx-X11/programs/Xserver/hw/nxagent/Dialog.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Dialog.h
@@ -41,6 +41,8 @@ typedef enum
   DIALOG_FAILED_RECONNECTION,
   DIALOG_ENABLE_DEFER_MODE,
   DIALOG_DISABLE_DEFER_MODE,
+  DIALOG_ENABLE_AUTOGRAB_MODE,
+  DIALOG_DISABLE_AUTOGRAB_MODE,
   DIALOG_LAST_TAG
 
 } DialogType;
@@ -54,6 +56,8 @@ extern int nxagentEnableRandRModeDialogPid;
 extern int nxagentDisableRandRModeDialogPid;
 extern int nxagentEnableDeferModePid;
 extern int nxagentDisableDeferModePid;
+extern int nxagentEnableAutograbModePid;
+extern int nxagentDisableAutograbModePid;
 
 #define NXAGENTFAILEDRECONNECTIONMESSAGELENGTH 256
 extern char nxagentFailedReconnectionMessage[NXAGENTFAILEDRECONNECTIONMESSAGELENGTH];
@@ -87,6 +91,8 @@ extern void nxagentTerminateDialogs(void);
              (type) == DIALOG_FAILED_RECONNECTION ? "DIALOG_FAILED_RECONNECTION" : \
              (type) == DIALOG_ENABLE_DEFER_MODE ? "DIALOG_ENABLE_DEFER_MODE" : \
              (type) == DIALOG_DISABLE_DEFER_MODE ? "DIALOG_DISABLE_DEFER_MODE" : \
+             (type) == DIALOG_ENABLE_AUTOGRAB_MODE ? "DIALOG_ENABLE_AUTGRAB_MODE" : \
+             (type) == DIALOG_DISABLE_AUTOGRAB_MODE ? "DIALOG_DISABLE_AUTOGRAB_MODE" : \
              "UNKNOWN_DIALOG")
 
 /*
@@ -213,6 +219,30 @@ Ctrl+Alt+E to enable it again.\
 #define DIALOG_DISABLE_DEFER_MODE_TYPE "ok"
 
 #define DIALOG_DISABLE_DEFER_MODE_LOCAL 0
+
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_MESSAGE \
+\
+"\
+Keyboard auto-grabbing mode is now enabled. You can press\n\
+Ctrl+Alt+G again to disable auto-grabbing.\
+"
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_TYPE "ok"
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_LOCAL 0
+
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_MESSAGE \
+\
+"\
+Keyboard auto-grabbing mode is now disabled. You can press\n\
+Ctrl+Alt+G again to re-enable auto-grabbing.\
+"
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_TYPE "ok"
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_LOCAL 0
 
 #endif /* __Dialog_H__ */
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1598,8 +1598,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           }
         }
 
-        /* FIXME: only when in windowed mode! */
-        if (nxagentOption(AutoGrab))
+        if (nxagentOption(AutoGrab) && !(nxagentOption(AllScreens) || nxagentOption(Fullscreen) || nxagentOption(Rootless)))
         {
           if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
           {

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1847,11 +1847,14 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           nxagentLastEnteredWindow = NULL;
         }
 
-        if (X.xcrossing.window == nxagentDefaultWindows[0] &&
-                X.xcrossing.detail != NotifyInferior &&
-                    X.xcrossing.mode == NotifyNormal)
+        if (!nxagentOption(AutoGrab))
         {
-          nxagentUngrabPointerAndKeyboard(&X);
+          if (X.xcrossing.window == nxagentDefaultWindows[0] &&
+              X.xcrossing.detail != NotifyInferior &&
+              X.xcrossing.mode == NotifyNormal)
+          {
+             nxagentUngrabPointerAndKeyboard(&X);
+          }
         }
 
         if (X.xcrossing.detail != NotifyInferior)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -678,8 +678,6 @@ static void nxagentSwitchDeferMode(void)
   }
 }
 
-static Bool autograb = False;
-
 static void nxagentEnableAutoGrab(void)
 {
 #ifdef DEBUG
@@ -687,7 +685,7 @@ static void nxagentEnableAutoGrab(void)
 #endif
 
   nxagentGrabPointerAndKeyboard(NULL);
-  autograb = True;
+  nxagentChangeOption(AutoGrab, True);
 }
 
 static void nxagentDisableAutoGrab(void)
@@ -697,7 +695,7 @@ static void nxagentDisableAutoGrab(void)
 #endif
 
   nxagentUngrabPointerAndKeyboard(NULL);
-  autograb = False;
+  nxagentChangeOption(AutoGrab, False);
 }
 
 static void nxagentToggleAutoGrab(void)
@@ -706,7 +704,7 @@ static void nxagentToggleAutoGrab(void)
   if (nxagentOption(Rootless) || nxagentOption(Fullscreen))
     return;
 
-  if (!autograb)
+  if (!nxagentOption(AutoGrab))
     nxagentEnableAutoGrab();
   else
     nxagentDisableAutoGrab();
@@ -1561,7 +1559,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         }
 
         /* FIXME: only when in windowed mode! */
-        if (autograb)
+        if (nxagentOption(AutoGrab))
         {
           if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
           {
@@ -1649,7 +1647,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         #endif /* NXAGENT_FIXKEYS */
 
-        if (autograb)
+        if (nxagentOption(AutoGrab))
         {
           XlibWindow w;
           int revert_to;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -678,6 +678,40 @@ static void nxagentSwitchDeferMode(void)
   }
 }
 
+static Bool autograb = False;
+
+static void nxagentEnableAutoGrab(void)
+{
+#ifdef DEBUG
+  fprintf(stderr, "enabling autograb\n");
+#endif
+
+  nxagentGrabPointerAndKeyboard(NULL);
+  autograb = True;
+}
+
+static void nxagentDisableAutoGrab(void)
+{
+#ifdef DEBUG
+  fprintf(stderr, "disabling autograb\n");
+#endif
+
+  nxagentUngrabPointerAndKeyboard(NULL);
+  autograb = False;
+}
+
+static void nxagentToggleAutoGrab(void)
+{
+  /* autograb only works in windowed mode */
+  if (nxagentOption(Rootless) || nxagentOption(Fullscreen))
+    return;
+
+  if (!autograb)
+    nxagentEnableAutoGrab();
+  else
+    nxagentDisableAutoGrab();
+}
+
 static Bool nxagentExposurePredicate(Display *display, XEvent *event, XPointer window)
 {
   /*
@@ -1068,6 +1102,12 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
             {
               nxagentSwitchDeferMode();
             }
+
+            break;
+          }
+          case doAutoGrab:
+          {
+            nxagentToggleAutoGrab();
 
             break;
           }
@@ -1520,6 +1560,17 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           }
         }
 
+        /* FIXME: only when in windowed mode! */
+        if (autograb)
+        {
+          if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
+          {
+            #ifdef DEBUG
+            fprintf(stderr, "%s: (FocusIn): grabbing\n", __func__);
+	    #endif
+            nxagentGrabPointerAndKeyboard(NULL);
+          }
+        }
         break;
       }
       case FocusOut:
@@ -1598,6 +1649,19 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         #endif /* NXAGENT_FIXKEYS */
 
+        if (autograb)
+        {
+          XlibWindow w;
+          int revert_to;
+          XGetInputFocus(nxagentDisplay, &w, &revert_to);
+          if (w != nxagentDefaultWindows[0] && X.xfocus.mode == NotifyWhileGrabbed)
+          {
+            #ifdef DEBUG
+            fprintf(stderr, "%s: (FocusOut): ungrabbing\n", __func__);
+            #endif
+            nxagentUngrabPointerAndKeyboard(NULL);
+          }
+        }
         break;
       }
       case KeymapNotify:
@@ -3922,13 +3986,26 @@ void nxagentGrabPointerAndKeyboard(XEvent *X)
   fprintf(stderr, "nxagentGrabPointerAndKeyboard: Going to grab the keyboard in context [B1].\n");
   #endif
 
-  result = XGrabKeyboard(nxagentDisplay, nxagentFullscreenWindow,
-                             True, GrabModeAsync, GrabModeAsync, now);
+  if (nxagentFullscreenWindow)
+    result = XGrabKeyboard(nxagentDisplay, nxagentFullscreenWindow,
+      True, GrabModeAsync, GrabModeAsync, now);
+  else
+    result = XGrabKeyboard(nxagentDisplay, RootWindow(nxagentDisplay, DefaultScreen(nxagentDisplay)),
+      True, GrabModeAsync, GrabModeAsync, now);
 
   if (result != GrabSuccess)
   {
+    #ifdef DEBUG
+    fprintf(stderr, "%s: keyboard grab failed.\n", __func__);
+    #endif
     return;
   }
+  #ifdef DEBUG
+  else
+  {
+    fprintf(stderr, "%s: keyboard grab successful.\n", __func__);
+  }
+  #endif
 
   /*
    * The smart scheduler could be stopped while
@@ -3946,7 +4023,8 @@ void nxagentGrabPointerAndKeyboard(XEvent *X)
   resource = nxagentWaitForResource(NXGetCollectGrabPointerResource,
                                         nxagentCollectGrabPointerPredicate);
 
-  NXCollectGrabPointer(nxagentDisplay, resource,
+  if (nxagentFullscreenWindow)
+     NXCollectGrabPointer(nxagentDisplay, resource,
                            nxagentFullscreenWindow, True, NXAGENT_POINTER_EVENT_MASK,
                                GrabModeAsync, GrabModeAsync, None, None, now);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1700,7 +1700,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         #endif /* NXAGENT_FIXKEYS */
 
-        if (nxagentOption(AutoGrab))
+        if (nxagentOption(AutoGrab) && !nxagentFullscreenWindow)
         {
           XlibWindow w;
           int revert_to;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -716,6 +716,7 @@ static void nxagentEnableAutoGrab(void)
 
   nxagentGrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, True);
+  nxagentLaunchDialog(DIALOG_ENABLE_AUTOGRAB_MODE);
 }
 
 static void nxagentDisableAutoGrab(void)
@@ -726,6 +727,7 @@ static void nxagentDisableAutoGrab(void)
 
   nxagentUngrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, False);
+  nxagentLaunchDialog(DIALOG_DISABLE_AUTOGRAB_MODE);
 }
 
 static void nxagentToggleAutoGrab(void)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -293,6 +293,36 @@ void ProcessInputEvents(void)
   mieqProcessInputEvents();
 }
 
+#ifdef DEBUG
+char * nxagentGetNotifyMode(int mode)
+{
+  switch (mode)
+  {
+    case NotifyNormal:
+    {
+      return "NotifyNormal";
+      break;
+    }
+    case NotifyGrab:
+    {
+      return "NotifyGrab";
+      break;
+    }
+    case NotifyUngrab:
+    {
+      return "NotifyUngrab";
+      break;
+    }
+    case NotifyWhileGrabbed:
+    {
+      return "NotifyWhileGrabbed";
+      break;
+    }
+  }
+  return "Unknown";
+}
+#endif
+
 #ifdef DEBUG_TREE
 
 /*
@@ -1531,8 +1561,18 @@ FIXME: Don't enqueue the KeyRelease event if the key was
       {
         WindowPtr pWin;
 
-        #ifdef TEST
-        fprintf(stderr, "nxagentDispatchEvents: Going to handle new FocusIn event.\n");
+	#ifdef DEBUG
+	fprintf(stderr, "%s: Going to handle new FocusIn event [0x%x] mode: [%s]\n", __func__, X.xfocus.window, nxagentGetNotifyMode(X.xfocus.mode));
+	{
+	  XlibWindow w;
+          int revert_to;
+          XGetInputFocus(nxagentDisplay, &w, &revert_to);
+	  fprintf(stderr, "%s: (FocusIn): Event win [0x%x] Focus owner [0x%x] nxagentDefaultWindows[0] [0x%x]\n", __func__, X.xfocus.window, w, nxagentDefaultWindows[0]);
+	}
+        #else
+	  #ifdef TEST
+	fprintf(stderr, "%s: Going to handle new FocusIn event\n", __func__);
+	  #endif
         #endif
 
         /*
@@ -1568,13 +1608,25 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 	    #endif
             nxagentGrabPointerAndKeyboard(NULL);
           }
+	  /*	  else
+          {
+            #ifdef DEBUG
+            fprintf(stderr, "%s: (FocusIn): ungrabbing\n", __func__);
+	    #endif
+            nxagentUngrabPointerAndKeyboard(NULL);
+          }
+	  */
         }
         break;
       }
       case FocusOut:
       {
-        #ifdef TEST
-        fprintf(stderr, "nxagentDispatchEvents: Going to handle new FocusOut event.\n");
+	#ifdef DEBUG
+	fprintf(stderr, "%s: Going to handle new FocusOut event [0x%x] mode: [%s]\n", __func__, X.xfocus.window, nxagentGetNotifyMode(X.xfocus.mode));
+	#else
+	  #ifdef TEST
+	  fprintf(stderr, "%s: Going to handle new FocusOut event.\n", __func__);
+          #endif
         #endif
 
         if (X.xfocus.detail != NotifyInferior)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.h
@@ -51,7 +51,8 @@ enum HandleEventResult
   doViewportRight,
   doViewportDown,
   doSwitchResizeMode,
-  doSwitchDeferMode
+  doSwitchDeferMode,
+  doAutoGrab,
 };
 
 extern CARD32 nxagentLastEventTime;

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
@@ -100,6 +100,9 @@ char * nxagentSpecialKeystrokeNames[] = {
        "viewport_scroll_down",
 
        "reread_keystrokes",
+
+       "autograb",
+
        NULL,
 };
 
@@ -139,6 +142,7 @@ struct nxagentSpecialKeystrokeMap default_map[] = {
   {KEYSTROKE_VIEWPORT_SCROLL_DOWN, ControlMask, True, XK_Down},
   {KEYSTROKE_VIEWPORT_SCROLL_DOWN, ControlMask, True, XK_KP_Down},
   {KEYSTROKE_REREAD_KEYSTROKES, ControlMask, True, XK_k},
+  {KEYSTROKE_AUTOGRAB, ControlMask, True, XK_g},
   {KEYSTROKE_END_MARKER, 0, False, NoSymbol},
 };
 struct nxagentSpecialKeystrokeMap *map = default_map;
@@ -468,7 +472,7 @@ static enum nxagentSpecialKeystroke find_keystroke(XKeyEvent *X)
   #endif
   for (struct nxagentSpecialKeystrokeMap *cur = map; cur->stroke != KEYSTROKE_END_MARKER; cur++) {
     #ifdef DEBUG
-    fprintf(stderr, "%s: checking keysym '%c' (%d)\n", __func__, cur->keysym, cur->keysym);
+    fprintf(stderr,"%s: keysym %d stroke %d, type %d\n", __func__, cur->keysym, cur->stroke, X->type);
     #endif
     if (cur->keysym == keysym && modifier_matches(cur->modifierMask, cur->modifierAltMeta, X->state)) {
       #ifdef DEBUG
@@ -631,6 +635,9 @@ Bool nxagentCheckSpecialKeystroke(XKeyEvent *X, enum HandleEventResult *result)
       */
       if (X->type == KeyRelease)
 	nxagentInitKeystrokes(True);
+      break;
+    case KEYSTROKE_AUTOGRAB:
+      *result = doAutoGrab;
       break;
     case KEYSTROKE_NOTHING: /* do nothing. difference to KEYSTROKE_IGNORE is the return value */
     case KEYSTROKE_END_MARKER: /* just to make gcc STFU */

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
@@ -73,6 +73,8 @@ enum nxagentSpecialKeystroke {
 
        KEYSTROKE_REREAD_KEYSTROKES,
 
+       KEYSTROKE_AUTOGRAB,
+
        KEYSTROKE_NOTHING,
 
        /* insert more here and in the string translation */

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.c
@@ -172,6 +172,8 @@ void nxagentInitOptions(void)
   nxagentOptions.ReconnectTolerance = DEFAULT_TOLERANCE;
 
   nxagentOptions.KeycodeConversion = DEFAULT_KEYCODE_CONVERSION;
+
+  nxagentOptions.AutoGrab = False;
 }
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -450,6 +450,13 @@ typedef struct _AgentOptions
    * Convert evdev keycodes to pc105.
    */
   KeycodeConversionMode KeycodeConversion;
+
+  /*
+   * True if agent should grab the input in windowed mode whenever the
+   * agent window gets the focus
+   */
+  int AutoGrab;  /* Should be Bool but I do not want to include Xlib.h here */
+
 } AgentOptionsRec;
 
 typedef AgentOptionsRec *AgentOptionsPtr;

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -801,7 +801,12 @@ void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
   else
   {
     nxagentFullscreenWindow = None;
-    nxagentUngrabPointerAndKeyboard(NULL);
+
+    /* if we had AutoGrab before entering fullscreen reactivate it now */
+    if (nxagentOption(AutoGrab))
+      nxagentGrabPointerAndKeyboard(NULL);
+    else
+      nxagentUngrabPointerAndKeyboard(NULL);
   }
 }
 
@@ -1055,6 +1060,10 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
   XMoveResizeWindow(nxagentDisplay, nxagentInputWindows[0], 0, 0,
                         nxagentOption(Width), nxagentOption(Height));
+
+  /* if we had AutoGrab before entering fullscreen reactivate it now */
+  if (nxagentOption(AutoGrab))
+    nxagentGrabPointerAndKeyboard(NULL);
 
   nxagentSetPrintGeometry(pScreen -> myNum);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -754,6 +754,10 @@ format must be included in both. This is potentially unsafe.
 means that all of these checks are essentially
 deactivated. This is a very bad idea.
 .RE
+.TP 8
+.B autograb=<int>
+enable or disable autograb (default: disabled)
+.RE
 
 If you want to use \fBnxagent\fR as a replacement for Xnest or Xephyr you
 can pass options like this:

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -455,6 +455,9 @@ The nx-X11 system adds the following command line arguments:
 .B \-forcenx
 force use of NX protocol messages assuming communication through \fBnxproxy\fR
 .TP 8
+.B \-autograb
+enable autograb mode on \fBnxagent\fR startup. The autograb feature can be toggled via nxagent keystrokes
+.TP 8
 .B \-nxrealwindowprop
 set property NX_REAL_WINDOW for each X11 client inside \fBnxagent\fR,
 providing the window XID of the corresponding window object on the X


### PR DESCRIPTION
@uli42: I took your pr/autograb branch and stripped out the autograb feature only for this PR for now.

The autograb feature is an interesting feature for our current sponsor, so we should have that in nxagent ASAP.

I will add some code, that triggers an NX dialog call when the autograb mode gets enabled. Once that commit is there, I'd love to have you review this subset of commits derived from your pr/autograb branch.