### PR TITLE
Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# Use new trusty images, should yield newer compilers and packages
+sudo: true
+dist: trusty
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+
+before_install:
+  - sudo apt-get update -qq
+  # imake
+  - sudo apt-get install -y xutils-dev
+  # X11 libaries
+  - sudo apt-get install -y libxcomposite-dev libxfont-dev libxinerama-dev libxrandr-dev libxtst-dev x11proto-fonts-dev
+  - eval "${MATRIX_EVAL}"
+script:
+  - make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NX development by ArticaProject, X2Go and TheQVD
+# NX development by ArticaProject, X2Go and TheQVD [![Build Status](https://travis-ci.org/ArcticaProject/nx-libs.svg)](https://travis-ci.org/ArcticaProject/nx-libs)
 
 This source tree started as a re-distribution of those NX packages needed
 to setup FreeNX and/or X2Go on a Linux server.

--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -3573,7 +3573,7 @@ int SetupAuthInstance()
 
   if (control -> ProxyMode == proxy_server)
   {
-    if (authCookie != NULL && *authCookie != '\0')
+    if (*authCookie != '\0')
     {
       if (useLaunchdSocket == 1)
       {

--- a/nxcompshad/src/X11.cpp
+++ b/nxcompshad/src/X11.cpp
@@ -363,7 +363,7 @@ void Poller::shmInit(void)
 
     shminfo_ -> shmaddr = (char *)shmat(shminfo_ -> shmid, 0, 0);
 
-    if (shminfo_ -> shmaddr < 0)
+    if (shminfo_ -> shmaddr < (void *)0)
     {
       logWarning("Poller::shmInit", "Couldn't attach to shm segment.");
     }


### PR DESCRIPTION
Hi @sunweaver,

As you told me in #622, I made an initial `TravisCI` implementation, running only on `Linux` (Ubuntu Trusty container images), but I think it is also possible building the project on `OS X`.

It runs *four* different builds in parallel with,
 
1. GCC 4.9, as an old GCC release.
1. GCC 7.X, as the latest GCC release.
1. CLANG 3.9, as an old CLANG release.
1. CLANG 5.0, as the latest CLANG release.

taking only 15 minutes for building the complete project.

I had to fix only two errors reported by Clang when compiling, but the build are all working in my fork now. You have to configure/activate Travis [here](https://travis-ci.org/) with the **ArcticaProject** account, and it should works here too.

The next step would be doing some testing from those builds, and fixing some of the many warnings GCC 7.2 and CLANG 5.0 are reporting now.