### PR TITLE
Reintroduce -co as no-op

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -161,6 +161,12 @@ sets key-click volume (allowable range: 0-100).
 sets the visual class for the root window of color screens.
 The class numbers are as specified in the X protocol.
 Not obeyed by all servers.
+.TP 8
+.B \-co \fIfilename\fP
+This used to be the option for specifying the path to the RGB color
+database file. As the RGB color database is now embedded into the
+binary this option has no effect but is kept for
+compatibility. Deprecated.
 .ig
 .TP 8
 .B \-config \fIfilename\fP

--- a/nx-X11/programs/Xserver/os/utils.c
+++ b/nx-X11/programs/Xserver/os/utils.c
@@ -571,6 +571,9 @@ void UseMsg(void)
     ErrorF("-c                     turns off key-click\n");
     ErrorF("c #                    key-click volume (0-100)\n");
     ErrorF("-cc int                default color visual class\n");
+#ifdef NXAGENT_SERVER
+    ErrorF("-co file               deprecated, has no effect\n");
+#endif
 #ifdef COMMANDLINE_CHALLENGED_OPERATING_SYSTEMS
     ErrorF("-config file           read options from file\n");
 #endif
@@ -776,6 +779,14 @@ ProcessCommandLine(int argc, char *argv[])
 	    else
 		UseMsg();
 	}
+#ifdef NXAGENT_SERVER
+	else if ( strcmp( argv[i], "-co") == 0)
+	{
+	    fprintf(stderr, "Warning: Ignoring deprecated command line option '%s'.\n", argv[i]);
+	    if(++i >= argc)
+	        UseMsg();
+	}
+#endif
 	else if ( strcmp( argv[i], "-core") == 0)
 	    CoreDump = TRUE;
 	else if ( strcmp( argv[i], "-dpi") == 0)


### PR DESCRIPTION
nxagent will abort if it encounters an unknown command line option. As
we want 3.6 to be a drop-in replacement for 3.5 we cannot simply drop old
options but must accept them as no-op.