### PR TITLE
nxcomp/src/{Loop,Proxy}.cpp: On Debian/kFreeBSD the sun_path property…

### DIFF
--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -3810,7 +3810,15 @@ int SetupAuthInstance()
 
         launchdAddrUnix.sun_family = AF_UNIX;
 
+        #ifdef __linux__
         const int launchdAddrNameLength = 108;
+        #else
+        /* POSIX/SUS does not specify a length.
+         * BSD derivatives generally support 104 bytes, other systems may be more constrained.
+         * If you happen to run into such systems, extend this section with the appropriate limit.
+         */
+        const int launchdAddrNameLength = 104;
+        #endif
 
         int success = -1;
 

--- a/nxcomp/src/Proxy.cpp
+++ b/nxcomp/src/Proxy.cpp
@@ -6294,7 +6294,15 @@ int Proxy::handleNewGenericConnectionFromProxyUnix(int channelId, T_channel_type
 
   serverAddrUnix.sun_family = AF_UNIX;
 
+  #ifdef __linux__
   const int serverAddrNameLength = 108;
+  #else
+  /* POSIX/SUS does not specify a length.
+   * BSD derivatives generally support 104 bytes, other systems may be more constrained.
+   * If you happen to run into such systems, extend this section with the appropriate limit.
+   */
+  const int serverAddrNameLength = 104;
+  #endif
 
   strncpy(serverAddrUnix.sun_path, path, serverAddrNameLength);
 


### PR DESCRIPTION
… is 104 chars long, not 108.

 Fixes ArcticaProject/nx-libs#507.