### PR TITLE
Use ctime_s/ctime_r instead of ctime in nxcomp.

### DIFF
--- a/nxcomp/configure.ac
+++ b/nxcomp/configure.ac
@@ -94,6 +94,23 @@ std::tm tm = *std::localtime(&t);
                              [Use std::put_time to format times, must be made available by the compiler if turned on.])],
                   [AC_MSG_RESULT([no])])
 
+# Check if ::ctime_s is available.
+AC_MSG_CHECKING([if ::ctime_s is available])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+[[
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <ctime>
+]],
+[[
+time_t res = time(NULL);
+char str[26] = { };
+::ctime_s(str, sizeof(str), &res);
+]])],
+                  [AC_MSG_RESULT([yes])
+                   AC_DEFINE(HAVE_CTIME_S, [1],
+                             [Use ::ctime_s to format times, must be made available by the compiler if turned on.])],
+                  [AC_MSG_RESULT([no])])
+
 AC_ARG_ENABLE([debug],
               [AS_HELP_STRING([--enable-debug],
                               [enable to get info session log output (disabled by default)])],

--- a/nxcomp/src/Timestamp.h
+++ b/nxcomp/src/Timestamp.h
@@ -26,11 +26,17 @@
 #ifndef Timestamp_H
 #define Timestamp_H
 
+#if HAVE_CTIME_S
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <time.h>
+#endif /* HAVE_CTIME_S */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
+#include <string>
 
-#include <time.h>
 #include <sys/time.h>
 
 #include "Misc.h"
@@ -260,15 +266,15 @@ inline int checkDiffTimestamp(const T_timestamp &ts1, const T_timestamp &ts2,
 // Return a string representing the timestamp.
 //
 
-char *strTimestamp(const T_timestamp &ts);
-char *strMsTimestamp(const T_timestamp &ts);
+std::string strTimestamp(const T_timestamp &ts);
+std::string strMsTimestamp(const T_timestamp &ts);
 
-inline char *strTimestamp()
+inline std::string strTimestamp()
 {
   return strTimestamp(getTimestamp());
 }
 
-inline char *strMsTimestamp()
+inline std::string strMsTimestamp()
 {
   return strMsTimestamp(getTimestamp());
 }


### PR DESCRIPTION
As mentioned in #616, the timestamping implementation in nxcomp is using ctime(), which isn't particularly modern or working well in multi-threaded code (should the need arise, anyway.)

Switch to ctime_r or ctime_s (with ctime_s being preferred if available), change to code to use on-stack `char*` buffers that do not need to be `free`'d and return std::string objects that will be copied around and leak no memory - without ugly code changes to "buffer" heap-allocated `char` arrays.