### PR TITLE
panoramiX: fix includes

### DIFF
--- a/nx-X11/programs/Xserver/Xext/panoramiXSwap.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXSwap.c
@@ -28,8 +28,8 @@ Equipment Corporation.
 #endif
 
 #include <stdio.h>
-#include <X11/X.h>
-#include <X11/Xproto.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
 #include "misc.h"
 #include "cursor.h"
 #include "cursorstr.h"

--- a/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
+++ b/nx-X11/programs/Xserver/Xext/panoramiXprocs.c
@@ -31,8 +31,8 @@ Equipment Corporation.
 #endif
 
 #include <stdio.h>
-#include <X11/X.h>
-#include <X11/Xproto.h>
+#include <nx-X11/X.h>
+#include <nx-X11/Xproto.h>
 #include "windowstr.h"
 #include "dixfontstr.h"
 #include "gcstruct.h"


### PR DESCRIPTION
`nx-X11/` had been reverted to `X11/` by accident in 9bc6ff269aa8bf4c41696ebf4a686c93729ba151. Fix this.