### PR TITLE
Make it possible to forward client ports to unix sockets

### DIFF
--- a/nxcomp/src/ChannelEndPoint.cpp
+++ b/nxcomp/src/ChannelEndPoint.cpp
@@ -209,8 +209,6 @@ ChannelEndPoint::getUnixPath(char **unixPath) const {
 
   if (unixPath)
     *unixPath = NULL;
-  else
-    return false;
 
   long p;
   char *path = NULL;
@@ -230,7 +228,9 @@ ChannelEndPoint::getUnixPath(char **unixPath) const {
       return false;
   }
 
-  *unixPath = strdup(path);
+  // Only return value wanted
+  if ( unixPath )
+    *unixPath = strdup(path);
 
   return true;
 }

--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -7803,6 +7803,7 @@ int ParseEnvironmentOptions(const char *env, int force)
   strcpy(opts, env);
 
   char *nextOpts = opts;
+  bool nxdisplay_found = false;
 
   //
   // Ensure that DISPLAY environment variable
@@ -7824,14 +7825,17 @@ int ParseEnvironmentOptions(const char *env, int force)
   else if (strncasecmp(opts, "nx/nx,", 6) == 0)
   {
     nextOpts += 6;
+    nxdisplay_found = true;
   }
   else if (strncasecmp(opts, "nx,", 3) == 0)
   {
     nextOpts += 3;
+    nxdisplay_found = true;
   }
   else if (strncasecmp(opts, "nx:", 3) == 0)
   {
     nextOpts += 3;
+    nxdisplay_found = true;
   }
   else if (force == 0)
   {
@@ -7860,7 +7864,7 @@ int ParseEnvironmentOptions(const char *env, int force)
 
   value = strrchr(nextOpts, ':');
 
-  if (value != NULL)
+  if (value != NULL && nxdisplay_found )
   {
     char *check = value + 1;
 


### PR DESCRIPTION
This is to address bug #737 

Modern versions of OSX don't have CUPS running all the time, and start it when /private/var/run/cupsd is opened.

The code already supports working with unix sockets, but specifying "cups=unix:/private/var/run/cupsd" doesn't work due to issues in the current commandline parser.

This should fix that. Please check the changes to ParseEnvironmentOptions, as I'm not 100% sure if there might be some edge case I'm not seeing.
