### PR TITLE
Xserver/os/xprintf.c: Drop NoMachine's own implementation of Xvasprin…

### DIFF
--- a/nx-X11/programs/Xserver/os/xprintf.c
+++ b/nx-X11/programs/Xserver/os/xprintf.c
@@ -89,54 +89,7 @@
 #undef  TEST
 #undef  DEBUG
 
-#define START_SIZE  256
-#define END_SIZE   2048
-
-int
-Xvasprintf(char **ret, const char *_X_RESTRICT_KYWD format, va_list va)
-{
-    char *newret;
-    int size;
-    int r;
-
-    size = 0;
-
-    for (;;)
-    {
-      if (size == 0)
-      {
-        *ret = (char *)malloc(START_SIZE);
-        if (*ret == NULL)
-          return -1;
-        size = START_SIZE;
-      }
-      else if (size < END_SIZE &&
-                   (newret = (char *) realloc(*ret, 2 * size)) != NULL)
-      {
-        *ret = newret;
-        size = 2 * size;
-      }
-      else
-      {
-        free(*ret);
-        return -1;
-      }
-
-      r = vsnprintf(*ret, size, format, va);
-
-      if (r == -1 || r == size || r > size || r == size - 1)
-      {
-        continue;
-      }
-      else
-      {
-        (*ret)[r] = 0;
-        return r;
-      }
-    }
-}
-
-#else
+#endif
 
 /**
  * Varargs sprintf that allocates a string buffer the right size for
@@ -170,8 +123,6 @@ Xvasprintf(char **ret, const char *_X_RESTRICT_KYWD format, va_list va)
     return size;
 #endif
 }
-
-#endif
 
 #ifndef HAVE_VASPRINTF
 #define vasprintf Xvasprintf


### PR DESCRIPTION
…tf(). Use stock implementation instead.

 * Reason from NoMachine's NX CHANGELOG for having its own implementation
   of Xvasprintf() (from around nxagent 3.3.0):

    - Fixed TR06G02225. The implementation of Xvprintf() has been reviewed
      to work on more platforms. Previous implementation caused a failure
      in the build of keyboard map on some platform like Solaris 8 and 9.
    - Fixed TR03G02198. Reimplemented Xvprintf() in Xserver/os to handle
      the case in which vsnprintf returned -1.

 * Reason for removing it again:

    - Fixes segfaults in SetDefaultFontPath when launching nxagent.
    - All locations in Xserver/** using the code check for return value
      of -1.
    - Solaris 8 and 9 are beyond of our support scope.
    - Keep more in sync with X.org.
    - Good moment to drop more GPL-2 code from Xserver's code base.