### PR TITLE
Render.c: Improve situation for multiple trapezoid requests.

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Render.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.c
@@ -93,12 +93,6 @@ FIXME: Most operations don't seem to produce any visible result
 #undef  SKIP_REALLY_ALL_LOUSY_RENDER_OPERATIONS
 
 /*
- * Do we split the big trapezoid requests?
- */
-
-#define TRAPEZOIDS_PER_REQUEST  256
-
-/*
  * Margin added around the glyphs extent (in pixels).
  */
 
@@ -1803,8 +1797,6 @@ FIXME: Is this useful or just a waste of bandwidth?
     nxagentSynchronizeBox(pDst -> pDrawable, nxagentTrapezoidExtents, NEVER_BREAK);
   }
 
-  while (remaining > 0)
-  {
     XRenderCompositeTrapezoids(nxagentDisplay,
                                op,
                                nxagentPicturePriv(pSrc) -> picture,
@@ -1812,13 +1804,8 @@ FIXME: Is this useful or just a waste of bandwidth?
                                pForm,
                                xSrc,
                                ySrc,
-                               (XTrapezoid *) current,
-                               (remaining > TRAPEZOIDS_PER_REQUEST ?
-                                   TRAPEZOIDS_PER_REQUEST : remaining));
+                               (XTrapezoid *) current,remaining);
 
-    remaining -= TRAPEZOIDS_PER_REQUEST;
-    current   += TRAPEZOIDS_PER_REQUEST;
-  }
 
   #endif
 


### PR DESCRIPTION
 This change improves the situation in nxagent for the following
 issue:

 ```
 "XRenderCompositeTrapezoids builds RenderTrapezoids requests to composite the
 specified list of trapezoids to dst.  XRenderCompositeTrapezoids will split
 the list of trapezoids to build requests no larger than the maximum request
 size supported by the server.  This can create rendering artifacts as the
 precompositing done by RenderTrapezoids when a maskFormat is specified
 cannot span multiple requests."
 ```

 For more information see:
 https://lists.freedesktop.org/archives/xorg/2008-June/036124.html

 Fixes ArcticaProject/nx-libs#336.