### PR TITLE
Pr/small improvements

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -2275,6 +2275,10 @@ void nxagentShapeWindow(WindowPtr pWin)
               (void *) pWin, nxagentWindow(pWin));
   #endif
 
+  /*
+    FIXME: this is the same code as below, just with another shape. Maybe move
+    this code to a helper function?
+   */
   if (!nxagentRegionEqual(nxagentWindowPriv(pWin)->boundingShape,
                         wBoundingShape(pWin)))
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -263,8 +263,7 @@ WindowPtr nxagentWindowPtr(Window window)
   return match.pWin;
 }
 
-Bool nxagentCreateWindow(pWin)
-     WindowPtr pWin;
+Bool nxagentCreateWindow(WindowPtr pWin)
 {
   unsigned long mask;
   XSetWindowAttributes attributes;
@@ -1568,9 +1567,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
   }
 }
 
-void nxagentReparentWindow(pWin, pOldParent)
-     WindowPtr pWin;
-     WindowPtr pOldParent;
+void nxagentReparentWindow(WindowPtr pWin, WindowPtr pOldParent)
 {
   if (nxagentScreenTrap)
   {
@@ -1589,9 +1586,7 @@ void nxagentReparentWindow(pWin, pOldParent)
                               pWin->origin.y - wBorderWidth(pWin));
 }
 
-Bool nxagentChangeWindowAttributes(pWin, mask)
-     WindowPtr pWin;
-     unsigned long mask;
+Bool nxagentChangeWindowAttributes(WindowPtr pWin, unsigned long mask)
 {
   XSetWindowAttributes attributes;
 
@@ -1953,8 +1948,7 @@ Bool nxagentRealizeWindow(WindowPtr pWin)
   return True;
 }
 
-Bool nxagentUnrealizeWindow(pWin)
-    WindowPtr pWin;
+Bool nxagentUnrealizeWindow(WindowPtr pWin)
 {
   if (nxagentScreenTrap)
   {
@@ -2011,10 +2005,7 @@ void nxagentFrameBufferPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what)
   }
 }
 
-void nxagentPaintWindowBackground(pWin, pRegion, what)
-     WindowPtr pWin;
-     RegionPtr pRegion;
-     int what;
+void nxagentPaintWindowBackground(WindowPtr pWin, RegionPtr pRegion, int what)
 {
   int i;
 
@@ -3428,8 +3419,7 @@ Bool nxagentIsIconic(WindowPtr pWin)
   }
 }
 
-void nxagentSetTopLevelEventMask(pWin)
-     WindowPtr pWin;
+void nxagentSetTopLevelEventMask(WindowPtr pWin)
 {
   unsigned long mask = CWEventMask;
   XSetWindowAttributes attributes;

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -232,10 +232,7 @@ static int nxagentFindWindowMatch(WindowPtr pWin, void * ptr)
 
 WindowPtr nxagentWindowPtr(Window window)
 {
-  WindowMatchRec match;
-
-  match.pWin = NullWindow;
-  match.id   = window;
+  WindowMatchRec match = {.pWin = NullWindow, .id   = window};
 
   for (int i = 0; i < nxagentNumScreens; i++)
   {
@@ -716,8 +713,6 @@ void nxagentRestackWindow(WindowPtr pWin, WindowPtr pOldNextSib)
 
 void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
 {
-  XEvent e = {0};
-
   if (nxagentOption(Rootless) == 1)
   {
     return;
@@ -754,14 +749,15 @@ void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
 
   nxagentChangeOption(Fullscreen, switchOn);
 
-  e.xclient.type = ClientMessage;
-  e.xclient.message_type = nxagentAtoms[13]; /* _NET_WM_STATE */
-  e.xclient.display = nxagentDisplay;
-  e.xclient.window = nxagentDefaultWindows[pScreen -> myNum];
-  e.xclient.format = 32;
-  e.xclient.data.l[0] = nxagentOption(Fullscreen) ? 1 : 0;
-  e.xclient.data.l[1] = nxagentAtoms[14]; /* _NET_WM_STATE_FULLSCREEN */
-
+  XEvent e = {
+    .xclient.type = ClientMessage,
+    .xclient.message_type = nxagentAtoms[13], /* _NET_WM_STATE */
+    .xclient.display = nxagentDisplay,
+    .xclient.window = nxagentDefaultWindows[pScreen -> myNum],
+    .xclient.format = 32,
+    .xclient.data.l[0] = nxagentOption(Fullscreen) ? 1 : 0,
+    .xclient.data.l[1] = nxagentAtoms[14] /* _NET_WM_STATE_FULLSCREEN */
+  };
   XSendEvent(nxagentDisplay, DefaultRootWindow(nxagentDisplay), False,
                  SubstructureRedirectMask, &e);
 
@@ -1170,11 +1166,7 @@ void nxagentMoveViewport(ScreenPtr pScreen, int hShift, int vShift)
        * pan and one for vertical pan.
        */
 
-      BoxRec hRect;
-      BoxRec vRect;
-
-      hRect.x1 = -newX;
-      hRect.y1 = -newY;
+      BoxRec hRect = {.x1 = -newX, .y1 = -newY};
 
       if (hShift < 0)
       {
@@ -1192,8 +1184,7 @@ void nxagentMoveViewport(ScreenPtr pScreen, int hShift, int vShift)
       fprintf(stderr, "nxagentMoveViewport: hRect p1[%i, %i] - p2[%i, %i].\n", hRect.x1, hRect.y1, hRect.x2, hRect.y2);
       #endif
 
-      vRect.x1 = -newX;
-      vRect.y1 = -newY;
+      BoxRec vRect = {.x1 = -newX, .y1 = -newY};
 
       if (vShift < 0)
       {
@@ -2263,7 +2254,6 @@ void nxagentShapeWindow(WindowPtr pWin)
 {
   Region reg;
   BoxPtr pBox;
-  XRectangle rect;
 
   if (NXDisplayError(nxagentDisplay) == 1)
   {
@@ -2308,10 +2298,12 @@ void nxagentShapeWindow(WindowPtr pWin)
            i < RegionNumRects(nxagentWindowPriv(pWin)->boundingShape);
            i++)
       {
-        rect.x = pBox[i].x1;
-        rect.y = pBox[i].y1;
-        rect.width = pBox[i].x2 - pBox[i].x1;
-        rect.height = pBox[i].y2 - pBox[i].y1;
+        XRectangle rect = {
+          .x = pBox[i].x1,
+          .y = pBox[i].y1,
+          .width = pBox[i].x2 - pBox[i].x1,
+          .height = pBox[i].y2 - pBox[i].y1
+        };
         XUnionRectWithRegion(&rect, reg, reg);
       }
 
@@ -2365,10 +2357,12 @@ void nxagentShapeWindow(WindowPtr pWin)
            i < RegionNumRects(nxagentWindowPriv(pWin)->clipShape);
            i++)
       {
-        rect.x = pBox[i].x1;
-        rect.y = pBox[i].y1;
-        rect.width = pBox[i].x2 - pBox[i].x1;
-        rect.height = pBox[i].y2 - pBox[i].y1;
+        XRectangle rect = {
+          .x = pBox[i].x1,
+          .y = pBox[i].y1,
+          .width = pBox[i].x2 - pBox[i].x1,
+          .height = pBox[i].y2 - pBox[i].y1
+        };
         XUnionRectWithRegion(&rect, reg, reg);
       }
 
@@ -2400,14 +2394,13 @@ static int nxagentForceExposure(WindowPtr pWin, void * ptr)
 {
   if (pWin -> drawable.class != InputOnly)
   {
-    BoxRec Box;
     WindowPtr pRoot = pWin->drawable.pScreen->root;
-
-    Box.x1 = pWin->drawable.x;
-    Box.y1 = pWin->drawable.y;
-    Box.x2 = Box.x1 + pWin->drawable.width;
-    Box.y2 = Box.y1 + pWin->drawable.height;
-
+    BoxRec Box = {
+      .x1 = pWin->drawable.x,
+      .y1 = pWin->drawable.y,
+      .x2 = Box.x1 + pWin->drawable.width,
+      .y2 = Box.y1 + pWin->drawable.height,
+    };
     RegionPtr exposedRgn = RegionCreate(&Box, 1);
 
     RegionIntersect(exposedRgn, exposedRgn, &pRoot->winSize);

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -2660,7 +2660,10 @@ void nxagentDisconnectWindow(void * p0, XID x1, void * p2)
 
 Bool nxagentReconnectAllWindows(void *p0)
 {
-  int flexibility = *(int *) p0;
+  /*
+    access the parameter like this if this function needs it in future:
+    int flexibility = *(int *) p0;
+  */
 
   #if defined(NXAGENT_RECONNECT_DEBUG) || defined(NXAGENT_RECONNECT_WINDOW_DEBUG)
   fprintf(stderr, "nxagentReconnectAllWindows\n");
@@ -2770,7 +2773,10 @@ Bool nxagentReconnectAllWindows(void *p0)
 
 Bool nxagentSetWindowCursors(void *p0)
 {
-  int flexibility = *(int *) p0;
+  /*
+    access the parameter like this if this function needs it in future:
+    int flexibility = *(int *) p0;
+   */
 
   #if defined(NXAGENT_RECONNECT_DEBUG) || defined(NXAGENT_RECONNECT_WINDOW_DEBUG)
   fprintf(stderr, "nxagentSetWindowCursors: Going to loop over the windows.\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -257,7 +257,10 @@ WindowPtr nxagentWindowPtr(Window window)
   {
     WalkTree(screenInfo.screens[i], nxagentFindWindowMatch, (void *) &match);
 
-    if (match.pWin) break;
+    if (match.pWin)
+    {
+      break;
+    }
   }
 
   return match.pWin;
@@ -285,11 +288,13 @@ Bool nxagentCreateWindow(WindowPtr pWin)
   fprintf(stderr, "nxagentCreateWindow: nxagentSplashCount [%d]\n", nxagentSplashCount);
 #endif
 
-  if (pWin->drawable.class == InputOnly) {
+  if (pWin->drawable.class == InputOnly)
+  {
     mask = CWEventMask;
     visual = CopyFromParent;
   }
-  else {
+  else
+  {
     mask = CWEventMask | CWBackingStore;
 
     if (pWin->optional)
@@ -310,31 +315,41 @@ Bool nxagentCreateWindow(WindowPtr pWin)
       FIXME: We need to set save under on the real display?
     */
     if (nxagentSaveUnder)
-      {
-        mask |= CWSaveUnder;
-        attributes.save_under = False;
-      }
+    {
+      mask |= CWSaveUnder;
+      attributes.save_under = False;
+    }
 
-    if (pWin->parent) {
-      if (pWin->optional && pWin->optional->visual != wVisual(pWin->parent)) {
+    if (pWin->parent)
+    {
+      if (pWin->optional && pWin->optional->visual != wVisual(pWin->parent))
+      {
         visual = nxagentVisualFromID(pWin->drawable.pScreen, wVisual(pWin));
         mask |= CWColormap;
-        if (pWin->optional->colormap) {
+        if (pWin->optional->colormap)
+        {
           pCmap = (ColormapPtr)LookupIDByType(wColormap(pWin), RT_COLORMAP);
           attributes.colormap = nxagentColormap(pCmap);
         }
         else
+        {
           attributes.colormap = nxagentDefaultVisualColormap(visual);
+        }
       }
       else if (pWin->optional)
-       visual = CopyFromParent;
-      else {
+      {
+        visual = CopyFromParent;
+      }
+      else
+      {
         visual = nxagentVisualFromID(pWin->drawable.pScreen, wVisual(pWin));
         mask |= CWColormap;
         attributes.colormap = nxagentDefaultVisualColormap(visual);
       }
     }
-    else { /* root windows have their own colormaps at creation time */
+    else
+    {
+      /* root windows have their own colormaps at creation time */
       visual = nxagentVisualFromID(pWin->drawable.pScreen, wVisual(pWin));
       pCmap = (ColormapPtr)LookupIDByType(wColormap(pWin), RT_COLORMAP);
       mask |= CWColormap;
@@ -473,11 +488,15 @@ Bool nxagentCreateWindow(WindowPtr pWin)
     Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
 
     if (ChangeWindowProperty(pWin, prop, XA_WINDOW, 32, PropModeReplace, 1, nxagentWindowPriv(pWin), 1) != Success)
-        fprintf(stderr, "nxagentCreateWindow: Adding NX_REAL_WINDOW failed.\n");
-#ifdef DEBUG
+    {
+      fprintf(stderr, "nxagentCreateWindow: Adding NX_REAL_WINDOW failed.\n");
+    }
+    #ifdef DEBUG
     else
-        fprintf(stderr, "nxagentCreateWindow: Added NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
-#endif
+    {
+      fprintf(stderr, "nxagentCreateWindow: Added NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+    }
+    #endif
   }
 
   nxagentWindowPriv(pWin)->x = pWin->origin.x - wBorderWidth(pWin);
@@ -537,11 +556,15 @@ void nxagentSetVersionProperty(WindowPtr pWin)
   Atom prop = MakeAtom(name, strlen(name), True);
 
   if (ChangeWindowProperty(pWin, prop, XA_STRING, 8, PropModeReplace, strlen(NX_VERSION_CURRENT_STRING), NX_VERSION_CURRENT_STRING, True) != Success)
+  {
     fprintf(stderr, "%s: Adding property [%s], value [%s] failed.\n", __func__, name, NX_VERSION_CURRENT_STRING);
-#ifdef DEBUG
+  }
+  #ifdef DEBUG
   else
-    fprintf(stderr, "%s: Added property [%s], value [%s] for root window [%x].\n", __func__, name, NX_VERSION_CURRENT_STRING, pWin);
-#endif
+  {
+      fprintf(stderr, "%s: Added property [%s], value [%s] for root window [%x].\n", __func__, name, NX_VERSION_CURRENT_STRING, pWin);
+  }
+  #endif
 }
 
 Bool nxagentSomeWindowsAreMapped(void)
@@ -1907,7 +1930,9 @@ Bool nxagentRealizeWindow(WindowPtr pWin)
     wmState.state = 1; /* NormalState */
     wmState.icon = None;
     if (ChangeWindowProperty(pWin, prop, prop, 32, 0, 2, &wmState, 1) != Success)
+    {
       fprintf(stderr, "nxagentRealizeWindow: Adding WM_STATE fail.\n");
+    }
   }
 
   #ifdef SHAPE
@@ -1963,7 +1988,9 @@ Bool nxagentUnrealizeWindow(WindowPtr pWin)
     wmState.state = 3; /* WithdrawnState */
     wmState.icon = None;
     if (ChangeWindowProperty(pWin, prop, prop, 32, 0, 2, &wmState, 1) != Success)
+    {
       fprintf(stderr, "nxagentUnRealizeWindow: Changing WM_STATE failed.\n");
+    }
   }
 
   XUnmapWindow(nxagentDisplay, nxagentWindow(pWin));
@@ -2121,7 +2148,7 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
    *
    * - We create a "fake" off-screen window. For every generated region
    *   we send a ConfigureWindow request for that window to synchronize
-   *  ourselves with both the remote X server and/or the window manager.
+   *   ourselves with both the remote X server and/or the window manager.
    *
    * - When the ConfigureNotify is received, we calculate the difference
    *   between the "remote-region" and the "local-region" for the window
@@ -2301,9 +2328,15 @@ static Bool nxagentRegionEqual(RegionPtr pReg1, RegionPtr pReg2)
   BoxPtr pBox1, pBox2;
   unsigned int n1, n2;
 
-  if (pReg1 == pReg2) return True;
+  if (pReg1 == pReg2)
+  {
+    return True;
+  }
 
-  if (pReg1 == NullRegion || pReg2 == NullRegion) return False;
+  if (pReg1 == NullRegion || pReg2 == NullRegion)
+  {
+    return False;
+  }
 
   pBox1 = RegionRects(pReg1);
   n1 = RegionNumRects(pReg1);
@@ -2311,11 +2344,20 @@ static Bool nxagentRegionEqual(RegionPtr pReg1, RegionPtr pReg2)
   pBox2 = RegionRects(pReg2);
   n2 = RegionNumRects(pReg2);
 
-  if (n1 != n2) return False;
+  if (n1 != n2)
+  {
+    return False;
+  }
 
-  if (pBox1 == pBox2) return True;
+  if (pBox1 == pBox2)
+  {
+    return True;
+  }
 
-  if (memcmp(pBox1, pBox2, n1 * sizeof(BoxRec))) return False;
+  if (memcmp(pBox1, pBox2, n1 * sizeof(BoxRec)))
+  {
+    return False;
+  }
 
   return True;
 }
@@ -2697,11 +2739,15 @@ void nxagentDisconnectWindow(void * p0, XID x1, void * p2)
     Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
 
     if (DeleteProperty(pWin, prop) != Success)
+    {
         fprintf(stderr, "nxagentDisconnectWindow: Deleting NX_REAL_WINDOW failed.\n");
-#ifdef DEBUG
+    }
+    #ifdef DEBUG
     else
-        fprintf(stderr, "nxagentDisconnectWindow: Deleting NX_REAL_WINDOW from Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
-#endif
+    {
+      fprintf(stderr, "nxagentDisconnectWindow: Deleting NX_REAL_WINDOW from Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+    }
+    #endif
   }
 
   nxagentWindow(pWin) = None;
@@ -2899,17 +2945,21 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
   ColormapPtr pCmap;
 
   if (!pWin || !*pBool)
+  {
     return;
+  }
 
   #ifdef NXAGENT_RECONNECT_WINDOW_DEBUG
   fprintf(stderr, "nxagentReconnectWindow: %p - ID %lx\n", pWin, nxagentWindow(pWin));
   #endif
 
-  if (pWin->drawable.class == InputOnly) {
+  if (pWin->drawable.class == InputOnly)
+  {
     mask = CWEventMask;
     visual = CopyFromParent;
   }
-  else {
+  else
+  {
     mask = CWEventMask | CWBackingStore;
 
     attributes.backing_store = NotUseful;
@@ -2930,21 +2980,30 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
       attributes.save_under = pWin->saveUnder;
     }
 
-    if (pWin->parent) {
-        if (pWin->optional && pWin->optional->visual != wVisual(pWin->parent)) {
+    if (pWin->parent)
+    {
+      if (pWin->optional && pWin->optional->visual != wVisual(pWin->parent))
+      {
         visual = nxagentVisualFromID(pWin->drawable.pScreen, wVisual(pWin));
         mask |= CWColormap;
-        if (pWin->optional->colormap) {
+        if (pWin->optional->colormap)
+        {
           pCmap = (ColormapPtr)LookupIDByType(wColormap(pWin), RT_COLORMAP);
           attributes.colormap = nxagentColormap(pCmap);
         }
         else
+        {
           attributes.colormap = nxagentDefaultVisualColormap(visual);
+        }
       }
       else
+      {
         visual = CopyFromParent;
+      }
     }
-    else { /* root windows have their own colormaps at creation time */
+    else
+    {
+      /* root windows have their own colormaps at creation time */
       visual = nxagentVisualFromID(pWin->drawable.pScreen, wVisual(pWin));
       pCmap = (ColormapPtr)LookupIDByType(wColormap(pWin), RT_COLORMAP);
       mask |= CWColormap;
@@ -3138,11 +3197,15 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
     Atom prop = MakeAtom("NX_REAL_WINDOW", strlen("NX_REAL_WINDOW"), True);
 
     if (ChangeWindowProperty(pWin, prop, XA_WINDOW, 32, PropModeReplace, 1, nxagentWindowPriv(pWin), 1) != Success)
-        fprintf(stderr, "nxagentReconnectWindow: Updating NX_REAL_WINDOW failed.\n");
-#ifdef DEBUG
+    {
+      fprintf(stderr, "nxagentReconnectWindow: Updating NX_REAL_WINDOW failed.\n");
+    }
+    #ifdef DEBUG
     else
-        fprintf(stderr, "nxagentReconnectWindow: Updated NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
-#endif
+    {
+      fprintf(stderr, "nxagentReconnectWindow: Updated NX_REAL_WINDOW for Window ID [%x].\n", nxagentWindowPriv(pWin)->window);
+    }
+    #endif
   }
 
   if (nxagentDrawableStatus((DrawablePtr) pWin) == NotSynchronized)
@@ -3159,7 +3222,9 @@ static void nxagentReconfigureWindowCursor(void * param0, XID param1, void * dat
   ScreenPtr   pScreen;
 
   if (!pWin || !*pBool || !(pCursor = wCursor(pWin)))
+  {
     return;
+  }
 
   pScreen = pWin -> drawable.pScreen;
 
@@ -3216,16 +3281,19 @@ static void nxagentReconfigureWindow(void * param0, XID param1, void * data_buff
   #endif
 
   if (pWin -> drawable.class == InputOnly)
+  {
     mask = CWWinGravity | CWEventMask | CWDontPropagate | CWOverrideRedirect | CWCursor;
+  }
   else
+  {
     mask = CWBackPixmap | CWBackPixel | CWBorderPixmap | CWBorderPixel |
          CWBitGravity | CWWinGravity | CWBackingStore | CWBackingPlanes |
          CWBackingPixel | CWOverrideRedirect | CWSaveUnder | CWEventMask |
          CWDontPropagate | CWColormap | CWCursor;
-
+  }
   nxagentChangeWindowAttributes(pWin, mask);
 
-#ifdef SHAPE
+  #ifdef SHAPE
   if (nxagentWindowPriv(pWin) -> boundingShape)
   {
     RegionDestroy(
@@ -3240,7 +3308,7 @@ static void nxagentReconfigureWindow(void * param0, XID param1, void * data_buff
     nxagentWindowPriv(pWin) -> clipShape = NULL;
   }
   nxagentShapeWindow(pWin);
-#endif
+  #endif
 
   if (pWin != screenInfo.screens[0]->root)
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -306,9 +306,9 @@ Bool nxagentCreateWindow(WindowPtr pWin)
                 (void*)pWin, attributes.backing_store);
     #endif
 
-/*
-FIXME: We need to set save under on the real display?
-*/
+    /*
+      FIXME: We need to set save under on the real display?
+    */
     if (nxagentSaveUnder)
       {
         mask |= CWSaveUnder;
@@ -461,10 +461,10 @@ FIXME: We need to set save under on the real display?
      * memory, if the composite extension is
      * supported on the display.
      */
-/*
-FIXME: Do all the windows for which nxagentWindowTopLevel(pWin)
-       returns true need to be redirected?
-*/
+    /*
+      FIXME: Do all the windows for which nxagentWindowTopLevel(pWin)
+             returns true need to be redirected?
+    */
     nxagentRedirectWindow(pWin);
   }
 
@@ -1753,10 +1753,10 @@ Bool nxagentChangeWindowAttributes(WindowPtr pWin, unsigned long mask)
     attributes.win_gravity = pWin -> winGravity;
   }
 
-/*
-FIXME: Do we need to set the attribute on the
-       remote display?
-*/
+  /*
+    FIXME: Do we need to set the attribute on the
+           remote display?
+  */
   if (mask & CWBackingStore)
   {
     attributes.backing_store = pWin -> backingStore;
@@ -1796,10 +1796,10 @@ FIXME: Do we need to set the attribute on the
     attributes.override_redirect = pWin -> overrideRedirect;
   }
 
-/*
-FIXME: Do we need to set the attribute on the
-       remote display?
-*/
+  /*
+    FIXME: Do we need to set the attribute on the
+           remote display?
+  */
   if (mask & CWSaveUnder)
   {
     attributes.save_under = pWin -> saveUnder;
@@ -1825,11 +1825,11 @@ FIXME: Do we need to set the attribute on the
 
     pCmap = (ColormapPtr) LookupIDByType(wColormap(pWin), RT_COLORMAP);
 
-/*
-FIXME: When the caller is nxagentReconfigureWindow
-       sometimes wColormap(pWin) is 0. Could a window
-       have no colormap?
-*/
+    /*
+      FIXME: When the caller is nxagentReconfigureWindow
+             sometimes wColormap(pWin) is 0. Could a window
+             have no colormap?
+    */
     if (pCmap != NULL)
     {
       attributes.colormap = nxagentColormap(pCmap);
@@ -2647,7 +2647,7 @@ Bool nxagentDisconnectAllWindows(void)
 /*
  * FIXME: We are giving up reconnecting those void *
  * that are not resource, and we are just disconnecting them.
- * perhaps we could do better and reconnect them.
+ * Perhaps we could do better and reconnect them.
  */
 
 void nxagentDisconnectWindow(void * p0, XID x1, void * p2)
@@ -2921,9 +2921,9 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
       attributes.backing_pixel = pWin->optional->backingPixel;
     }
 
-/*
-FIXME: Do we need to set save unders attribute here?
-*/
+    /*
+      FIXME: Do we need to set save unders attribute here?
+    */
     if (nxagentSaveUnder)
     {
       mask |= CWSaveUnder;
@@ -3528,11 +3528,11 @@ void nxagentFlushConfigureWindow(void)
 
 void nxagentPostValidateTree(WindowPtr pParent, WindowPtr pChild, VTKind kind)
 {
-/*
-FIXME: Do we need this here?
+  /*
+    FIXME: Do we need this here?
 
   nxagentFlushConfigureWindow();
-*/
+  */
 
   return;
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -232,13 +232,12 @@ static int nxagentFindWindowMatch(WindowPtr pWin, void * ptr)
 
 WindowPtr nxagentWindowPtr(Window window)
 {
-  int i;
   WindowMatchRec match;
 
   match.pWin = NullWindow;
   match.id   = window;
 
-  for (i = 0; i < nxagentNumScreens; i++)
+  for (int i = 0; i < nxagentNumScreens; i++)
   {
     WalkTree(screenInfo.screens[i], nxagentFindWindowMatch, (void *) &match);
 
@@ -559,8 +558,6 @@ Bool nxagentSomeWindowsAreMapped(void)
 
 Bool nxagentDestroyWindow(WindowPtr pWin)
 {
-  int j;
-
   nxagentPrivWindowPtr pWindowPriv;
 
   if (nxagentScreenTrap == 1)
@@ -570,7 +567,7 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
 
   nxagentClearClipboard(NULL, pWin);
 
-  for (j = 0; j < nxagentExposeQueue.length; j++)
+  for (int j = 0; j < nxagentExposeQueue.length; j++)
   {
     int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
@@ -1234,7 +1231,6 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
 {
   unsigned int valuemask;
   XWindowChanges values;
-  int j;
   int offX = nxagentWindowPriv(pWin)->x - pWin->origin.x;
   int offY = nxagentWindowPriv(pWin)->y - pWin->origin.y;
 
@@ -1333,7 +1329,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
 
       nxagentAddStaticResizedWindow(pWin, XNextRequest(nxagentDisplay), offX, offY);
 
-      for (j = 0; j < nxagentExposeQueue.length; j++)
+      for (int j = 0; j < nxagentExposeQueue.length; j++)
       {
         int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
@@ -1966,10 +1962,9 @@ void nxagentPaintWindowBackground(WindowPtr pWin, RegionPtr pRegion, int what)
 
   if (pWin -> realized)
   {
-    int i;
     BoxPtr pBox = RegionRects(pRegion);
 
-    for (i = 0; i < RegionNumRects(pRegion); i++)
+    for (int i = 0; i < RegionNumRects(pRegion); i++)
     {
       XClearArea(nxagentDisplay, nxagentWindow(pWin),
                  pBox[i].x1 - pWin->drawable.x,
@@ -2082,13 +2077,11 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
   {
     if (nxagentExposeArrayIsInitialized == 0)
     {
-      int i;
-
       #ifdef TEST
       fprintf(stderr, "nxagentWindowExposures: Initializing expose queue.\n");
       #endif
 
-      for (i = 0; i < EXPOSED_SIZE; i++)
+      for (int i = 0; i < EXPOSED_SIZE; i++)
       {
         nxagentExposeQueue.exposures[i].pWindow = NULL;
         nxagentExposeQueue.exposures[i].localRegion = NullRegion;
@@ -2271,7 +2264,6 @@ void nxagentShapeWindow(WindowPtr pWin)
   Region reg;
   BoxPtr pBox;
   XRectangle rect;
-  int i;
 
   if (NXDisplayError(nxagentDisplay) == 1)
   {
@@ -2308,7 +2300,7 @@ void nxagentShapeWindow(WindowPtr pWin)
 
       reg = XCreateRegion();
       pBox = RegionRects(nxagentWindowPriv(pWin)->boundingShape);
-      for (i = 0;
+      for (int i = 0;
            i < RegionNumRects(nxagentWindowPriv(pWin)->boundingShape);
            i++)
       {
@@ -2365,7 +2357,7 @@ void nxagentShapeWindow(WindowPtr pWin)
 
       reg = XCreateRegion();
       pBox = RegionRects(nxagentWindowPriv(pWin)->clipShape);
-      for (i = 0;
+      for (int i = 0;
            i < RegionNumRects(nxagentWindowPriv(pWin)->clipShape);
            i++)
       {
@@ -2438,9 +2430,7 @@ void nxagentUnmapWindows(void)
 {
   if (nxagentOption(Fullscreen) == 1)
   {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++)
+    for (int i = 0; i < screenInfo.numScreens; i++)
     {
       if (nxagentDefaultWindows[i])
       {
@@ -2454,9 +2444,7 @@ void nxagentUnmapWindows(void)
 
 void nxagentMapDefaultWindows(void)
 {
-  int i;
-
-  for (i = 0; i < screenInfo.numScreens; i++)
+  for (int i = 0; i < screenInfo.numScreens; i++)
   {
     WindowPtr pWin = screenInfo.screens[i]->root;
     ScreenPtr pScreen = pWin -> drawable.pScreen;
@@ -2563,13 +2551,12 @@ void nxagentMapDefaultWindows(void)
 Bool nxagentDisconnectAllWindows(void)
 {
   Bool succeeded = True;
-  int i;
 
   #if defined(NXAGENT_RECONNECT_DEBUG) || defined(NXAGENT_RECONNECT_WINDOW_DEBUG)
   fprintf(stderr, "nxagentDisconnectAllWindows\n");
   #endif
 
-  for (i = 0; i < screenInfo.numScreens; i++)
+  for (int i = 0; i < screenInfo.numScreens; i++)
   {
     WindowPtr pWin = screenInfo.screens[i]->root;
     nxagentTraverseWindow( pWin, nxagentDisconnectWindow, &succeeded);
@@ -2709,9 +2696,7 @@ Bool nxagentReconnectAllWindows(void *p0)
 
   if (nxagentOption(Rootless) == 0)
   {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++)
+    for (int i = 0; i < screenInfo.numScreens; i++)
     {
       XRaiseWindow(nxagentDisplay, nxagentInputWindows[i]);
     }
@@ -2817,10 +2802,9 @@ static void nxagentTraverseWindow(
 
 static Bool nxagentLoopOverWindows(void (*pF)(void *, XID, void *))
 {
-  int i;
   Bool windowSuccess = True;
 
-  for (i = 0; i < screenInfo.numScreens; i++)
+  for (int i = 0; i < screenInfo.numScreens; i++)
   {
     nxagentTraverseWindow(screenInfo.screens[i]->root, pF, &windowSuccess);
   }
@@ -3004,7 +2988,6 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
       unsigned char *data = NULL;
       #ifdef _XSERVER64
       unsigned char *data64 = NULL;
-      unsigned int i;
       #endif
 
       ret = GetWindowProperty(pWin,
@@ -3032,14 +3015,14 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
         #ifdef _XSERVER64
         data64 = (unsigned char *) malloc(sizeof(XSizeHints) + 4);
 
-        for (i = 0; i < 4; i++)
+        for (int i = 0; i < 4; i++)
         {
           *(data64 + i) = *(data + i);
         }
 
         *(((int *) data64) + 1) = 0;
 
-        for (i = 8; i < sizeof(XSizeHints) + 4; i++)
+        for (int i = 8; i < sizeof(XSizeHints) + 4; i++)
         {
           *(data64 + i) = *(data + i - 4);
         }
@@ -3276,15 +3259,12 @@ Bool nxagentCheckWindowIntegrity(WindowPtr pWin)
 
      if (image && memcmp(image->data, data, length) != 0)
      {
-       #ifdef TEST
-       int i;
-       char *p, *q;
-       #endif
-
        integrity = False;
 
        #ifdef TEST
-       for (i = 0, p = image->data, q = data; i < length; i++)
+       char *p = image->data, *q = data;
+
+       for (int i = 0; i < length; i++)
        {
          if (p[i] != q[i])
          {
@@ -3395,7 +3375,6 @@ void nxagentFlushConfigureWindow(void)
 {
   ConfiguredWindowStruct *index;
   XWindowChanges changes;
-  int j;
 
   index = nxagentConfiguredWindowList;
 
@@ -3434,7 +3413,7 @@ void nxagentFlushConfigureWindow(void)
 
   nxagentConfiguredWindowList = NULL;
 
-  for (j = 0; j < nxagentExposeQueue.length; j++)
+  for (int j = 0; j < nxagentExposeQueue.length; j++)
   {
     int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
@@ -3729,9 +3708,7 @@ void nxagentInitBSPixmapList(void)
 
 int nxagentAddItemBSPixmapList(unsigned long id, PixmapPtr pPixmap, WindowPtr pWin, int bsx, int bsy)
 {
-  int i;
-
-  for (i = 0; i < BSPIXMAPLIMIT; i++)
+  for (int i = 0; i < BSPIXMAPLIMIT; i++)
   {
     if (nxagentBSPixmapList[i] == NULL)
     {
@@ -3779,14 +3756,12 @@ int nxagentAddItemBSPixmapList(unsigned long id, PixmapPtr pPixmap, WindowPtr pW
 
 int nxagentRemoveItemBSPixmapList(unsigned long pixmapId)
 {
-  int i;
-
   if (pixmapId == 0 || nxagentBSPixmapList[0] == NULL)
   {
     return 0;
   }
 
-  for (i = 0; i < BSPIXMAPLIMIT; i++)
+  for (int i = 0; i < BSPIXMAPLIMIT; i++)
   {
     if ((nxagentBSPixmapList[i] != NULL) &&
             (nxagentBSPixmapList[i] -> storingPixmapId == pixmapId))
@@ -3828,9 +3803,7 @@ int nxagentRemoveItemBSPixmapList(unsigned long pixmapId)
 
 int nxagentEmptyBSPixmapList(void)
 {
-  int i;
-
-  for (i = 0; i < BSPIXMAPLIMIT; i++)
+  for (int i = 0; i < BSPIXMAPLIMIT; i++)
   {
     free(nxagentBSPixmapList[i]);
     nxagentBSPixmapList[i] = NULL;

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -587,7 +587,6 @@ Bool nxagentSomeWindowsAreMapped(void)
 
 Bool nxagentDestroyWindow(WindowPtr pWin)
 {
-  int i;
   int j;
 
   nxagentPrivWindowPtr pWindowPriv;
@@ -601,7 +600,7 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
 
   for (j = 0; j < nxagentExposeQueue.length; j++)
   {
-    i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
+    int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
     if (nxagentExposeQueue.exposures[i].pWindow == pWin)
     {
@@ -1295,7 +1294,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
   unsigned int valuemask;
   XWindowChanges values;
   int offX, offY;
-  int i, j;
+  int j;
 
   offX = nxagentWindowPriv(pWin)->x - pWin->origin.x;
   offY = nxagentWindowPriv(pWin)->y - pWin->origin.y;
@@ -1397,7 +1396,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
 
       for (j = 0; j < nxagentExposeQueue.length; j++)
       {
-        i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
+        int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
         if (nxagentExposeQueue.exposures[i].pWindow == pWin &&
                 nxagentExposeQueue.exposures[i].remoteRegion != NullRegion)
@@ -2034,15 +2033,12 @@ void nxagentFrameBufferPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what)
 
 void nxagentPaintWindowBackground(WindowPtr pWin, RegionPtr pRegion, int what)
 {
-  int i;
-
   RegionRec temp;
 
   if (pWin -> realized)
   {
-    BoxPtr pBox;
-
-    pBox = RegionRects(pRegion);
+    int i;
+    BoxPtr pBox = RegionRects(pRegion);
 
     for (i = 0; i < RegionNumRects(pRegion); i++)
     {
@@ -2229,9 +2225,7 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
 
       if (nxagentExposeQueue.length < EXPOSED_SIZE)
       {
-        int index;
-
-        index = (nxagentExposeQueue.start + nxagentExposeQueue.length) % EXPOSED_SIZE;
+        int index = (nxagentExposeQueue.start + nxagentExposeQueue.length) % EXPOSED_SIZE;
 
         nxagentExposeQueue.exposures[index].pWindow = pWin;
 
@@ -2503,12 +2497,12 @@ void nxagentShapeWindow(WindowPtr pWin)
 
 static int nxagentForceExposure(WindowPtr pWin, void * ptr)
 {
-  RegionPtr exposedRgn;
-  BoxRec Box;
-  WindowPtr pRoot = pWin->drawable.pScreen->root;
-
   if (pWin -> drawable.class != InputOnly)
   {
+    BoxRec Box;
+    RegionPtr exposedRgn;
+    WindowPtr pRoot = pWin->drawable.pScreen->root;
+
     Box.x1 = pWin->drawable.x;
     Box.y1 = pWin->drawable.y;
     Box.x2 = Box.x1 + pWin->drawable.width;
@@ -2537,10 +2531,10 @@ void nxagentRefreshWindows(WindowPtr pWin)
 
 void nxagentUnmapWindows(void)
 {
-  int i;
-
   if (nxagentOption(Fullscreen) == 1)
   {
+    int i;
+
     for (i = 0; i < screenInfo.numScreens; i++)
     {
       if (nxagentDefaultWindows[i])
@@ -2666,7 +2660,6 @@ Bool nxagentDisconnectAllWindows(void)
 {
   Bool succeeded = True;
   int i;
-  WindowPtr pWin;
 
   #if defined(NXAGENT_RECONNECT_DEBUG) || defined(NXAGENT_RECONNECT_WINDOW_DEBUG)
   fprintf(stderr, "nxagentDisconnectAllWindows\n");
@@ -2674,7 +2667,7 @@ Bool nxagentDisconnectAllWindows(void)
 
   for (i = 0; i < screenInfo.numScreens; i++)
   {
-    pWin = screenInfo.screens[i]->root;
+    WindowPtr pWin = screenInfo.screens[i]->root;
     nxagentTraverseWindow( pWin, nxagentDisconnectWindow, &succeeded);
     nxagentDefaultWindows[i] = None;
   }
@@ -2924,12 +2917,10 @@ static Bool nxagentLoopOverWindows(void (*pF)(void *, XID, void *))
 {
   int i;
   Bool windowSuccess = True;
-  WindowPtr pWin;
 
   for (i = 0; i < screenInfo.numScreens; i++)
   {
-    pWin = screenInfo.screens[i]->root;
-    nxagentTraverseWindow(pWin, pF, &windowSuccess);
+    nxagentTraverseWindow(screenInfo.screens[i]->root, pF, &windowSuccess);
   }
 
   return windowSuccess;
@@ -3110,17 +3101,14 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
       Atom type;
       int format;
       unsigned long nItems, bytesLeft;
-      XSizeHints *props, hints;
+      XSizeHints hints = {0};
       unsigned char *data = NULL;
-
       #ifdef _XSERVER64
 
       unsigned char *data64 = NULL;
       unsigned int i;
 
       #endif
-
-      hints.flags = 0;
 
       ret = GetWindowProperty(pWin,
                                   XA_WM_NORMAL_HINTS,
@@ -3138,13 +3126,13 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
                   bytesLeft == 0 &&
                       type == XA_WM_SIZE_HINTS)
       {
+        XSizeHints *props;
         #ifdef TEST
         fprintf(stderr, "nxagentReconnectWindow: setting WMSizeHints on window %p [%lx - %lx].\n",
                     (void*)pWin, pWin -> drawable.id, nxagentWindow(pWin));
         #endif
 
         #ifdef _XSERVER64
-
         data64 = (unsigned char *) malloc(sizeof(XSizeHints) + 4);
 
         for (i = 0; i < 4; i++)
@@ -3527,7 +3515,6 @@ void nxagentFlushConfigureWindow(void)
 {
   ConfiguredWindowStruct *index;
   XWindowChanges changes;
-  int i;
   int j;
 
   index = nxagentConfiguredWindowList;
@@ -3544,8 +3531,6 @@ void nxagentFlushConfigureWindow(void)
 
   while (index)
   {
-    ConfiguredWindowStruct *tmp;
-
     WindowPtr pWin = index -> pWin;
     unsigned int valuemask = index -> valuemask;
 
@@ -3554,23 +3539,24 @@ void nxagentFlushConfigureWindow(void)
       nxagentConfigureWindow(pWin, valuemask);
     }
 
-    tmp = index;
-
     if (index == nxagentConfiguredWindowList)
     {
-      free(tmp);
+      free(index);
       break;
     }
-
-    index = index -> prev;
-    free(tmp);
-  }
+    else
+    {
+      ConfiguredWindowStruct *tmp = index;
+      index = index -> prev;
+      free(tmp);
+    }
+}
 
   nxagentConfiguredWindowList = NULL;
 
   for (j = 0; j < nxagentExposeQueue.length; j++)
   {
-    i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
+    int i = (nxagentExposeQueue.start + j) % EXPOSED_SIZE;
 
     if (nxagentExposeQueue.exposures[i].synchronize == 1)
     {
@@ -3929,7 +3915,6 @@ int nxagentAddItemBSPixmapList(unsigned long id, PixmapPtr pPixmap, WindowPtr pW
 int nxagentRemoveItemBSPixmapList(unsigned long pixmapId)
 {
   int i;
-  int j;
 
   if (pixmapId == 0 || nxagentBSPixmapList[0] == NULL)
   {
@@ -3946,6 +3931,8 @@ int nxagentRemoveItemBSPixmapList(unsigned long pixmapId)
 
       if (i < BSPIXMAPLIMIT - 1)
       {
+        int j;
+
         for (j = i; j < BSPIXMAPLIMIT -1; j++)
         {
           nxagentBSPixmapList[j] = nxagentBSPixmapList[j + 1];

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -269,9 +269,9 @@ Bool nxagentCreateWindow(WindowPtr pWin)
   {
       nxagentClearSplash(nxagentRootTileWindow);
   }
-#ifdef NXAGENT_LOGO_DEBUG
+  #ifdef NXAGENT_LOGO_DEBUG
   fprintf(stderr, "nxagentCreateWindow: nxagentSplashCount [%d]\n", nxagentSplashCount);
-#endif
+  #endif
 
   if (pWin->drawable.class == InputOnly)
   {
@@ -495,17 +495,15 @@ Bool nxagentCreateWindow(WindowPtr pWin)
     nxagentWindowPriv(pWin->nextSib)->siblingAbove = nxagentWindow(pWin);
   }
 
-#ifdef NXAGENT_SHAPE2
-#ifdef SHAPE
-  nxagentWindowPriv(pWin)->boundingShape = NULL;
-  nxagentWindowPriv(pWin)->clipShape = NULL;
-#endif /* SHAPE */
-#else
-#ifdef SHAPE
-  nxagentWindowPriv(pWin)->boundingShape = RegionCreate(NULL, 1);
-  nxagentWindowPriv(pWin)->clipShape = RegionCreate(NULL, 1);
-#endif /* SHAPE */
-#endif
+  #ifdef SHAPE
+    #ifdef NXAGENT_SHAPE2
+      nxagentWindowPriv(pWin)->boundingShape = NULL;
+      nxagentWindowPriv(pWin)->clipShape = NULL;
+    #else
+      nxagentWindowPriv(pWin)->boundingShape = RegionCreate(NULL, 1);
+      nxagentWindowPriv(pWin)->clipShape = RegionCreate(NULL, 1);
+    #endif
+  #endif /* SHAPE */
 
   fbCreateWindow(pWin);
 
@@ -604,22 +602,22 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
            pWindowPriv->siblingAbove;
   }
 
-#ifdef NXAGENT_SHAPE2
-  #ifdef SHAPE
-  if (pWindowPriv->boundingShape)
-  {
-    RegionDestroy(pWindowPriv->boundingShape);
-  }
+  #ifdef NXAGENT_SHAPE2
+    #ifdef SHAPE
+    if (pWindowPriv->boundingShape)
+    {
+      RegionDestroy(pWindowPriv->boundingShape);
+    }
 
-  if (pWindowPriv->clipShape)
-  {
+    if (pWindowPriv->clipShape)
+    {
+      RegionDestroy(pWindowPriv->clipShape);
+    }
+    #endif
+  #else
+    RegionDestroy(pWindowPriv->boundingShape);
     RegionDestroy(pWindowPriv->clipShape);
-  }
   #endif
-#else
-  RegionDestroy(pWindowPriv->boundingShape);
-  RegionDestroy(pWindowPriv->clipShape);
-#endif
 
   if (pWindowPriv -> corruptedRegion)
   {
@@ -2031,13 +2029,13 @@ void nxagentClipNotify(WindowPtr pWin, int dx, int dy)
   nxagentAddConfiguredWindow(pWin, CWStackingOrder);
   nxagentAddConfiguredWindow(pWin, CW_Shape);
 
-#ifndef NXAGENT_SHAPE
-  #ifdef SHAPE
- /*
- * nxagentShapeWindow(pWin);
- */
- #endif /* SHAPE */
-#endif /* NXAGENT_SHAPE */
+  #ifndef NXAGENT_SHAPE
+    #ifdef SHAPE
+    /*
+     * nxagentShapeWindow(pWin);
+     */
+    #endif /* SHAPE */
+  #endif /* NXAGENT_SHAPE */
 }
 
 void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_exposed)
@@ -2299,12 +2297,12 @@ void nxagentShapeWindow(WindowPtr pWin)
                   RegionNumRects(wBoundingShape(pWin)));
       #endif
 
-#ifdef NXAGENT_SHAPE2
+      #ifdef NXAGENT_SHAPE2
       if (!nxagentWindowPriv(pWin)->boundingShape)
       {
         nxagentWindowPriv(pWin)->boundingShape = RegionCreate(NULL, 1);
       }
-#endif
+      #endif
 
       RegionCopy(nxagentWindowPriv(pWin)->boundingShape, wBoundingShape(pWin));
 
@@ -2321,10 +2319,10 @@ void nxagentShapeWindow(WindowPtr pWin)
         XUnionRectWithRegion(&rect, reg, reg);
       }
 
-#ifndef NXAGENT_SHAPE
+      #ifndef NXAGENT_SHAPE
       XShapeCombineRegion(nxagentDisplay, nxagentWindow(pWin),
                               ShapeBounding, 0, 0, reg, ShapeSet);
-#endif
+      #endif
 
       XDestroyRegion(reg);
     }
@@ -2336,11 +2334,10 @@ void nxagentShapeWindow(WindowPtr pWin)
 
       RegionEmpty(nxagentWindowPriv(pWin)->boundingShape);
 
-#ifndef NXAGENT_SHAPE
+      #ifndef NXAGENT_SHAPE
       XShapeCombineMask(nxagentDisplay, nxagentWindow(pWin),
                             ShapeBounding, 0, 0, None, ShapeSet);
-#endif
-
+      #endif
     }
   }
 
@@ -2357,12 +2354,12 @@ void nxagentShapeWindow(WindowPtr pWin)
                   RegionNumRects(wClipShape(pWin)));
       #endif
 
-#ifdef NXAGENT_SHAPE2
+      #ifdef NXAGENT_SHAPE2
       if (!nxagentWindowPriv(pWin)->clipShape)
       {
         nxagentWindowPriv(pWin)->clipShape = RegionCreate(NULL, 1);
       }
-#endif
+      #endif
 
       RegionCopy(nxagentWindowPriv(pWin)->clipShape, wClipShape(pWin));
 
@@ -2379,10 +2376,10 @@ void nxagentShapeWindow(WindowPtr pWin)
         XUnionRectWithRegion(&rect, reg, reg);
       }
 
-#ifndef NXAGENT_SHAPE
+      #ifndef NXAGENT_SHAPE
       XShapeCombineRegion(nxagentDisplay, nxagentWindow(pWin),
                               ShapeClip, 0, 0, reg, ShapeSet);
-#endif
+      #endif
 
       XDestroyRegion(reg);
     }
@@ -2394,10 +2391,10 @@ void nxagentShapeWindow(WindowPtr pWin)
 
       RegionEmpty(nxagentWindowPriv(pWin)->clipShape);
 
-#ifndef NXAGENT_SHAPE
+      #ifndef NXAGENT_SHAPE
       XShapeCombineMask(nxagentDisplay, nxagentWindow(pWin),
                             ShapeClip, 0, 0, None, ShapeSet);
-#endif
+      #endif
     }
   }
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -129,7 +129,7 @@ int nxagentSplashCount = 0;
 
 Bool nxagentExposeArrayIsInitialized = False;
 Window nxagentConfiguredSynchroWindow;
-static int nxagentExposeSerial = 0; 
+static int nxagentExposeSerial = 0;
 
 StoringPixmapPtr nxagentBSPixmapList[BSPIXMAPLIMIT];
 
@@ -142,13 +142,10 @@ typedef struct _WindowMatch
 {
   WindowPtr pWin;
   Window    id;
-
 } WindowMatchRec;
 
 Bool nxagentReconnectAllWindows(void *);
-
 Bool nxagentDisconnectAllWindows(void);
-
 Bool nxagentIsIconic(WindowPtr);
 
 /*
@@ -169,21 +166,13 @@ void nxagentClearSplash(WindowPtr pWin);
  */
 
 static Bool nxagentSomeWindowsAreMapped(void);
-
 static void nxagentFrameBufferPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what);
-
 static void nxagentTraverseWindow(WindowPtr, void(*)(void *, XID, void *), void *);
-
 static void nxagentDisconnectWindow(void *, XID, void *);
-
 static Bool nxagentLoopOverWindows(void(*)(void *, XID, void *));
-
 static void nxagentReconfigureWindowCursor(void *, XID, void *);
-
 static void nxagentReconnectWindow(void *, XID, void *);
-
 static void nxagentReconfigureWindow(void *, XID, void *);
-
 static int nxagentForceExposure(WindowPtr pWin, void * ptr);
 
 /* by dimbor */
@@ -199,9 +188,7 @@ nxagentWMStateRec;
  */
 
 #ifdef TEST
-
 static Bool nxagentCheckWindowIntegrity(WindowPtr pWin);
-
 #endif
 
 WindowPtr nxagentGetWindowFromID(Window id)
@@ -235,7 +222,6 @@ static int nxagentFindWindowMatch(WindowPtr pWin, void * ptr)
   if (match -> id == nxagentWindow(pWin))
   {
     match -> pWin = pWin;
-
     return WT_STOPWALKING;
   }
   else
@@ -247,7 +233,6 @@ static int nxagentFindWindowMatch(WindowPtr pWin, void * ptr)
 WindowPtr nxagentWindowPtr(Window window)
 {
   int i;
-
   WindowMatchRec match;
 
   match.pWin = NullWindow;
@@ -406,23 +391,14 @@ Bool nxagentCreateWindow(WindowPtr pWin)
 
   nxagentWindowPriv(pWin) -> isMapped = 0;
   nxagentWindowPriv(pWin) -> isRedirected = 0;
-
   nxagentWindowPriv(pWin) -> visibilityState = VisibilityUnobscured;
-
   nxagentWindowPriv(pWin) -> corruptedRegion = RegionCreate(NULL, 1);
-
   nxagentWindowPriv(pWin) -> hasTransparentChildren = 0;
-
   nxagentWindowPriv(pWin) -> containGlyphs = 0;
-
   nxagentWindowPriv(pWin) -> corruptedId = 0;
-
   nxagentWindowPriv(pWin) -> deferredBackgroundExpose = 0;
-
   nxagentWindowPriv(pWin) -> synchronizationBitmap = NullPixmap;
-
   nxagentWindowPriv(pWin) -> corruptedTimestamp = 0;
-
   nxagentWindowPriv(pWin) -> splitResource = NULL;
 
   if (nxagentOption(Rootless) == 1)
@@ -464,7 +440,6 @@ Bool nxagentCreateWindow(WindowPtr pWin)
   if (nxagentOption(Rootless) && nxagentWindowTopLevel(pWin))
   {
     Atom prop = nxagentMakeAtom("WM_PROTOCOLS", strlen("WM_PROTOCOLS"), True);
-
     XlibAtom atom = nxagentMakeAtom("WM_DELETE_WINDOW", strlen("WM_DELETE_WINDOW"), True);
 
     XSetWMProtocols(nxagentDisplay, nxagentWindowPriv(pWin)->window, &atom, 1);
@@ -552,7 +527,6 @@ Bool nxagentCreateWindow(WindowPtr pWin)
 void nxagentSetVersionProperty(WindowPtr pWin)
 {
   char *name = "NX_AGENT_VERSION";
-
   Atom prop = MakeAtom(name, strlen(name), True);
 
   if (ChangeWindowProperty(pWin, prop, XA_STRING, 8, PropModeReplace, strlen(NX_VERSION_CURRENT_STRING), NX_VERSION_CURRENT_STRING, True) != Success)
@@ -630,39 +604,26 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
            pWindowPriv->siblingAbove;
   }
 
-  #ifdef NXAGENT_SHAPE2
-
+#ifdef NXAGENT_SHAPE2
   #ifdef SHAPE
-
   if (pWindowPriv->boundingShape)
   {
-    RegionDestroy(
-                       pWindowPriv->boundingShape);
+    RegionDestroy(pWindowPriv->boundingShape);
   }
 
   if (pWindowPriv->clipShape)
   {
-    RegionDestroy(
-                       pWindowPriv->clipShape);
+    RegionDestroy(pWindowPriv->clipShape);
   }
-
   #endif
-
-  #else
-
-  RegionDestroy(
-                     pWindowPriv->boundingShape);
-
-  RegionDestroy(
-                     pWindowPriv->clipShape);
-
-  #endif
+#else
+  RegionDestroy(pWindowPriv->boundingShape);
+  RegionDestroy(pWindowPriv->clipShape);
+#endif
 
   if (pWindowPriv -> corruptedRegion)
   {
-    RegionDestroy(
-                       pWindowPriv -> corruptedRegion);
-
+    RegionDestroy(pWindowPriv -> corruptedRegion);
     pWindowPriv -> corruptedRegion = NULL;
   }
 
@@ -677,7 +638,6 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
   }
 
   nxagentDestroyCorruptedResource((DrawablePtr) pWin, RT_NX_CORR_WINDOW);
-
   nxagentDestroyDrawableBitmap((DrawablePtr) pWin);
 
   if (pWindowPriv -> splitResource != NULL)
@@ -707,7 +667,6 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
   if (pWin == nxagentRootTileWindow)
   {
     nxagentWindowPriv(nxagentRootTileWindow)->window = None;
-
     nxagentRootTileWindow = None;
   }
 
@@ -758,7 +717,6 @@ void nxagentRestackWindow(WindowPtr pWin, WindowPtr pOldNextSib)
   }
 
   nxagentAddConfiguredWindow(pWin, CW_RootlessRestack);
-
 }
 
 void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
@@ -817,15 +775,13 @@ void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
   if (switchOn)
   {
     nxagentFullscreenWindow = nxagentDefaultWindows[pScreen -> myNum];
-
     nxagentGrabPointerAndKeyboard(NULL);
   }
   else
   {
     nxagentFullscreenWindow = None;
-
     nxagentUngrabPointerAndKeyboard(NULL);
-  } 
+  }
 }
 
 void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
@@ -907,7 +863,6 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
       nxagentChangeOption(Fullscreen, True);
       nxagentChangeOption(AllScreens, True);
-      
 
       /*
        * Save the window-mode configuration.
@@ -956,7 +911,6 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
       if (nxagentIconWindow == None)
       {
         nxagentIconWindow = nxagentCreateIconWindow();
-
         XMapWindow(nxagentDisplay, nxagentIconWindow);
       }
 
@@ -988,7 +942,7 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
       #ifdef WARNING
       fprintf(stderr, "nxagentSwitchAllScreens: WARNING! Expected ReparentNotify event missing.\n");
       #endif
- 
+
       nxagentWMIsRunning = False;
       attributes.override_redirect = False;
       XChangeWindowAttributes(nxagentDisplay, w, valuemask, &attributes);
@@ -1030,10 +984,8 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
     if (nxagentOption(WMBorderWidth) > 0 && nxagentOption(WMTitleHeight) > 0)
     {
-      nxagentChangeOption(X, nxagentOption(SavedX) -
-                              nxagentOption(WMBorderWidth));
-      nxagentChangeOption(Y, nxagentOption(SavedY) -
-                              nxagentOption(WMTitleHeight));
+      nxagentChangeOption(X, nxagentOption(SavedX) - nxagentOption(WMBorderWidth));
+      nxagentChangeOption(Y, nxagentOption(SavedY) - nxagentOption(WMTitleHeight));
     }
     else
     {
@@ -1064,7 +1016,7 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
   XMoveResizeWindow(nxagentDisplay, nxagentInputWindows[0], 0, 0,
                         nxagentOption(Width), nxagentOption(Height));
 
-  nxagentSetPrintGeometry(pScreen -> myNum); 
+  nxagentSetPrintGeometry(pScreen -> myNum);
 }
 
 #ifdef VIEWPORT_FRAME
@@ -1141,7 +1093,6 @@ void nxagentMoveViewport(ScreenPtr pScreen, int hShift, int vShift)
   #endif
 
   nxagentChangeOption(ViewportXSpan, nxagentOption(Width) - nxagentOption(RootWidth));
-
   nxagentChangeOption(ViewportYSpan, nxagentOption(Height) - nxagentOption(RootHeight));
 
   if (nxagentOption(ViewportXSpan) < 0)
@@ -1224,7 +1175,7 @@ void nxagentMoveViewport(ScreenPtr pScreen, int hShift, int vShift)
 
     if (nxagentOption(ClientOs) == ClientOsWinnt)
     {
-      /* 
+      /*
        * If doMove is True we add exposed rectangles
        * to the remote expose region. This is done to
        * refresh the areas showed newly in the viewport.
@@ -1505,7 +1456,6 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
   }
 
   #ifdef NXAGENT_SPLASH
-
   /*
    * This should bring again the splash window
    * on top, so why the else clause? Is this
@@ -1531,8 +1481,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
    *    }
    *  }
    */
-
-  #endif
+  #endif /* NXAGENT_SPLASH */
 
   if (mask & CW_RootlessRestack)
   {
@@ -1571,12 +1520,10 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
   }
 
   #ifdef SHAPE
-
   if (mask & CW_Shape)
   {
     nxagentShapeWindow(pWin);
   }
-
   #endif
 
   if (mask & CW_Map &&
@@ -1584,7 +1531,6 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
              nxagentRootlessWindow != pWin))
   {
     XMapWindow(nxagentDisplay, nxagentWindow(pWin));
-
     return;
   }
 }
@@ -1873,7 +1819,7 @@ Bool nxagentChangeWindowAttributes(WindowPtr pWin, unsigned long mask)
   {
     if (nxagentOption(Rootless))
     {
-      if (pWin->cursorIsNone == 0 && pWin->optional != NULL && 
+      if (pWin->cursorIsNone == 0 && pWin->optional != NULL &&
               pWin->optional->cursor != NULL && nxagentCursorPriv(pWin ->
                   optional -> cursor, pWin -> drawable.pScreen) != NULL)
       {
@@ -1934,15 +1880,13 @@ Bool nxagentRealizeWindow(WindowPtr pWin)
     }
   }
 
-  #ifdef SHAPE
-
   /*
    * Not needed.
    *
-   * nxagentShapeWindow(pWin);
+    #ifdef SHAPE
+    nxagentShapeWindow(pWin);
+    #endif
    */
-
-  #endif /* SHAPE */
 
   /*
    * Mapping of the root window is called by
@@ -1999,7 +1943,6 @@ Bool nxagentUnrealizeWindow(WindowPtr pWin)
 
 void nxagentFrameBufferPaintWindow(WindowPtr pWin, RegionPtr pRegion, int what)
 {
-
   void (*PaintWindowBackgroundBackup)(WindowPtr, RegionPtr, int);
 
   if (pWin->backgroundState == BackgroundPixmap)
@@ -2065,11 +2008,8 @@ void nxagentPaintWindowBackground(WindowPtr pWin, RegionPtr pRegion, int what)
    */
 
   RegionInit(&temp, NullBox, 1);
-
   RegionIntersect(&temp, pRegion, &pWin -> clipList);
-
   nxagentFrameBufferPaintWindow(pWin, &temp, what);
-
   RegionUninit(&temp);
 }
 
@@ -2084,11 +2024,8 @@ void nxagentPaintWindowBorder(WindowPtr pWin, RegionPtr pRegion, int what)
    */
 
   RegionInit(&temp, NullBox, 1);
-
   RegionIntersect(&temp, pRegion, &pWin -> borderClip);
-
   nxagentFrameBufferPaintWindow(pWin, &temp, what);
-
   RegionUninit(&temp);
 }
 
@@ -2106,18 +2043,12 @@ void nxagentClipNotify(WindowPtr pWin, int dx, int dy)
   nxagentAddConfiguredWindow(pWin, CWStackingOrder);
   nxagentAddConfiguredWindow(pWin, CW_Shape);
 
-#ifdef NXAGENT_SHAPE
-  return;
-#else
-
-#ifdef SHAPE
-
-/*
+#ifndef NXAGENT_SHAPE
+  #ifdef SHAPE
+ /*
  * nxagentShapeWindow(pWin);
  */
-
-#endif /* SHAPE */
-
+ #endif /* SHAPE */
 #endif /* NXAGENT_SHAPE */
 }
 
@@ -2184,11 +2115,9 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
         nxagentExposeQueue.exposures[i].serial = 0;
       }
 
-      nxagentExposeQueue.length = 0;
-
-      nxagentExposeSerial = 0;
-
       nxagentExposeQueue.start = 0;
+      nxagentExposeQueue.length = 0;
+      nxagentExposeSerial = 0;
 
       nxagentConfiguredSynchroWindow = XCreateWindow(nxagentDisplay, DefaultRootWindow(nxagentDisplay), 0, 0,
                                                            1, 1, 0, 0, InputOutput, 0, CWEventMask, &attributes);
@@ -2228,7 +2157,6 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
         int index = (nxagentExposeQueue.start + nxagentExposeQueue.length) % EXPOSED_SIZE;
 
         nxagentExposeQueue.exposures[index].pWindow = pWin;
-
         nxagentExposeQueue.exposures[index].localRegion = RegionCreate(NULL, 1);
 
         if (nxagentOption(Rootless) && nxagentWindowPriv(pWin) &&
@@ -2270,7 +2198,6 @@ void nxagentWindowExposures(WindowPtr pWin, RegionPtr pRgn, RegionPtr other_expo
          */
 
         nxagentExposeQueue.exposures[index].synchronize = 1;
-
         nxagentExposeQueue.length++;
 
         if (nxagentOption(Rootless) && nxagentWindowPriv(pWin) &&
@@ -2390,12 +2317,11 @@ void nxagentShapeWindow(WindowPtr pWin)
 #ifdef NXAGENT_SHAPE2
       if (!nxagentWindowPriv(pWin)->boundingShape)
       {
-         nxagentWindowPriv(pWin)->boundingShape = RegionCreate(NULL, 1);
+        nxagentWindowPriv(pWin)->boundingShape = RegionCreate(NULL, 1);
       }
 #endif
 
-      RegionCopy(
-                      nxagentWindowPriv(pWin)->boundingShape, wBoundingShape(pWin));
+      RegionCopy(nxagentWindowPriv(pWin)->boundingShape, wBoundingShape(pWin));
 
       reg = XCreateRegion();
       pBox = RegionRects(nxagentWindowPriv(pWin)->boundingShape);
@@ -2423,8 +2349,7 @@ void nxagentShapeWindow(WindowPtr pWin)
       fprintf(stderr, "nxagentShapeWindow: wBounding shape does not exist. Removing the shape.\n");
       #endif
 
-      RegionEmpty(
-                       nxagentWindowPriv(pWin)->boundingShape);
+      RegionEmpty(nxagentWindowPriv(pWin)->boundingShape);
 
 #ifndef NXAGENT_SHAPE
       XShapeCombineMask(nxagentDisplay, nxagentWindow(pWin),
@@ -2454,8 +2379,7 @@ void nxagentShapeWindow(WindowPtr pWin)
       }
 #endif
 
-      RegionCopy(
-                  nxagentWindowPriv(pWin)->clipShape, wClipShape(pWin));
+      RegionCopy(nxagentWindowPriv(pWin)->clipShape, wClipShape(pWin));
 
       reg = XCreateRegion();
       pBox = RegionRects(nxagentWindowPriv(pWin)->clipShape);
@@ -2483,8 +2407,7 @@ void nxagentShapeWindow(WindowPtr pWin)
       fprintf(stderr, "nxagentShapeWindow: wClip shape does not exist. Removing the shape.\n");
       #endif
 
-      RegionEmpty(
-                       nxagentWindowPriv(pWin)->clipShape);
+      RegionEmpty(nxagentWindowPriv(pWin)->clipShape);
 
 #ifndef NXAGENT_SHAPE
       XShapeCombineMask(nxagentDisplay, nxagentWindow(pWin),
@@ -2554,7 +2477,6 @@ void nxagentMapDefaultWindows(void)
   for (i = 0; i < screenInfo.numScreens; i++)
   {
     WindowPtr pWin = screenInfo.screens[i]->root;
-
     ScreenPtr pScreen = pWin -> drawable.pScreen;
 
     MapWindow(pWin, serverClient);
@@ -2819,11 +2741,8 @@ Bool nxagentReconnectAllWindows(void *p0)
   }
 
   #ifdef NXAGENT_RECONNECT_WINDOW_DEBUG
-
   XSync(nxagentDisplay, 0);
-
   fprintf(stderr, "nxagentReconnectAllWindows: All windows reconfigured.\n");
-
   #endif
 
   if (nxagentInitClipboard(screenInfo.screens[0]->root) == -1)
@@ -2836,15 +2755,11 @@ Bool nxagentReconnectAllWindows(void *p0)
   }
 
   #ifdef NXAGENT_RECONNECT_WINDOW_DEBUG
-
   XSync(nxagentDisplay, 0);
-
   fprintf(stderr, "nxagentReconnectAllWindows: Clipboard initialized.\n");
-
   #endif
 
   #ifdef VIEWPORT_FRAME
-
   /*
    * We move the viewport frames out of the way on the X server side.
    */
@@ -2863,7 +2778,6 @@ Bool nxagentReconnectAllWindows(void *p0)
     XMoveWindow(nxagentDisplay, nxagentWindow(nxagentViewportFrameBelow),
                     0, nxagentOption(RootHeight));
   }
-
   #endif /* #ifdef VIEWPORT_FRAME */
 
   return True;
@@ -3015,9 +2929,6 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
 
   #ifdef TEST
   fprintf(stderr, "nxagentReconnectWindow: Going to create new window.\n");
-  #endif
-
-  #ifdef TEST
   fprintf(stderr, "nxagentReconnectWindow: Recreating %swindow at %p current event mask = %lX mask & CWEventMask = %ld "
               "event_mask = %lX\n",
                   nxagentWindowTopLevel(pWin) ? "toplevel " : "", (void*)pWin, pWin -> eventMask,
@@ -3104,10 +3015,8 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
       XSizeHints hints = {0};
       unsigned char *data = NULL;
       #ifdef _XSERVER64
-
       unsigned char *data64 = NULL;
       unsigned int i;
-
       #endif
 
       ret = GetWindowProperty(pWin,
@@ -3148,11 +3057,8 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
         }
 
         props = (XSizeHints *) data64;
-
         #else
-
         props = (XSizeHints *) data;
-
         #endif   /* _XSERVER64 */
 
         hints = *props;
@@ -3284,15 +3190,13 @@ static void nxagentReconfigureWindow(void * param0, XID param1, void * data_buff
   #ifdef SHAPE
   if (nxagentWindowPriv(pWin) -> boundingShape)
   {
-    RegionDestroy(
-                   nxagentWindowPriv(pWin) -> boundingShape);
+    RegionDestroy(nxagentWindowPriv(pWin) -> boundingShape);
     nxagentWindowPriv(pWin) -> boundingShape = NULL;
   }
 
   if (nxagentWindowPriv(pWin) -> clipShape)
   {
-    RegionDestroy(
-                   nxagentWindowPriv(pWin) -> clipShape);
+    RegionDestroy(nxagentWindowPriv(pWin) -> clipShape);
     nxagentWindowPriv(pWin) -> clipShape = NULL;
   }
   nxagentShapeWindow(pWin);
@@ -3330,7 +3234,6 @@ XXX: This would break Motif menus.
 
     XMoveWindow(nxagentDisplay, nxagentWindow(pWin),
                     nxagentOption(RootX), nxagentOption(RootY));
-
     XMapWindow(nxagentDisplay, nxagentWindow(pWin));
   }
 }
@@ -3350,7 +3253,6 @@ Bool nxagentCheckIllegalRootMonitoring(WindowPtr pWin, Mask mask)
 }
 
 #ifdef TEST
-
 Bool nxagentCheckWindowIntegrity(WindowPtr pWin)
 {
   Bool integrity = True;
@@ -3444,8 +3346,7 @@ Bool nxagentCheckWindowIntegrity(WindowPtr pWin)
 
   return integrity;
 }
-
-#endif
+#endif /* TEST */
 
 Bool nxagentIsIconic(WindowPtr pWin)
 {
@@ -3499,13 +3400,11 @@ void nxagentSetTopLevelEventMask(WindowPtr pWin)
 int nxagentExtentsPredicate(int total)
 {
   #ifdef TEST
-
   if (total == 6 || total == 11 || total == 10)
   {
     fprintf(stderr, "nxagentExtentsPredicate: WARNING! Returning [%d] with [%d] rectangles.\n",
                 (total == 6 || total == 11 || total == 10), total);
   }
-
   #endif
 
   return (total == 6 || total == 11 || total == 10);
@@ -3996,7 +3895,7 @@ StoringPixmapPtr nxagentFindItemBSPixmapList(unsigned long pixmapId)
   #ifdef TEST
   fprintf(stderr, "nxagentFindItemBSPixmapList: WARNING! Item not found.\n");
   #endif
-  
+
   #ifdef TEST
   fprintf(stderr, "nxagentFindItemBSPixmapList: Pixmap with id [%lu] not found.\n",
               pixmapId);
@@ -4006,4 +3905,3 @@ StoringPixmapPtr nxagentFindItemBSPixmapList(unsigned long pixmapId)
 
   return NULL;
 }
-


### PR DESCRIPTION
Cleanup Window.c a bit:
- use C99 designated initializers at some places
- add FIXME
- save some lines by declarating loop variables in the loop
- indent ifdefs for better readability
- silence compiler warnings
- some code simplifications
- whitespace cleanup
- scope improvements
- reformat/add braces for readability
- indent FIXMEs
- convert old-style function definitions to ANSI C89 style
