### PR TITLE
Fix FTBFS on non-ELF platforms.

### DIFF
--- a/m4/nx-macros.m4
+++ b/m4/nx-macros.m4
@@ -407,6 +407,23 @@ FreeBSD=
 test "$nxconf_cv_freebsd" = yes && FreeBSD=yes
 ]) # NX_BUILD_ON_FreeBSD
 
+# Check to see if we're generating binaries in ELF format.
+
+AC_DEFUN([NX_TARGET_USE_ELF],
+[AC_CACHE_CHECK([if target system is ELF-based], [nxconf_cv_targetelf],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+[[
+#ifndef __ELF__
+#error not an ELF-based system
+error!
+#endif
+]],
+[[
+]])],
+[nxconf_cv_targetelf=yes], [nxconf_cv_targetelf=no])])
+AM_CONDITIONAL([TARGET_ELF], [test x"$nxconf_cv_targetelf" = "xyes"])
+]) # NX_TARGET_USE_ELF
+
 AC_DEFUN([LIBJPEG_FALLBACK_CHECK],[
 AC_MSG_CHECKING([for libjpeg shared libary file and headers])
 AC_CHECK_LIB([jpeg], [jpeg_destroy_compress],

--- a/nxcompshad/configure.ac
+++ b/nxcompshad/configure.ac
@@ -47,6 +47,8 @@ AC_LANG([C++])
 NX_COMPILER_BRAND
 NX_DEFAULT_OPTIONS
 
+NX_TARGET_USE_ELF
+
 AC_ARG_ENABLE([cxx11],
               [AS_HELP_STRING([--enable-cxx11],
                               [enable optional features requiring C++11 support (disabled by default)])],

--- a/nxcompshad/src/Makefile.am
+++ b/nxcompshad/src/Makefile.am
@@ -39,9 +39,13 @@ AM_CPPFLAGS =						\
 
 libXcompshad_la_LDFLAGS =				\
     -version-number @LT_COMPSHAD_VERSION@ -no-undefined	\
-    -Wl,--enable-new-dtags				\
     -R '$(libdir)/nx/X11'				\
     $(NULL)
+
+if TARGET_ELF
+libXcompshad_la_LDFLAGS +=				\
+    -Wl,--enable-new-dtags				\
+endif TARGET_ELF
 
 libXcompshadincludedir = $(includedir)/nx
 libXcompshadinclude_HEADERS =				\

--- a/nxproxy/configure.ac
+++ b/nxproxy/configure.ac
@@ -26,6 +26,8 @@ AC_LANG([C])
 NX_COMPILER_BRAND
 NX_DEFAULT_OPTIONS
 
+NX_TARGET_USE_ELF
+
 dnl This is a workaround for a nasty libtool bug.
 dnl We actually compile libXcomp with pthread support, but libtool uses g++ ... -nostdlib ... -pthread
 dnl on Linux. -nostdlib causes -pthread to be ignored.

--- a/nxproxy/src/Makefile.am
+++ b/nxproxy/src/Makefile.am
@@ -15,8 +15,13 @@ nxproxy_LDADD =						\
 
 nxproxy_LDFLAGS =					\
     $(PTHREAD_LDFLAGS)					\
+    $(NULL)
+
+if TARGET_ELF
+nxproxy_LDFLAGS +=					\
     -Wl,--enable-new-dtags				\
     $(NULL)
+endif TARGET_ELF
 
 nxproxy_CFLAGS =					\
     $(BASE_CFLAGS)					\


### PR DESCRIPTION
Check if target system is ELF-based and only add flag that enables new ELF dtags on ELF-based target systems.

Fixes: ArcticaProject/nx-libs#661