### PR TITLE
Pr/decode options

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1037,14 +1037,14 @@ int ddxProcessArgument(int argc, char *argv[], int i)
   return 0;
 }
 
-static void nxagentParseOptions(char *name, char *value)
+static void nxagentParseSingleOption(char *name, char *value)
 {
   int size, argc;
 
   char *argv[2] = { NULL, NULL };
 
   #ifdef TEST
-  fprintf(stderr, "nxagentParseOptions: Processing option '%s' = '%s'.\n",
+  fprintf(stderr, "nxagentParseSingleOption: Processing option '%s' = '%s'.\n",
               validateString(name), validateString(value));
   #endif
 
@@ -1081,7 +1081,7 @@ static void nxagentParseOptions(char *name, char *value)
     if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
-      fprintf(stderr, "nxagentParseOptions: Ignoring option 'render' at reconnection.\n");
+      fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'render' at reconnection.\n");
       #endif
     }
     else if (nxagentRenderEnable == UNDEFINED)
@@ -1113,7 +1113,7 @@ static void nxagentParseOptions(char *name, char *value)
     if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
-      fprintf(stderr, "nxagentParseOptions: Ignoring option 'fullscreen' at reconnection.\n");
+      fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'fullscreen' at reconnection.\n");
       #endif
     }
     else if (!strcmp(value, "1"))
@@ -1283,7 +1283,7 @@ static void nxagentParseOptions(char *name, char *value)
     if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
-      fprintf(stderr, "nxagentParseOptions: Ignoring option 'autodpi' at reconnection.\n");
+      fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'autodpi' at reconnection.\n");
       #endif
     }
     else if (!strcmp(value, "0"))
@@ -1368,7 +1368,7 @@ static void nxagentParseOptions(char *name, char *value)
 
     if ((errno) && (0 == sleep_parse))
     {
-      fprintf(stderr, "nxagentParseOptions: Unable to convert value [%s] of option [%s]. "
+      fprintf(stderr, "nxagentParseSingleOption: Unable to convert value [%s] of option [%s]. "
                       "Ignoring option.\n",
                       validateString(value), validateString(name));
 
@@ -1379,7 +1379,7 @@ static void nxagentParseOptions(char *name, char *value)
     {
       sleep_parse = UINT_MAX;
 
-      fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+      fprintf(stderr, "nxagentParseSingleOption: Warning: value [%s] of option [%s] "
                       "out of range, clamped to [%lu].\n",
                       validateString(value), validateString(name), sleep_parse);
     }
@@ -1388,7 +1388,7 @@ static void nxagentParseOptions(char *name, char *value)
     {
       sleep_parse = 0;
 
-      fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+      fprintf(stderr, "nxagentParseSingleOption: Warning: value [%s] of option [%s] "
                       "out of range, clamped to [%lu].\n",
                       validateString(value), validateString(name), sleep_parse);
     }
@@ -1427,7 +1427,7 @@ static void nxagentParseOptions(char *name, char *value)
 
       if ((errno) && (0 == tolerance_parse))
       {
-        fprintf(stderr, "nxagentParseOptions: Unable to convert value [%s] of option [%s]. "
+        fprintf(stderr, "nxagentParseSingleOption: Unable to convert value [%s] of option [%s]. "
                         "Ignoring option.\n",
                         validateString(value), validateString(name));
 
@@ -1438,7 +1438,7 @@ static void nxagentParseOptions(char *name, char *value)
       {
         tolerance_parse = UINT_MAX;
 
-        fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+        fprintf(stderr, "nxagentParseSingleOption: Warning: value [%s] of option [%s] "
                         "out of range, clamped to [%lu].\n",
                         validateString(value), validateString(name), tolerance_parse);
       }
@@ -1447,7 +1447,7 @@ static void nxagentParseOptions(char *name, char *value)
       {
         tolerance_parse = 0;
 
-        fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of option [%s] "
+        fprintf(stderr, "nxagentParseSingleOption: Warning: value [%s] of option [%s] "
                         "out of range, clamped to [%lu].\n",
                         validateString(value), validateString(name), tolerance_parse);
       }
@@ -1460,7 +1460,7 @@ static void nxagentParseOptions(char *name, char *value)
         case ToleranceChecksBypass:
                                break;
         default:
-                               fprintf(stderr, "nxagentParseOptions: Warning: value [%s] of "
+                               fprintf(stderr, "nxagentParseSingleOption: Warning: value [%s] of "
                                                "option [%s] unknown, will be mapped to "
                                                "\"Bypass\" [%u] value internally.\n",
                                        validateString(value), validateString(name),
@@ -1495,7 +1495,7 @@ static void nxagentParseOptions(char *name, char *value)
   else
   {
     #ifdef DEBUG
-    fprintf(stderr, "nxagentParseOptions: Ignored option [%s] with value [%s].\n",
+    fprintf(stderr, "nxagentParseSingleOption: Ignored option [%s] with value [%s].\n",
                 validateString(name), validateString(value));
     #endif
 
@@ -1563,7 +1563,7 @@ static void nxagentParseOptionString(char *string)
       value = NULL;
     }
 
-    nxagentParseOptions(option, value);
+    nxagentParseSingleOption(option, value);
   }
 }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1037,6 +1037,39 @@ int ddxProcessArgument(int argc, char *argv[], int i)
   return 0;
 }
 
+/* copy from nxcomp's Loop.cpp */
+static int
+hexval(char c) {
+    if ((c >= '0') && (c <= '9'))
+        return c - '0';
+    if ((c >= 'a') && (c <= 'f'))
+        return c - 'a' + 10;
+    if ((c >= 'A') && (c <= 'F'))
+        return c - 'A' + 10;
+    return -1;
+}
+
+static void
+URLDecodeInPlace(char *str)
+{
+  if (str) {
+    char *to = str;
+    while (str[0])
+    {
+      if ((str[0] == '%') &&
+          (hexval(str[1]) >= 0) &&
+          (hexval(str[2]) >= 0))
+      {
+        *(to++) = hexval(str[1]) * 16 + hexval(str[2]);
+        str += 3;
+      }
+      else
+        *(to++) = *(str++);
+    }
+    *to = '\0';
+  }
+}
+
 static void nxagentParseSingleOption(char *name, char *value)
 {
   int size, argc;
@@ -1047,6 +1080,8 @@ static void nxagentParseSingleOption(char *name, char *value)
   fprintf(stderr, "nxagentParseSingleOption: Processing option '%s' = '%s'.\n",
               validateString(name), validateString(value));
   #endif
+
+  URLDecodeInPlace(value);
 
   if (!strcmp(name, "kbtype") ||
           !strcmp(name, "keyboard") ||

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -480,6 +480,11 @@ As <proxy-port> you can pick an arbitrary (unused) TCP port or Unix
 socket file path. This is the port / socket that you have to connect to
 with the \fBnxproxy\fR application.
 .PP
+The right hand side of an option (the part following the "=" character)
+can include URL encoded characters. It is required to URL encode at
+least "," (as %2D) and "=" (as %3D) to avoid wrong parsing of the
+options string.
+.PP
 Available \fBnxagent\fR options (as an addition to nx/nx options supported
 by nxcomp already):
 .TP 8


### PR DESCRIPTION
decode URL encoded characters in options string. This is a much lighter (and cleaner) solution for the problem that #551 tries to solve.

(I did not succeed in linking the URLdecode stuff from nxcomp so I cloned it. If I get that right nxagent is not using anything from nxcomp directly currently.)