### PR TITLE
Pr/saver unvalidated lengths proc screen saver unset attributes

### DIFF
--- a/nx-X11/programs/Xserver/Xext/saver.c
+++ b/nx-X11/programs/Xserver/Xext/saver.c
@@ -1342,6 +1342,8 @@ ProcScreenSaverUnsetAttributes (ClientPtr client)
        PanoramiXRes *draw;
        int i;
 
+       REQUEST_SIZE_MATCH(xScreenSaverUnsetAttributesReq);
+
        if(!(draw = (PanoramiXRes *)SecurityLookupIDByClass(
                    client, stuff->drawable, XRC_DRAWABLE, DixWriteAccess)))
            return BadDrawable;


### PR DESCRIPTION
Two patches from X.org that are missing in Xserver/Xext/saver.c. One of them addresses a CVE.