### PR TITLE
hw/nxagent/Screen.c: Cover Xinerama bounding box corner cases.

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -4126,22 +4126,6 @@ int nxagentAdjustRandRXinerama(ScreenPtr pScreen)
       unsigned int new_w = 0;
       unsigned int new_h = 0;
 
-      /*
-      if ((nxagentOption(X) < bbx1 || (nxagentOption(X) + width >= bbx2 )) {
-        #ifdef DEBUG
-        fprintf(stderr, "nxagentAdjustRandRXinerama: output [%d] name [%s]: window has parts outside visible area - width stays unchanged [%d]\n", i, pScrPriv->outputs[i]->name, width);
-        #endif
-	new_w = width;
-      }
-
-	if ((nxagentOption(Y) < bby1 || (nxagentOption(Y) + height >= bby2 ) {
-          #ifdef DEBUG
-          fprintf(stderr, "nxagentAdjustRandRXinerama: output [%d] name [%s]: window has parts outside visible area - height stays unchanged [%d]\n", i, pScrPriv->outputs[i]->name, height);
-          #endif
-	  new_h = height;
-	}
-      */
-
       /* if there's no intersection disconnect the output */
 #ifdef NXAGENT_RANDR_XINERAMA_CLIPPING
       disable_output = !intersect(nxagentOption(X), nxagentOption(Y),


### PR DESCRIPTION
  If the agent window is moved around on screen, it can happen
  that it is moved into an invisible area of the real Xserver,
  we calls this "beyond the bounding box".
  .
  If the agent window is partially beyond the bounding box, we
  don't want Xinerama to re-adjust the RandR parameters inside the
  agent. Near the bounding box, the session shall stay intact.
  .
  This means, desktop env wise, the desktop session control
  elements can be moved (with the agent window) into the invisible
  areas of the real Xserver and moved out again without RandR
  events arriving inside the agent session.

Fixes ArcticaProject/nx-libs#662.