### PR TITLE
nxcomp/configure.ac: Don't rely on pkg-config alone when it comes to …

### DIFF
--- a/m4/nx-macros.m4
+++ b/m4/nx-macros.m4
@@ -303,3 +303,21 @@ rm -f conftest*])
 FreeBSD=
 test "$nxconf_cv_freebsd" = yes && FreeBSD=yes
 ]) # NX_BUILD_ON_FreeBSD
+
+AC_DEFUN([LIBJPEG_FALLBACK_CHECK],[
+AC_MSG_CHECKING([for libjpeg shared libary file and headers])
+AC_CHECK_LIB([jpeg], [jpeg_destroy_compress],
+    [have_jpeg_lib=yes], [have_jpeg_lib=no])
+AC_CHECK_HEADERS([jpeglib.h],
+    [have_jpeg_headers=yes], [have_jpeg_headers=no])
+
+if test x"$have_jpeg_lib" = "xyes" && test x"$have_jpeg_headers" = "xyes"; then
+    AC_MSG_RESULT([yes])
+    JPEG_CFLAGS=""
+    JPEG_LIBS="-ljpeg"
+else
+    AC_MSG_RESULT([no])
+    AC_MSG_FAILURE([Could not find libjpeg on your system, make sure
+the JPEG shared library and header files are installed.])
+fi
+]) # LIBJPEG_FALLBACK_CHECK

--- a/nxcomp/configure.ac
+++ b/nxcomp/configure.ac
@@ -25,10 +25,6 @@ AC_SUBST([COMP_VERSION])
 LT_COMP_VERSION=[`echo $COMP_VERSION | sed -r -e 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/' -e 's/\./:/g'`] 
 AC_SUBST([LT_COMP_VERSION])
 
-PKG_CHECK_MODULES(JPEG, libjpeg)
-PKG_CHECK_MODULES(PNG, libpng)
-PKG_CHECK_MODULES(Z, zlib)
-
 # Upstream's pkg.m4 (since 0.27) offers this now, but define our own
 # compatible version in case the local version of pkgconfig isn't new enough.
 # https://bugs.freedesktop.org/show_bug.cgi?id=48743
@@ -38,6 +34,10 @@ m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],
                       [install directory for nxcompshad.pc pkg-config file])],
                        [],[with_pkgconfigdir='$(libdir)/pkgconfig'])
           AC_SUBST([pkgconfigdir], [${with_pkgconfigdir}])])
+
+PKG_CHECK_MODULES([JPEG], [libjpeg], [], [LIBJPEG_FALLBACK_CHECK])
+PKG_CHECK_MODULES([PNG], [libpng], [], [])
+PKG_CHECK_MODULES([Z], [zlib], [], [])
 
 AC_LANG([C++])
 NX_COMPILER_BRAND


### PR DESCRIPTION
…testing for presence of libjpeg shared lib and header files.

 Especially systems still using the IJG's libjpeg implementation
 are likely to lack the libjpeg.pc file.
 .
 So we add some alternative way of detecting if all libjpeg related
 build-dependencies are in place.

This fixes nx-libs builds on Ubuntu trusty:
https://jenkins.arctica-project.org/job/nx-libs.deb+nightly/target=trusty/272/