### PR TITLE
Pr/pre rrxinerama fallback

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Extensions.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Extensions.c
@@ -136,7 +136,7 @@ void nxagentInitRandRExtension(ScreenPtr pScreen)
 
   pRandRScrPriv = rrGetScrPriv(pScreen);
 
-  pRandRScrPriv -> rrGetInfo   = nxagentRandRGetInfo;
+  pRandRScrPriv -> rrGetInfo = nxagentRandRGetInfo;
 
   #if RANDR_15_INTERFACE
   /* nothing to be assigned here, so far */

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -3675,7 +3675,6 @@ RRModePtr    nxagentRRCustomMode = NULL;
 */
 void nxagentAdjustCustomMode(ScreenPtr pScreen)
 {
-  int          doNotify = TRUE;
   rrScrPrivPtr pScrPriv = rrGetScrPriv(pScreen);
   RROutputPtr  output;
 
@@ -3735,8 +3734,6 @@ void nxagentAdjustCustomMode(ScreenPtr pScreen)
       RRCrtcSet(crtc, nxagentRRCustomMode, 0, 0, RR_Rotate_0, 1, &output);
 
       RROutputChanged(output, 1);
-
-      doNotify = FALSE;
     }
 
     pScrPriv -> lastSetTime = currentTime;
@@ -3745,10 +3742,7 @@ void nxagentAdjustCustomMode(ScreenPtr pScreen)
     pScrPriv->configChanged = 1;
   } /* if (pScrPriv) */
 
-  if (doNotify)
-  {
-    RRScreenSizeNotify(pScreen);
-  }
+  RRScreenSizeNotify(pScreen);
 }
 
 int nxagentChangeScreenConfig(int screen, int width, int height, int mmWidth, int mmHeight)


### PR DESCRIPTION
part of #475, was forgotten

The current version is not resizable via xrandr. This patch re-enables that feature if Xinerama is disabled (`-rrxinerama`)
