### PR TITLE
Fix broken 9a7c0b081fad98bfcfcceff9557781f4b39ec572

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -853,8 +853,6 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
   unsigned long valuemask;
   XSetWindowAttributes attributes;
   XWindowAttributes gattributes;
-  XSizeHints* sizeHints;
-  XWMHints* wmHints;
   Mask mask;
   Bool resetAgentPosition = False;
 
@@ -1870,6 +1868,9 @@ N/A
       XSelectInput(nxagentDisplay, nxagentFullscreenWindow, mask);
     }
 
+    XSizeHints* sizeHints;
+    XWMHints* wmHints;
+
     if ((sizeHints = XAllocSizeHints()))
     {
       sizeHints->flags = PPosition | PMinSize | PMaxSize;
@@ -1898,15 +1899,6 @@ N/A
         sizeHints->flags |= USSize;
     }
 
-    Xutf8SetWMProperties(nxagentDisplay, 
-                         nxagentDefaultWindows[pScreen->myNum],
-                         nxagentWindowName, 
-                         nxagentWindowName,
-                         argv , argc , &sizeHints, &wmHints, NULL);
-
-    if (sizeHints)
-      XFree(sizeHints);
-
     if ((wmHints = XAllocWMHints()))
     {
       wmHints->icon_pixmap = nxagentIconPixmap;
@@ -1920,9 +1912,24 @@ N/A
       {
         wmHints->flags = IconPixmapHint;
       }
+    }
 
-      XSetWMHints(nxagentDisplay, nxagentDefaultWindows[pScreen->myNum], wmHints);
-      XFree(wmHints);
+    Xutf8SetWMProperties(nxagentDisplay,
+                         nxagentDefaultWindows[pScreen->myNum],
+                         nxagentWindowName,
+                         nxagentWindowName,
+                         argv , argc , sizeHints, wmHints, NULL);
+
+    if (sizeHints)
+    {
+        XFree(sizeHints);
+        sizeHints = NULL;
+    }
+
+    if (wmHints)
+    {
+        XFree(wmHints);
+        wmHints = NULL;
     }
 
     /*


### PR DESCRIPTION
Windowsize was wrong when run with nxagent :<someDisplay>.

Basically three changes:
- reference sizeHints and wmHints correctly (no &)
- do not use uninitialized wmHints
- set wmHints Xutf8SetWMProperties() call instead of separate call