### PR TITLE
nxagent: Fix an excessive request size limitation that broke big-requ…

### DIFF
--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -301,7 +301,8 @@ ReadRequestFromClient(ClientPtr client)
 	 */
 
 	oci->lenLastReq = 0;
-	if (needed > MAXBUFSIZE)
+#ifdef BIGREQS
+	if (needed > maxBigRequestSize << 2)
 	{
 	    /* request is too big for us to handle */
 	    /*
@@ -312,6 +313,7 @@ ReadRequestFromClient(ClientPtr client)
 	    oci->lenLastReq = gotnow;
 	    return needed;
 	}
+#endif
 	if ((gotnow == 0) ||
 	    ((oci->bufptr - oci->buffer + needed) > oci->size))
 	{


### PR DESCRIPTION
…ests.

Fixes ArcticaProject/nx-libs#301, #631

Backport from xorg-xserver:

  commit ca82d4bddf235c9b68d51d68636bab40eafb9889
  Author: Eric Anholt <eric@anholt.net>
  Date:   Fri Aug 31 13:00:23 2007 -0700

    Bug #7186: Fix an excessive request size limitation that broke big-requests.

    MAXBUFSIZE appears to be a leftover of some previous time.  Instead, just
    use maxBigRequestSize when bigreqs are available (limiting buffers to ~16MB).
    When bigreqs are not available, needed won't be larger than the maximum
    size of a non-bigreqs request (256kB).