### PR TITLE
travis.yml: Add cppcheck - A tool for static C/C++ code analysis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,20 @@ matrix:
       addons:
         apt:
           sources:
+            - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
             - ubuntu-toolchain-r-test
+          packages:
+            - cppcheck/trusty-backports
+            # imake
+            - xutils-dev
+            # X11 libaries
+            - libxcomposite-dev
+            - libxfont-dev
+            - libxinerama-dev
+            - libxrandr-dev
+            - libxtst-dev
+            - x11proto-fonts-dev
+
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
         - STATIC_ANALYSIS="yes"
@@ -21,19 +34,20 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
-      env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+            - g++-8
+            # imake
+            - xutils-dev
+            # X11 libaries
+            - libxcomposite-dev
+            - libxfont-dev
+            - libxinerama-dev
+            - libxrandr-dev
+            - libxtst-dev
+            - x11proto-fonts-dev
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - STATIC_ANALYSIS="no"
 
     - os: linux
       addons:
@@ -42,28 +56,45 @@ matrix:
             - llvm-toolchain-trusty-3.9
           packages:
             - clang-3.9
+            # imake
+            - xutils-dev
+            # X11 libaries
+            - libxcomposite-dev
+            - libxfont-dev
+            - libxinerama-dev
+            - libxrandr-dev
+            - libxtst-dev
+            - x11proto-fonts-dev
+
       env:
         - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+        - STATIC_ANALYSIS="no"
 
     - os: linux
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
           packages:
-            - clang-5.0
+            - clang-6.0
+            - g++-4.9
+            # imake
+            - xutils-dev
+            # X11 libaries
+            - libxcomposite-dev
+            - libxfont-dev
+            - libxinerama-dev
+            - libxrandr-dev
+            - libxtst-dev
+            - x11proto-fonts-dev
+
       env:
-        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+        - STATIC_ANALYSIS="no"
 
 before_install:
-  - sudo apt-get update -qq
-  # cppcheck tool
-  - sudo apt-get install -y cppcheck/trusty-backports
-  # imake
-  - sudo apt-get install -y xutils-dev
-  # X11 libaries
-  - sudo apt-get install -y libxcomposite-dev libxfont-dev libxinerama-dev libxrandr-dev libxtst-dev x11proto-fonts-dev
-  - eval "${MATRIX_EVAL}"
+   - eval "${MATRIX_EVAL}"
 script:
    # run static analysis tools
    - ./run-static-analysis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,20 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+      env:
+        - MATRIX_EVAL="CC=gcc && CXX=g++"
+        - STATIC_ANALYSIS="yes"
+      fail_fast: true
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
     - os: linux
       addons:
@@ -47,10 +57,15 @@ matrix:
 
 before_install:
   - sudo apt-get update -qq
+  # cppcheck tool
+  - sudo apt-get install -y cppcheck/trusty-backports
   # imake
   - sudo apt-get install -y xutils-dev
   # X11 libaries
   - sudo apt-get install -y libxcomposite-dev libxfont-dev libxinerama-dev libxrandr-dev libxtst-dev x11proto-fonts-dev
   - eval "${MATRIX_EVAL}"
 script:
-  - make
+   # run static analysis tools
+   - ./run-static-analysis.sh
+   # build all packages
+   - make

--- a/doc/libNX_X11/lcUniConv/8bit_tab_to_h.c
+++ b/doc/libNX_X11/lcUniConv/8bit_tab_to_h.c
@@ -121,9 +121,15 @@ int main (int argc, char *argv[])
 
     {
       char* fname = malloc(strlen(directory)+strlen(filename)+1);
+      if (fname == NULL)
+      {
+        printf("malloc failed\n");
+        exit(1);
+      }
       strcpy(fname,directory); strcat(fname,filename);
       f = fopen(fname,"w");
       if (f == NULL)
+        free(fname);
         exit(1);
     }
 

--- a/nx-X11/lib/include/xtrans/Xtrans.c
+++ b/nx-X11/lib/include/xtrans/Xtrans.c
@@ -980,16 +980,17 @@ TRANS(GetMyAddr) (XtransConnInfo ciptr, int *familyp, int *addrlenp,
     {
        prmsg (1,"GetMyAddr: malloc failed\n");
        return -1;
+    } else {
+       memcpy(*addrp, ciptr->addr, ciptr->addrlen);
+       free(addrp);
     }
-    memcpy(*addrp, ciptr->addr, ciptr->addrlen);
-
     return 0;
 }
 #endif
 
 int
 TRANS(GetPeerAddr) (XtransConnInfo ciptr, int *familyp, int *addrlenp,
-		    Xtransaddr **addrp)
+                 Xtransaddr **addrp)
 
 {
     prmsg (2,"GetPeerAddr(%d)\n", ciptr->fd);
@@ -999,11 +1000,11 @@ TRANS(GetPeerAddr) (XtransConnInfo ciptr, int *familyp, int *addrlenp,
 
     if ((*addrp = malloc (ciptr->peeraddrlen)) == NULL)
     {
-	prmsg (1,"GetPeerAddr: malloc failed\n");
-	return -1;
+        prmsg (1,"GetPeerAddr: malloc failed\n");
+        return -1;
     }
     memcpy(*addrp, ciptr->peeraddr, ciptr->peeraddrlen);
-
+    free(addrp);
     return 0;
 }
 

--- a/nx-X11/lib/include/xtrans/Xtranssock.c
+++ b/nx-X11/lib/include/xtrans/Xtranssock.c
@@ -2442,19 +2442,18 @@ SocketUNIXConnectPost:
        (ciptr->peeraddr = malloc(namelen)) == NULL)
     {
         prmsg (1,
-	"SocketUNIXCreateListener: Can't allocate space for the addr\n");
+        "SocketUNIXCreateListener: Can't allocate space for the addr\n");
         return TRANS_CONNECT_FAILED;
     }
 
     if (abstract)
-	sockname.sun_path[0] = '@';
+        sockname.sun_path[0] = '@';
 
     ciptr->family = AF_UNIX;
     ciptr->addrlen = namelen;
     ciptr->peeraddrlen = namelen;
     memcpy (ciptr->addr, &sockname, ciptr->addrlen);
     memcpy (ciptr->peeraddr, &sockname, ciptr->peeraddrlen);
-
     return 0;
 }
 

--- a/nx-X11/programs/Xserver/Xi/exevents.c
+++ b/nx-X11/programs/Xserver/Xi/exevents.c
@@ -656,6 +656,7 @@ AddExtensionClient(WindowPtr pWin, ClientPtr client, Mask mask, int mskidx)
     if (!others)
 	return BadAlloc;
     if (!pWin->optional->inputMasks && !MakeInputMasks(pWin))
+	free(others);
 	return BadAlloc;
     bzero((char *)&others->mask[0], sizeof(Mask) * EMASKSIZE);
     others->mask[mskidx] = mask;

--- a/nx-X11/programs/Xserver/dix/cursor.c
+++ b/nx-X11/programs/Xserver/dix/cursor.c
@@ -371,6 +371,7 @@ AllocGlyphCursor(Font source, unsigned sourceChar, Font mask, unsigned maskChar,
 	    if (!pShare)
 	    {
 		FreeCursorBits(bits);
+		free(pCurs);
 		return BadAlloc;
 	    }
 	    pShare->font = sourcefont;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXmiexpose.c
@@ -629,11 +629,13 @@ int what;
 	    screenContext[i] = CreateGC((DrawablePtr)pWin, (BITS32) 0,
 					(XID *)NULL, &status);
 	    if (!screenContext[i])
+		free(prect);
 		return;
 	    numGCs++;
 	    if (!AddResource(FakeClientID(0), ResType,
-			     (void *)screenContext[i]))
-	        return;
+				    (void *)screenContext[i]))
+		free(prect);
+		return;
 	}
 	pGC = screenContext[i];
 	newValues[SUBWINDOW].val = IncludeInferiors;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -995,6 +995,7 @@ ProcRenderCompositeGlyphs (ClientPtr client)
     {
 	listsBase = (GlyphListPtr) malloc (nlist * sizeof (GlyphListRec));
 	if (!listsBase)
+	    free(glyphsBase);
 	    return BadAlloc;
     }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/compext/Png.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/compext/Png.c
@@ -283,6 +283,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
                 bitsPerPixel);
     #endif
 
+    free(image_index);
     return NULL;
   }
 
@@ -315,6 +316,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
     fprintf(stderr, "******PngCompressData: PANIC! Failed creating the png_create_write_struct.\n");
     #endif
 
+    free(image_index);
     return NULL;
   }
 
@@ -327,7 +329,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
     #endif
 
     png_destroy_write_struct(&png_ptr, NULL);
-
+    free(image_index);
     return NULL;
   }
 
@@ -339,6 +341,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
 
     png_destroy_write_struct(&png_ptr, &info_ptr);
 
+    free(image_index);
     return NULL;
   }
 
@@ -360,6 +363,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
                 PNG_DEST_SIZE(w, h));
     #endif
 
+    free(image_index);
     return NULL;
   }
 
@@ -374,7 +378,6 @@ char *PngCompressData(XImage *image, int *compressed_size)
     png_destroy_write_struct(&png_ptr, &info_ptr);
 
     free(pngCompBuf);
-
     return NULL;
   }
 
@@ -470,7 +473,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
     png_destroy_write_struct(&png_ptr, &info_ptr);
 
     free(pngCompBuf);
-
+    free(image_index);
     return NULL;
   }
 
@@ -484,7 +487,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
       fprintf(stderr, "******PngCompressData: PANIC! Cannot allocate [%d] bytes.\n",
                   (int) (w * sizeof(CARD8)));
       #endif
-
+      free(image_index);
       return NULL;
     }
 
@@ -516,7 +519,7 @@ char *PngCompressData(XImage *image, int *compressed_size)
     #endif
 
     free(pngCompBuf);
-
+    free(image_index);
     return NULL;
   }
 

--- a/nx-X11/programs/Xserver/mi/miexpose.c
+++ b/nx-X11/programs/Xserver/mi/miexpose.c
@@ -766,11 +766,13 @@ int what;
 	    screenContext[i] = CreateGC((DrawablePtr)pWin, (BITS32) 0,
 					(XID *)NULL, &status);
 	    if (!screenContext[i])
+		free(prect);
 		return;
 	    numGCs++;
 	    if (!AddResource(FakeClientID(0), ResType,
 			     (void *)screenContext[i]))
-	        return;
+		free(prect);
+		return;
 	}
 	pGC = screenContext[i];
 	newValues[SUBWINDOW].val = IncludeInferiors;

--- a/nx-X11/programs/Xserver/mi/mizerline.c
+++ b/nx-X11/programs/Xserver/mi/mizerline.c
@@ -158,7 +158,9 @@ miZeroLine(pDraw, pGC, mode, npt, pptInit)
     pspanInit = (DDXPointPtr)malloc(list_len * sizeof(DDXPointRec));
     pwidthInit = (int *)malloc(list_len * sizeof(int));
     if (!pspanInit || !pwidthInit)
-	return;
+        free(pspanInit);
+        free(pwidthInit);
+        return;
 
     Nspans = 0;
     new_span = TRUE;

--- a/nx-X11/programs/Xserver/render/render.c
+++ b/nx-X11/programs/Xserver/render/render.c
@@ -1346,6 +1346,8 @@ ProcRenderCompositeGlyphs (ClientPtr client)
     {
 	listsBase = (GlyphListPtr) malloc (nlist * sizeof (GlyphListRec));
 	if (!listsBase)
+	    free(glyphsBase);
+	    free(listsBase);
 	    return BadAlloc;
     }
     buffer = (CARD8 *) (stuff + 1);
@@ -2918,9 +2920,7 @@ PanoramiXRenderFillRectangles (ClientPtr client)
 	    result = (*PanoramiXSaveRenderVector[X_RenderFillRectangles]) (client);
 	    if(result != Success) break;
 	}
-	free(extra);
     }
-
     return result;
 }
 
@@ -2979,10 +2979,9 @@ PanoramiXRenderTrapezoids(ClientPtr client)
 
 	    if(result != Success) break;
 	}
-	
-        free(extra);
     }
 
+    free(extra);
     return result;
 }
 
@@ -3038,9 +3037,8 @@ PanoramiXRenderTriangles(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        free(extra);
     }
-
+    free(extra);
     return result;
 }
 
@@ -3092,9 +3090,8 @@ PanoramiXRenderTriStrip(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        free(extra);
     }
-
+    free(extra);
     return result;
 }
 
@@ -3146,9 +3143,8 @@ PanoramiXRenderTriFan(ClientPtr client)
 	    if(result != Success) break;
 	}
 	
-        free(extra);
     }
-
+    free(extra);
     return result;
 }
 
@@ -3276,9 +3272,8 @@ PanoramiXRenderAddTraps (ClientPtr client)
 	    result = (*PanoramiXSaveRenderVector[X_RenderAddTraps]) (client);
 	    if(result != Success) break;
 	}
-	free(extra);
     }
-
+    free(extra);
     return result;
 }
 

--- a/nxcomp/src/Children.cpp
+++ b/nxcomp/src/Children.cpp
@@ -1038,6 +1038,7 @@ int UnsetEnv(const char *name)
   }
 
   result = 0;
+  delete[] varName;
 
   #else
 

--- a/run-static-analysis.sh
+++ b/run-static-analysis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ "${STATIC_ANALYSIS}" == "yes" ]]; then
+    # cppcheck
+    if ! [ -x "$(command -v cppcheck)" ]; then
+        echo 'Error: cppcheck is not installed.' >&2
+        exit 1
+    fi
+    CPPCHECK_OPTS='--error-exitcode=0 --force --quiet'
+    # we exclude some external projects
+    CPPCHECK_EXCLUDES='-i ./nx-X11/extras/Mesa* -i ./nx-X11/extras/Mesa_* -i nx-X11/programs/Xserver/GL/mesa*'
+    echo "$(cppcheck --version):";
+    cppcheck $CPPCHECK_OPTS $CPPCHECK_EXCLUDES .;
+fi


### PR DESCRIPTION
This is still WIP, but the first approach to integrate `cppcheck` to the CI #699. PTAL at the `gcc-4.9` run.

TODO List:
   1. Still have to figure out how to configure TravisCI outside the Compilers-Matrix, to make this an independent check. I could also use CircleCI for example, if you dont mind having two parallel CIs running.
   2. Fix the errors, and then, to take a look at the warnings I disabled now. I also excluded Mesa as being an external project. 