### PR TITLE
Backport IDLETIME system counter to nx-X11 Xserver

### DIFF
--- a/nx-X11/programs/Xserver/Xext/dpms.c
+++ b/nx-X11/programs/Xserver/Xext/dpms.c
@@ -232,19 +232,10 @@ ProcDPMSForceLevel(client)
     if (!DPMSEnabled)
 	return BadMatch;
 
-    if (stuff->level == DPMSModeOn) {
-      lastDeviceEventTime.milliseconds =
-          GetTimeInMillis();
-    } else if (stuff->level == DPMSModeStandby) {
-      lastDeviceEventTime.milliseconds =
-          GetTimeInMillis() -  DPMSStandbyTime;
-    } else if (stuff->level == DPMSModeSuspend) {
-      lastDeviceEventTime.milliseconds =
-          GetTimeInMillis() -  DPMSSuspendTime;
-    } else if (stuff->level == DPMSModeOff) {
-      lastDeviceEventTime.milliseconds =
-          GetTimeInMillis() -  DPMSOffTime;
-    } else {
+    if (stuff->level != DPMSModeOn &&
+        stuff->level != DPMSModeStandby &&
+        stuff->level != DPMSModeSuspend &&
+        stuff->level != DPMSModeOff) {
 	client->errorValue = stuff->level;
 	return BadValue;
     }

--- a/nx-X11/programs/Xserver/dix/window.c
+++ b/nx-X11/programs/Xserver/dix/window.c
@@ -3348,8 +3348,6 @@ SaveScreens(int on, int mode)
 
     if (on == SCREEN_SAVER_FORCER)
     {
-	UpdateCurrentTimeIf();
-	lastDeviceEventTime = currentTime;
 	if (mode == ScreenSaverReset)
 	    what = SCREEN_SAVER_OFF;
 	else


### PR DESCRIPTION
This resolves issues with non-starting mate-screensaver which relies on the IDLETIME API these days.
