### PR TITLE
TravisCI: Update from Ubuntu Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,11 +80,10 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-6.0
+            - llvm-toolchain-xenial-7
             - ubuntu-toolchain-r-test
           packages:
-            - clang-6.0
-            - g++-4.9
+            - clang-7
             # imake
             - xutils-dev
             # X11 libaries
@@ -98,7 +97,7 @@ matrix:
             - x11proto-fonts-dev
 
       env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
         - STATIC_ANALYSIS="no"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-# Use new trusty images, should yield newer compilers and packages
+# Use new xenial images, should yield newer compilers and packages
 sudo: true
-dist: trusty
+dist: xenial
 language: cpp
 
 matrix:
@@ -9,16 +9,18 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+            - sourceline: 'deb http://archive.ubuntu.com/ubuntu main restricted universe multiverse'
             - ubuntu-toolchain-r-test
           packages:
-            - cppcheck/trusty-backports
+            - cppcheck
             # imake
             - xutils-dev
             # X11 libaries
             - libxcomposite-dev
+            - libxdamage-dev
             - libxfont-dev
             - libxinerama-dev
+            - libxpm-dev
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
@@ -39,8 +41,10 @@ matrix:
             - xutils-dev
             # X11 libaries
             - libxcomposite-dev
+            - libxdamage-dev
             - libxfont-dev
             - libxinerama-dev
+            - libxpm-dev
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
@@ -53,15 +57,17 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-3.9
+            - llvm-toolchain-xenial-3.9
           packages:
             - clang-3.9
             # imake
             - xutils-dev
             # X11 libaries
             - libxcomposite-dev
+            - libxdamage-dev
             - libxfont-dev
             - libxinerama-dev
+            - libxpm-dev
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
@@ -74,7 +80,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
             - ubuntu-toolchain-r-test
           packages:
             - clang-6.0
@@ -83,8 +89,10 @@ matrix:
             - xutils-dev
             # X11 libaries
             - libxcomposite-dev
+            - libxdamage-dev
             - libxfont-dev
             - libxinerama-dev
+            - libxpm-dev
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
+            # soft requirements
+            - quilt
+            - x11-xkb-utils
 
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
@@ -48,6 +51,9 @@ matrix:
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
+            # soft requirements
+            - quilt
+            - x11-xkb-utils
 
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
@@ -71,6 +77,9 @@ matrix:
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
+            # soft requirements
+            - quilt
+            - x11-xkb-utils
 
       env:
         - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
@@ -95,6 +104,9 @@ matrix:
             - libxrandr-dev
             - libxtst-dev
             - x11proto-fonts-dev
+            # soft requirements
+            - quilt
+            - x11-xkb-utils
 
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"


### PR DESCRIPTION
Hi @sunweaver,

I upgraded the TravisCI's configuration from **Ubuntu Trusty (14.04 LTS)** to **Xenial (16.04)**, and also updated the **Clang** latest version from 6.0 to 7.

@uli42 PTAL, there is some new warnings with Clang-7.