### PR TITLE
allow a custom version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ ifneq ($(shell pkg-config --exists fontutil && echo yes), yes)
     $(warning fontutil devel package missing, using imake default values)
 endif
 
+ifneq "$(strip $(NX_VERSION_CUSTOM))" ""
+    CUSTOM_VERSION_DEFINE = NX_VERSION_CUSTOM="$(NX_VERSION_CUSTOM)"
+endif
+
 IMAKE_DEFINES	?=
 
 SHELL:=/bin/bash
@@ -96,6 +100,9 @@ version:
 	    -e 's/###NX_VERSION_PATCH###/$(shell ./version.sh 4)/' \
 	    nx-X11/config/cf/nxversion.def.in \
 	    > nx-X11/config/cf/nxversion.def
+ifneq "$(strip $(NX_VERSION_CUSTOM))" ""
+	echo '#define NX_VERSION_CUSTOM $(NX_VERSION_CUSTOM)' >>nx-X11/config/cf/nxversion.def
+endif
 
 imakeconfig:
 	# auto-config some setting
@@ -157,17 +164,17 @@ build-full: build-env
 # in the full case, we rely on "magic" in the nx-X11 imake-based makefiles...
 
 	# build nxcomp first
-	cd nxcomp && autoreconf -vfsi && (${CONFIGURE}) && ${MAKE}
+	cd nxcomp && autoreconf -vfsi && (${CONFIGURE} $(CUSTOM_VERSION_DEFINE)) && ${MAKE}
 
 	# build libNX_X11 second
-	cd nx-X11/lib && autoreconf -vfsi && (${CONFIGURE} --disable-poll) && ${MAKE}
+	cd nx-X11/lib && autoreconf -vfsi && (${CONFIGURE} $(CUSTOM_VERSION_DEFINE) --disable-poll) && ${MAKE}
 	mkdir -p nx-X11/exports/lib/
 	$(SYMLINK_FILE) ../../lib/src/.libs/libNX_X11.so nx-X11/exports/lib/libNX_X11.so
 	$(SYMLINK_FILE) ../../lib/src/.libs/libNX_X11.so.6 nx-X11/exports/lib/libNX_X11.so.6
 	$(SYMLINK_FILE) ../../lib/src/.libs/libNX_X11.so.6.3.0 nx-X11/exports/lib/libNX_X11.so.6.3.0
 
 	# build nxcompshad third
-	cd nxcompshad && autoreconf -vfsi && (${CONFIGURE}) && ${MAKE}
+	cd nxcompshad && autoreconf -vfsi && (${CONFIGURE} $(CUSTOM_VERSION_DEFINE)) && ${MAKE}
 
 	# build nxagent fourth
 	./mesa-quilt push -a
@@ -175,7 +182,7 @@ build-full: build-env
 	${MAKE} -C nx-X11 World USRLIBDIR="$(USRLIBDIR)" SHLIBDIR="$(SHLIBDIR)" IMAKE_DEFINES="$(IMAKE_DEFINES)"
 
 	# build nxproxy fifth
-	cd nxproxy && autoreconf -vfsi && (${CONFIGURE}) && ${MAKE}
+	cd nxproxy && autoreconf -vfsi && (${CONFIGURE} $(CUSTOM_VERSION_DEFINE)) && ${MAKE}
 
 	# "build" nxdialog last
 	cd nxdialog && autoreconf -vfsi && (${CONFIGURE}) && ${MAKE}

--- a/nx-X11/config/cf/xorg.cf
+++ b/nx-X11/config/cf/xorg.cf
@@ -59,7 +59,11 @@ RELEASE_VERSION = ReleaseVersion
 #if !defined(nxVersionString) && \
     defined(NX_VERSION_MAJOR) && defined(NX_VERSION_MINOR) && \
     defined(NX_VERSION_MICRO) && defined(NX_VERSION_PATCH)
+#if defined(NX_VERSION_CUSTOM)
+# define nxVersionString NX_VERSION_CUSTOM (`echo NX_VERSION_MAJOR NX_VERSION_MINOR NX_VERSION_MICRO NX_VERSION_PATCH | sed 's/ /./g'`)
+#else
 # define nxVersionString `echo NX_VERSION_MAJOR NX_VERSION_MINOR NX_VERSION_MICRO NX_VERSION_PATCH | sed 's/ /./g'`
+#endif
 #endif
 
 /*

--- a/nxcomp/configure.ac
+++ b/nxcomp/configure.ac
@@ -19,6 +19,13 @@ AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2])
 # Initialize libtool
 AC_PROG_LIBTOOL
 
+# enable this to add the variable to the Makefiles
+#AC_ARG_VAR(NX_VERSION_CUSTOM, [custom version string])
+
+if test "x$NX_VERSION_CUSTOM" != x; then
+    AC_DEFINE_UNQUOTED([NX_VERSION_CUSTOM], ["${NX_VERSION_CUSTOM}"], [user provided custom version string])
+fi
+
 COMP_VERSION=nxcomp_version
 AC_SUBST([COMP_VERSION])
 

--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -13308,13 +13308,18 @@ void PrintConnectionInfo()
 
 void PrintVersionInfo()
 {
-  cerr << "NXPROXY - " << "Version "
+  cerr << "NXPROXY - Version "
+#ifdef NX_VERSION_CUSTOM
+       << NX_VERSION_CUSTOM << " ("
+#endif
        << control -> LocalVersionMajor << "."
        << control -> LocalVersionMinor << "."
        << control -> LocalVersionPatch << "."
-       << control -> LocalVersionMaintenancePatch;
-
-  cerr << endl;
+       << control -> LocalVersionMaintenancePatch
+#ifdef NX_VERSION_CUSTOM
+       << ")"
+#endif
+       << endl;
 }
 
 void PrintCopyrightInfo()

--- a/nxcompshad/configure.ac
+++ b/nxcompshad/configure.ac
@@ -19,6 +19,13 @@ AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2])
 # Initialize libtool
 AC_PROG_LIBTOOL
 
+# enable this to add the variable to the Makefiles
+#AC_ARG_VAR(NX_VERSION_CUSTOM, [custom version string])
+
+if test "x$NX_VERSION_CUSTOM" != x; then
+    AC_DEFINE_UNQUOTED([NX_VERSION_CUSTOM], ["${NX_VERSION_CUSTOM}"], [user provided custom version string])
+fi
+
 COMPSHAD_VERSION=nxcompshad_version
 AC_SUBST([COMPSHAD_VERSION])
 

--- a/nxproxy/configure.ac
+++ b/nxproxy/configure.ac
@@ -8,6 +8,7 @@ m4_define([nxproxy_version], m4_esyscmd([tr -d '\n' < VERSION]))
 AC_PREREQ(2.60)
 
 AC_INIT([NX Proxy], [nxproxy_version], [https://github.com/ArcticaProject/nx-libs/issues])
+
 AC_CONFIG_AUX_DIR([build-aux])
 AC_PROG_CC
 AC_CONFIG_SRCDIR([Makefile.am])
@@ -18,6 +19,13 @@ AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2])
 
 # Initialize libtool
 AC_PROG_LIBTOOL
+
+# enable this to add the variable to the Makefiles
+#AC_ARG_VAR(NX_VERSION_CUSTOM, [custom version string])
+
+if test "x$NX_VERSION_CUSTOM" != x; then
+    AC_DEFINE_UNQUOTED([NX_VERSION_CUSTOM], ["${NX_VERSION_CUSTOM}"], [user provided custom version string])
+fi
 
 PROXY_VERSION=nxproxy_version
 AC_SUBST([PROXY_VERSION])


### PR DESCRIPTION
run `make NX_VERSION_CUSTOM=bla` to get a custom version string into nxagent and nxproxy.

We can discuss how the output should look like, I am not really satiesfied with the current solution:

Currently you will get
```
    NXPROXY - Version 3.5.99.22
    NXAGENT - Version 3.5.99.22
```
when compiled _without_ a custom version and 
```
    NXPROXY - Version myvers (3.5.99.22)
    NXAGENT - Version myvers (3.5.99.22)
```
when compiled _with_ a custom version


