### PR TITLE
hw/nxagent/Screen.c: Additionally check for noRRXineramaExtension set…

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -3797,7 +3797,7 @@ int nxagentChangeScreenConfig(int screen, int width, int height, int mmWidth, in
 
   if (r != 0)
   {
-    if (nxagentOption(Xinerama))
+    if (nxagentOption(Xinerama) && (noRRXineramaExtension == FALSE))
     {
       nxagentAdjustRandRXinerama(pScreen);
     }


### PR DESCRIPTION
… to FALSE before using the nxagentAdjustRandRXinerama() function and providing a Xinerama-like user experience.

 Fixes ArcticaProject/nx-libs#634.