### PR TITLE
Re-enable XC-MISC extension

### DIFF
--- a/nx-X11/config/cf/X11.tmpl
+++ b/nx-X11/config/cf/X11.tmpl
@@ -623,6 +623,7 @@ FCHOWN_DEFINES = -DHAS_FCHOWN
 	DBEDefines \
 	XTestDefines \
 	XSyncDefines \
+	XCMiscDefines \
 	RECORDDefines \
 	ShmDefines \
 	BigReqDefines \

--- a/nx-X11/programs/Xserver/Xext/xcmisc.c
+++ b/nx-X11/programs/Xserver/Xext/xcmisc.c
@@ -30,8 +30,8 @@ from The Open Group.
 #include <dix-config.h>
 #endif
 
-#include <X11/X.h>
-#include <X11/Xproto.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "os.h"
 #include "dixstruct.h"


### PR DESCRIPTION
Got dropped by accident in 9bc6ff269aa8bf4c41696ebf4a686c93729ba151

Fixes ArcticaProject/nx-libs#589