### PR TITLE
Revert "nxagent: rework Bool handling"

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -522,7 +522,7 @@ int ddxProcessArgument(int argc, char *argv[], int i)
             sscanf(argv[i], "%i", &level) == 1 &&
                 level >= 0 && level <= 2)
     {
-      if (!nxagentOption(Shadow))
+      if (nxagentOption(Shadow) == 0)
       {
         nxagentChangeOption(DeferLevel, level);
 
@@ -624,7 +624,7 @@ int ddxProcessArgument(int argc, char *argv[], int i)
         }
       }
 
-      if (nxagentUserGeometry.flag || nxagentOption(Fullscreen)) return 2;
+      if (nxagentUserGeometry.flag || (nxagentOption(Fullscreen) == 1)) return 2;
     }
 
     return 0;
@@ -1122,7 +1122,7 @@ static void nxagentParseSingleOption(char *name, char *value)
   }
   else if (!strcmp(name, "render"))
   {
-    if (nxagentReconnectTrap)
+    if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
       fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'render' at reconnection.\n");
@@ -1154,7 +1154,7 @@ static void nxagentParseSingleOption(char *name, char *value)
   }
   else if (!strcmp(name, "fullscreen"))
   {
-    if (nxagentReconnectTrap)
+    if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
       fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'fullscreen' at reconnection.\n");
@@ -1267,13 +1267,13 @@ static void nxagentParseSingleOption(char *name, char *value)
   }
   else if (!strcmp(name, "resize"))
   {
-    if (!nxagentOption(DesktopResize) || strcmp(value, "0") == 0)
+    if (nxagentOption(DesktopResize) == 0 || strcmp(value, "0") == 0)
     {
-      nxagentResizeDesktopAtStartup = False;
+      nxagentResizeDesktopAtStartup = 0;
     }
     else if (strcmp(value, "1") == 0)
     {
-      nxagentResizeDesktopAtStartup = True;
+      nxagentResizeDesktopAtStartup = 1;
     }
     else
     {
@@ -1324,7 +1324,7 @@ static void nxagentParseSingleOption(char *name, char *value)
   }
   else if (!strcmp(name, "autodpi"))
   {
-    if (nxagentReconnectTrap)
+    if (nxagentReconnectTrap == True)
     {
       #ifdef DEBUG
       fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'autodpi' at reconnection.\n");
@@ -1793,7 +1793,7 @@ N/A
 
     #endif
 
-    if (nxagentOption(Rootless) && nxagentOption(Fullscreen))
+    if ((nxagentOption(Rootless) == 1) && nxagentOption(Fullscreen) == 1)
     {
       #ifdef TEST
       fprintf(stderr, "WARNING: Ignoring fullscreen option for rootless session.\n");
@@ -2092,7 +2092,7 @@ FIXME: In rootless mode the backing-store support is not functional yet.
       nxagentAlphaEnabled = False;
     }
 
-    if (nxagentOption(Rootless) && nxagentOption(Xdmcp))
+    if ((nxagentOption(Rootless) == 1) && nxagentOption(Xdmcp))
     {
       FatalError("PANIC! Cannot start a XDMCP session in rootless mode.\n");
     }
@@ -2102,7 +2102,7 @@ FIXME: In rootless mode the backing-store support is not functional yet.
      * XDMCP sessions.
      */
 
-    if (nxagentOption(Reset) && nxagentMaxAllowedResets == 0)
+    if (nxagentOption(Reset) == True && nxagentMaxAllowedResets == 0)
     {
       #ifdef WARNING
       fprintf(stderr, "nxagentPostProcessArgs: Disabling the server reset.\n");
@@ -2119,7 +2119,7 @@ FIXME: In rootless mode the backing-store support is not functional yet.
      * to a standard XFree86 server.
      */
 
-    if (!nxagentOption(Reset))
+    if (nxagentOption(Reset) == False)
     {
       #ifdef TEST
       fprintf(stderr, "nxagentPostProcessArgs: Disabling dispatch of exception at server reset.\n");
@@ -2399,7 +2399,7 @@ void nxagentSetDeferLevel(void)
    * of the agent.
    */
 
-  if (nxagentOption(Streaming))
+  if (nxagentOption(Streaming) == 1)
   {
     fprintf(stderr, "Warning: Streaming of images not available in this agent.\n");
 
@@ -2484,7 +2484,7 @@ void nxagentSetDeferLevel(void)
    * Set the defer timeout.
    */
 
-  if (nxagentOption(Shadow))
+  if (nxagentOption(Shadow) == 1)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentSetDeferLevel: Ignoring defer timeout parameter in shadow mode.\n");
@@ -2499,7 +2499,7 @@ void nxagentSetDeferLevel(void)
    * Set the defer level.
    */
 
-  if (nxagentOption(Shadow) )
+  if (nxagentOption(Shadow) == 1)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentSetDeferLevel: Ignoring defer parameter in shadow mode.\n");
@@ -2631,7 +2631,7 @@ void nxagentSetScheduler(void)
    * The smart scheduler is the default.
    */
 
-  if (nxagentOption(Shadow))
+  if (nxagentOption(Shadow) == 1)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentSetScheduler: Using the dumb scheduler in shadow mode.\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Composite.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Composite.c
@@ -59,7 +59,7 @@ void nxagentCompositeExtensionInit(void)
 
   nxagentCompositeEnable = 0;
 
-  if (nxagentOption(Composite))
+  if (nxagentOption(Composite) == 1)
   {
     int eventBase, errorBase;
 
@@ -119,7 +119,7 @@ void nxagentRedirectDefaultWindows(void)
 {
   int i;
 
-  if (nxagentOption(Rootless) ||
+  if (nxagentOption(Rootless) == 1 ||
           nxagentCompositeEnable == 0)
   {
     #ifdef TEST
@@ -159,7 +159,7 @@ void nxagentRedirectDefaultWindows(void)
 
 void nxagentRedirectWindow(WindowPtr pWin)
 {
-  if (!nxagentOption(Rootless) ||
+  if (nxagentOption(Rootless) == 0 ||
           nxagentCompositeEnable == 0)
   {
     #ifdef TEST

--- a/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Cursor.c
@@ -134,7 +134,7 @@ Bool nxagentDisplayCursor(ScreenPtr pScreen, CursorPtr pCursor)
 
   cursor = (pCursor != rootCursor) ? nxagentCursor(pCursor, pScreen): None;
 
-  if (!nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == False)
   {
     XDefineCursor(nxagentDisplay,
                       nxagentInputWindows[pScreen -> myNum],

--- a/nx-X11/programs/Xserver/hw/nxagent/Display.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Display.c
@@ -313,7 +313,7 @@ static void nxagentSighupHandler(int signal)
   }
   else if (nxagentSessionState == SESSION_UP)
   {
-    if (nxagentOption(Persistent))
+    if (nxagentOption(Persistent) == 1)
     {
       #ifdef TEST
       fprintf(stderr, "nxagentSighupHandler: Handling the signal by disconnecting the agent.\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Drawable.c
@@ -148,7 +148,7 @@ int nxagentSynchronizeDrawable(DrawablePtr pDrawable, int wait, unsigned int bre
 
   pDrawable = nxagentSplitDrawable(pDrawable);
 
-  if (!nxagentLosslessTrap)
+  if (nxagentLosslessTrap == 0)
   {
     if (nxagentDrawableStatus(pDrawable) == Synchronized)
     {
@@ -171,15 +171,15 @@ int nxagentSynchronizeDrawable(DrawablePtr pDrawable, int wait, unsigned int bre
    * transferred in a single operation.
    */
 
-  nxagentFBTrap = True;
+  nxagentFBTrap = 1;
 
-  nxagentSplitTrap = True;
+  nxagentSplitTrap = 1;
 
   result = nxagentSynchronizeDrawableData(pDrawable, breakMask, owner);
 
-  nxagentSplitTrap = False;
+  nxagentSplitTrap = 0;
 
-  nxagentFBTrap = False;
+  nxagentFBTrap = 0;
 
   if (wait == DO_WAIT && nxagentSplitResource(pDrawable) != NULL)
   {
@@ -253,7 +253,7 @@ int nxagentSynchronizeDrawableData(DrawablePtr pDrawable, unsigned int breakMask
      * compression turned off.
      */
 
-    if (nxagentLosslessTrap)
+    if (nxagentLosslessTrap == 1)
     {
       pGC = nxagentGetGraphicContext(pDrawable);
 
@@ -285,7 +285,7 @@ int nxagentSynchronizeDrawableData(DrawablePtr pDrawable, unsigned int breakMask
 
       goto nxagentSynchronizeDrawableDataEnd;
     }
-    else if (nxagentReconnectTrap)
+    else if (nxagentReconnectTrap == 1)
     {
       /*
        * The pixmap data is not synchronized unless
@@ -298,7 +298,7 @@ int nxagentSynchronizeDrawableData(DrawablePtr pDrawable, unsigned int breakMask
       {
         #ifdef TEST
 
-        if (nxagentReconnectTrap)
+        if (nxagentReconnectTrap == 1)
         {
           static int totalLength;
           static int totalReconnectedPixmaps;
@@ -586,11 +586,11 @@ int nxagentSynchronizeRegion(DrawablePtr pDrawable, RegionPtr pRegion, unsigned 
 
   saveTrap = nxagentGCTrap;
 
-  nxagentGCTrap = False;
+  nxagentGCTrap = 0;
 
-  nxagentFBTrap = True;
+  nxagentFBTrap = 1;
 
-  nxagentSplitTrap = True;
+  nxagentSplitTrap = 1;
 
   pGC = nxagentGetGraphicContext(pDrawable);
 
@@ -894,7 +894,7 @@ int nxagentSynchronizeRegion(DrawablePtr pDrawable, RegionPtr pRegion, unsigned 
 
         if (owner != NULL)
         {
-          if (nxagentOption(Shadow) &&
+          if (nxagentOption(Shadow) == 1 &&
                   (nxagentOption(XRatio) != DONT_SCALE ||
                       nxagentOption(YRatio) != DONT_SCALE))
           {
@@ -945,15 +945,15 @@ int nxagentSynchronizeRegion(DrawablePtr pDrawable, RegionPtr pRegion, unsigned 
 
 nxagentSynchronizeRegionStop:
 
-  nxagentSplitTrap = False;
+  nxagentSplitTrap = 0;
 
-  nxagentFBTrap = False;
+  nxagentFBTrap = 0;
 
   nxagentGCTrap = saveTrap;
 
   success = 1;
 
-  if (!nxagentOption(Shadow))
+  if (nxagentOption(Shadow) == 0)
   {
     if (nxagentSynchronization.abort == 1)
     {
@@ -1025,7 +1025,7 @@ nxagentSynchronizeRegionStop:
         w = RegionRects(&collectedUpdates)[i].x2 - RegionRects(&collectedUpdates)[i].x1;
         h = RegionRects(&collectedUpdates)[i].y2 - RegionRects(&collectedUpdates)[i].y1;
        
-        if (nxagentOption(Shadow) &&
+        if (nxagentOption(Shadow) == 1 &&
                 (nxagentOption(XRatio) != DONT_SCALE ||
                     nxagentOption(YRatio) != DONT_SCALE))
         {
@@ -2633,7 +2633,7 @@ void nxagentCreateDrawableBitmap(DrawablePtr pDrawable)
 
   saveTrap = nxagentGCTrap;
 
-  nxagentGCTrap = True;
+  nxagentGCTrap = 1;
 
   if (nxagentDrawableStatus(pDrawable) == Synchronized)
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -583,13 +583,13 @@ void nxagentSwitchResizeMode(ScreenPtr pScreen)
 
   nxagentChangeOption(DesktopResize, !desktopResize);
 
-  if (!nxagentOption(DesktopResize))
+  if (nxagentOption(DesktopResize) == 0)
   {
     fprintf(stderr,"Info: Disabled desktop resize mode in agent.\n");
 
     nxagentLaunchDialog(DIALOG_DISABLE_DESKTOP_RESIZE_MODE);
 
-    if (!nxagentOption(Fullscreen))
+    if (nxagentOption(Fullscreen) == 0)
     {
       nxagentSetWMNormalHintsMaxsize(pScreen,
                                      nxagentOption(RootWidth),
@@ -621,7 +621,7 @@ void nxagentShadowSwitchResizeMode(ScreenPtr pScreen)
 
   nxagentChangeOption(DesktopResize, !desktopResize);
 
-  if (!nxagentOption(DesktopResize))
+  if (nxagentOption(DesktopResize) == 0)
   {
     nxagentShadowSetRatio(1.0, 1.0);
 
@@ -1048,7 +1048,7 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
           }
           case doSwitchResizeMode:
           {
-            if (!nxagentOption(Shadow))
+            if (nxagentOption(Shadow) == 0)
             {
               if (nxagentNoDialogIsRunning)
               {
@@ -1096,7 +1096,7 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
           nxagentRemoveDuplicatedKeys(&X);
         }
 
-        if (!nxagentOption(ViewOnly) && nxagentOption(Shadow) && result == doNothing)
+        if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow) == 1 && result == doNothing)
         {
           X.xkey.keycode = nxagentConvertKeycode(X.xkey.keycode);
 
@@ -1147,17 +1147,17 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         {
           if (X.xkey.keycode == nxagentCapsLockKeycode)
           {
-            nxagentXkbCapsTrap = True;
+            nxagentXkbCapsTrap = 1;
           }
           else if (X.xkey.keycode == nxagentNumLockKeycode)
           {
-            nxagentXkbNumTrap = True;
+            nxagentXkbNumTrap = 1;
           }
 
           nxagentInitXkbKeyboardState();
 
-          nxagentXkbCapsTrap = False;
-          nxagentXkbNumTrap = False;
+          nxagentXkbCapsTrap = 0;
+          nxagentXkbNumTrap = 0;
         }
 
         memset(&x, 0, sizeof(xEvent));
@@ -1181,7 +1181,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
           CriticalOutputPending = 1;
 
-          if (!nxagentOption(ViewOnly) && nxagentOption(Shadow))
+          if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow))
           {
             X.xkey.keycode = nxagentConvertKeycode(X.xkey.keycode);
 
@@ -1204,7 +1204,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         if (nxagentOption(Fullscreen))
         {
-          if ( nxagentOption(MagicPixel) && (nxagentMagicPixelZone(X.xbutton.x, X.xbutton.y)) )
+          if ( (nxagentOption(MagicPixel) == 1) && (nxagentMagicPixelZone(X.xbutton.x, X.xbutton.y)) )
           {
             pScreen = nxagentScreen(X.xbutton.window);
 
@@ -1219,7 +1219,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           closeSession = TRUE;
         }
 
-        if (!nxagentOption(DesktopResize) &&
+        if (nxagentOption(DesktopResize) == False &&
                 (X.xbutton.state & (ControlMask | Mod1Mask)) == (ControlMask | Mod1Mask))
         {
           /*
@@ -1275,7 +1275,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           CriticalOutputPending = 1;
         }
 
-        if (!nxagentOption(ViewOnly) && nxagentOption(Shadow))
+        if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow))
         {
           X.xbutton.x -= nxagentOption(RootX);
           X.xbutton.y -= nxagentOption(RootY);
@@ -1349,7 +1349,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           CriticalOutputPending = 1;
         }
 
-        if (!nxagentOption(ViewOnly) && nxagentOption(Shadow))
+        if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow))
         {
           X.xbutton.x -= nxagentOption(RootX);
           X.xbutton.y -= nxagentOption(RootY);
@@ -1410,7 +1410,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
                                 (nxagentLastEnteredTopLevelWindow -> drawable.width >> 1) - 50) &&
                                     X.xmotion.x_root < (nxagentLastEnteredTopLevelWindow -> drawable.x +
                                         (nxagentLastEnteredTopLevelWindow -> drawable.width >> 1) + 50) &&
-                                            nxagentOption(Menu))
+                                            nxagentOption(Menu) == 1)
             {
               nxagentPulldownDialog(nxagentLastEnteredTopLevelWindow -> drawable.id);
             }
@@ -1464,7 +1464,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           viewportLastY = X.xmotion.y;
         }
 
-        if (!nxagentOption(ViewOnly) && nxagentOption(Shadow) && !viewportCursor)
+        if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow) && !viewportCursor)
         {
           X.xmotion.x -= nxagentOption(RootX);
           X.xmotion.y -= nxagentOption(RootY);
@@ -1482,7 +1482,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           NXShadowEvent(nxagentDisplay, X);
         }
 
-        if (!nxagentOption(Shadow))
+        if (nxagentOption(Shadow) == 0)
         {
           nxagentInputEvent = 1;
         }
@@ -1575,7 +1575,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
                     x.u.u.detail = i * 8 + k;
                     x.u.keyButtonPointer.time = nxagentLastEventTime = GetTimeInMillis();
 
-                    if (!nxagentOption(ViewOnly) && nxagentOption(Shadow))
+                    if (nxagentOption(ViewOnly) == 0 && nxagentOption(Shadow))
                     {
                       xM.type = KeyRelease;
                       xM.xkey.display = nxagentDisplay;
@@ -1672,14 +1672,14 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
           mask = CWX | CWY;
 
-          nxagentScreenTrap = True;
+          nxagentScreenTrap = 1;
 
           ConfigureWindow(pWin, mask, (XID *) values, pClient);
 
-          nxagentScreenTrap = False;
+          nxagentScreenTrap = 0;
         }
 
-        if (nxagentOption(Fullscreen) &&
+        if (nxagentOption(Fullscreen) == 1 &&
                 X.xcrossing.window == nxagentFullscreenWindow &&
                     X.xcrossing.detail != NotifyInferior)
         {
@@ -1803,7 +1803,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
             {
               int value = X.xvisibility.state;
 
-              if (nxagentOption(Rootless))
+              if (nxagentOption(Rootless) == 1)
               {
                 TraverseTree(pWin, nxagentChangeVisibilityPrivate, &value);
               }
@@ -1970,22 +1970,22 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         fprintf(stderr, "nxagentDispatchEvents: Going to handle new UnmapNotify event.\n");
         #endif
 
-        if (nxagentOption(Rootless))
+        if (nxagentOption(Rootless) == 1)
         {
           if ((pWin = nxagentRootlessTopLevelWindow(X.xunmap.window)) != NULL ||
                   ((pWin = nxagentWindowPtr(X.xunmap.window)) != NULL &&
                       nxagentWindowTopLevel(pWin) == 1))
           {
-            nxagentScreenTrap = True;
+            nxagentScreenTrap = 1;
 
             UnmapWindow(pWin, False);
 
-            nxagentScreenTrap = False;
+            nxagentScreenTrap = 0;
           }
         }
 
-        if (nxagentUseNXTrans == 1 && !nxagentOption(Rootless) &&
-                !nxagentOption(Nested) &&
+        if (nxagentUseNXTrans == 1 && nxagentOption(Rootless) == 0 &&
+                nxagentOption(Nested) == 0 &&
                     X.xmap.window != nxagentIconWindow)
         {
           nxagentVisibility = VisibilityFullyObscured;
@@ -2002,7 +2002,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         fprintf(stderr, "nxagentDispatchEvents: Going to handle new MapNotify event.\n");
         #endif
 
-        if (nxagentOption(Rootless))
+        if (nxagentOption(Rootless) == 1)
         {
           Bool value = 1;
 
@@ -2012,11 +2012,11 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           {
             pClient = wClient(pWin);
 
-            nxagentScreenTrap = True;
+            nxagentScreenTrap = 1;
 
             MapWindow(pWin, pClient);
 
-            nxagentScreenTrap = False;
+            nxagentScreenTrap = 0;
           }
 
           if (pWin != NULL)
@@ -2025,7 +2025,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           }
         }
 
-        if (nxagentOption(AllScreens))
+        if (nxagentOption(AllScreens) == 1)
         {
           if (X.xmap.window == nxagentIconWindow)
           {
@@ -2034,7 +2034,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           }
         }
 
-        if (nxagentOption(Fullscreen))
+        if (nxagentOption(Fullscreen) == 1)
         {
           nxagentVisibility = VisibilityUnobscured;
           nxagentVisibilityStop = False;
@@ -2155,7 +2155,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
   if (switchFullscreen)
   {
-    if (nxagentOption(AllScreens) && nxagentOption(Fullscreen))
+    if (nxagentOption(AllScreens) == 1 && nxagentOption(Fullscreen) == 1)
     {
       nxagentSwitchAllScreens(pScreen, 0);
     }
@@ -2167,7 +2167,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
   if (switchAllScreens)
   {
-    if (!nxagentOption(AllScreens) && nxagentOption(Fullscreen))
+    if (nxagentOption(AllScreens) == 0 && nxagentOption(Fullscreen) == 1)
     {
       nxagentSwitchFullscreen(pScreen, 0);
     }
@@ -2310,17 +2310,17 @@ int nxagentHandleKeyPress(XEvent *X, enum HandleEventResult *result)
   {
     if (X -> xkey.keycode == nxagentCapsLockKeycode)
     {
-      nxagentXkbCapsTrap = True;
+      nxagentXkbCapsTrap = 1;
     }
     else if (X -> xkey.keycode == nxagentNumLockKeycode)
     {
-      nxagentXkbNumTrap = True;
+      nxagentXkbNumTrap = 1;
     }
 
     nxagentInitXkbKeyboardState();
 
-    nxagentXkbCapsTrap = False;
-    nxagentXkbNumTrap = False;
+    nxagentXkbCapsTrap = 0;
+    nxagentXkbNumTrap = 0;
   }
 
   if (nxagentCheckSpecialKeystroke(&X -> xkey, result))
@@ -3208,7 +3208,7 @@ int nxagentCheckWindowConfiguration(XConfigureEvent* X)
 
 int nxagentHandleConfigureNotify(XEvent* X)
 {
-  if (nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == True)
   {
     ClientPtr pClient;
     WindowPtr pWinWindow;
@@ -3281,11 +3281,11 @@ int nxagentHandleConfigureNotify(XEvent* X)
 
       mask |= CWHeight | CWWidth | CWBorderWidth;
 
-      nxagentScreenTrap = True;
+      nxagentScreenTrap = 1;
 
       ConfigureWindow(pWinWindow, mask, (XID *) values, pClient);
 
-      nxagentScreenTrap = False;
+      nxagentScreenTrap = 0;
 
       nxagentCheckWindowConfiguration((XConfigureEvent*)X);
 
@@ -3358,7 +3358,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
 
     if (X -> xconfigure.window == nxagentDefaultWindows[pScreen -> myNum])
     {
-      if (!nxagentOption(AllScreens))
+      if (nxagentOption(AllScreens) == 0)
       {
         /*
          * - WITHOUT window manager any position change is relevant
@@ -3370,7 +3370,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
         int newX = X -> xconfigure.x;
         int newY = X -> xconfigure.y;
 
-        if (nxagentOption(DesktopResize))
+        if (nxagentOption(DesktopResize) == 1)
         {
           if (nxagentOption(Width) != X -> xconfigure.width ||
                 nxagentOption(Height) != X -> xconfigure.height ||
@@ -3434,7 +3434,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
           nxagentChangeOption(Y, newY);
         }
 
-        if (nxagentOption(Shadow) && nxagentOption(DesktopResize) &&
+        if (nxagentOption(Shadow) == 1 && nxagentOption(DesktopResize) == 1 &&
                 (nxagentOption(Width) != X -> xconfigure.width ||
                     nxagentOption(Height) != X -> xconfigure.height))
         {
@@ -3454,7 +3454,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
         /* if in shadowing mode or if neither size nor position have
            changed we do not need to adjust RandR */
         /* FIXME: Comment makes no sense */
-        if (nxagentOption(Shadow) ||
+        if (nxagentOption(Shadow) == 1 ||
                 (nxagentOption(Width) == nxagentOption(RootWidth) &&
 		 nxagentOption(Height) == nxagentOption(RootHeight) &&
 		 nxagentOption(X) == nxagentOption(RootX) &&
@@ -3469,7 +3469,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
         XMoveResizeWindow(nxagentDisplay, nxagentInputWindows[0], 0, 0,
                               X -> xconfigure.width, X -> xconfigure.height);
 
-        if (!nxagentOption(Fullscreen))
+        if (nxagentOption(Fullscreen) == 0)
         {
           nxagentMoveViewport(pScreen, 0, 0);
         }
@@ -3639,7 +3639,7 @@ int nxagentHandleReparentNotify(XEvent* X)
 
     return 1;
   }
-  else if (nxagentWMIsRunning && !nxagentOption(Fullscreen) &&
+  else if (nxagentWMIsRunning && nxagentOption(Fullscreen) == 0 &&
                nxagentOption(WMBorderWidth) == -1)
   {
     XlibWindow w;
@@ -4415,7 +4415,7 @@ int nxagentUserInput(void *p)
    * tus.
    */
 
-  if (nxagentOption(Shadow) &&
+  if (nxagentOption(Shadow) == 1 &&
           nxagentPendingEvents(nxagentDisplay) > 0)
   {
     nxagentDispatchEvents(NULL);
@@ -4436,7 +4436,7 @@ int nxagentUserInput(void *p)
    * order to update the screen smoothly.
    */
 
-  if (nxagentOption(Shadow))
+  if (nxagentOption(Shadow) == 1)
   {
     return result;
   }

--- a/nx-X11/programs/Xserver/hw/nxagent/Extensions.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Extensions.c
@@ -396,7 +396,7 @@ void nxagentRandRSetWindowsSize(int width, int height)
 {
   if (width == 0)
   {
-    if (nxagentOption(Fullscreen))
+    if (nxagentOption(Fullscreen) == 1)
     {
       width = WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay));
     }
@@ -408,7 +408,7 @@ void nxagentRandRSetWindowsSize(int width, int height)
 
   if (height == 0)
   {
-    if (nxagentOption(Fullscreen))
+    if (nxagentOption(Fullscreen) == 1)
     {
       height = HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay));
     }
@@ -420,7 +420,7 @@ void nxagentRandRSetWindowsSize(int width, int height)
 
   XResizeWindow(nxagentDisplay, nxagentDefaultWindows[0], width, height);
 
-  if (!nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == 0)
   {
     XMoveResizeWindow(nxagentDisplay, nxagentInputWindows[0], 0, 0, width,
                           height);
@@ -434,8 +434,8 @@ int nxagentRandRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
 
   UpdateCurrentTime();
 
-  if (nxagentOption(DesktopResize) &&
-          (nxagentOption(Fullscreen) ||
+  if (nxagentOption(DesktopResize) == 1 &&
+          (nxagentOption(Fullscreen) == 1 ||
                width > WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay)) ||
                    height > HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay))))
   {
@@ -446,8 +446,8 @@ int nxagentRandRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
     }
   }
 
-  if (nxagentOption(DesktopResize) && !nxagentOption(Fullscreen) &&
-          !nxagentOption(AllScreens))
+  if (nxagentOption(DesktopResize) == 1 && nxagentOption(Fullscreen) == 0 &&
+          nxagentOption(AllScreens) == 0)
   {
     nxagentChangeOption(Width, width);
     nxagentChangeOption(Height, height);
@@ -455,8 +455,8 @@ int nxagentRandRScreenSetSize(ScreenPtr pScreen, CARD16 width, CARD16 height,
 
   result = nxagentResizeScreen(pScreen, width, height, mmWidth, mmHeight);
 
-  if (result == 1 && nxagentOption(DesktopResize) &&
-          !nxagentOption(Fullscreen) && !nxagentOption(AllScreens))
+  if (result == 1 && nxagentOption(DesktopResize) == 1 &&
+          nxagentOption(Fullscreen) == 0 && nxagentOption(AllScreens) == 0)
   {
     nxagentRandRSetWindowsSize(width, height);
     nxagentSetWMNormalHints(pScreen -> myNum, nxagentOption(Width), nxagentOption(Height));

--- a/nx-X11/programs/Xserver/hw/nxagent/GC.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/GC.c
@@ -385,7 +385,7 @@ void nxagentChangeGC(GCPtr pGC, unsigned long mask)
     else
     {
       if (nxagentDrawableStatus((DrawablePtr) pGC -> tile.pixmap) == NotSynchronized &&
-              !nxagentGCTrap)
+              nxagentGCTrap == 0)
       {
         /*
          * If the tile is corrupted and is not too
@@ -437,7 +437,7 @@ void nxagentChangeGC(GCPtr pGC, unsigned long mask)
   if (mask & GCStipple)
   {
     if (nxagentDrawableStatus((DrawablePtr) pGC -> stipple) == NotSynchronized &&
-            !nxagentGCTrap)
+            nxagentGCTrap == 0)
     {
       #ifdef TEST
       fprintf(stderr, "nxagentChangeGC: WARNING! Synchronizing GC at [%p] due the stipple at [%p].\n",
@@ -535,7 +535,7 @@ void nxagentChangeGC(GCPtr pGC, unsigned long mask)
   {
     mask &= ~GCDashList;
 
-    if (!nxagentGCTrap)
+    if (nxagentGCTrap == 0)
     {
       XSetDashes(nxagentDisplay, nxagentGC(pGC),
                      pGC->dashOffset, (char *)pGC->dash, pGC->numInDashList);
@@ -549,7 +549,7 @@ void nxagentChangeGC(GCPtr pGC, unsigned long mask)
     changeFlag += nxagentTestGC(values.arc_mode, arc_mode);
   }
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentChangeGC: Skipping change of GC at [%p] on the real X server.\n",
@@ -668,7 +668,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
   {
     case CT_NONE:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {
         XSetClipMask(nxagentDisplay, nxagentGC(pGC), None);
       }
@@ -677,7 +677,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_REGION:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {
         nRects = RegionNumRects((RegionPtr)pValue);
         size = nRects * sizeof(*pRects);
@@ -701,7 +701,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_PIXMAP:
     {
-      if (!nxagentGCTrap)
+      if (nxagentGCTrap == 0)
       {
         XSetClipMask(nxagentDisplay, nxagentGC(pGC),
                          nxagentPixmap((PixmapPtr)pValue));
@@ -719,7 +719,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_UNSORTED:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {    
         XSetClipRectangles(nxagentDisplay, nxagentGC(pGC),
                                pGC->clipOrg.x, pGC->clipOrg.y,
@@ -730,7 +730,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_YSORTED:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {
         XSetClipRectangles(nxagentDisplay, nxagentGC(pGC),
                            pGC->clipOrg.x, pGC->clipOrg.y,
@@ -741,7 +741,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_YXSORTED:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {
         XSetClipRectangles(nxagentDisplay, nxagentGC(pGC),
                            pGC->clipOrg.x, pGC->clipOrg.y,
@@ -752,7 +752,7 @@ void nxagentChangeClip(GCPtr pGC, int type, void * pValue, int nRects)
     }
     case CT_YXBANDED:
     {
-      if (clipsMatch == 0 && !nxagentGCTrap)
+      if (clipsMatch == 0 && nxagentGCTrap == 0)
       {
         XSetClipRectangles(nxagentDisplay, nxagentGC(pGC),
                          pGC->clipOrg.x, pGC->clipOrg.y,
@@ -809,7 +809,7 @@ void nxagentDestroyClip(GCPtr pGC)
 
   nxagentDestroyClipHelper(pGC);
 
-  if (!nxagentGCTrap)
+  if (nxagentGCTrap == 0)
   {
     XSetClipMask(nxagentDisplay, nxagentGC(pGC), None);
   }
@@ -1453,7 +1453,7 @@ GCPtr nxagentGetScratchGC(unsigned depth, ScreenPtr pScreen)
 
   nxagentSaveGCTrap = nxagentGCTrap;
 
-  nxagentGCTrap = False;
+  nxagentGCTrap = 0;
 
   pGC = GetScratchGC(depth, pScreen);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/GCOps.c
@@ -80,7 +80,7 @@ static int nxagentSaveGCTrap;
 { \
   nxagentSaveGCTrap = nxagentGCTrap;\
 \
-  nxagentGCTrap = True; \
+  nxagentGCTrap = 1; \
 }
 
 #define RESET_GC_TRAP() \
@@ -696,7 +696,7 @@ RegionPtr nxagentCopyArea(DrawablePtr pSrcDrawable, DrawablePtr pDstDrawable,
   }
 
 
-  if (nxagentGCTrap || nxagentShmTrap)
+  if (nxagentGCTrap == 1 || nxagentShmTrap == 1)
   {
     if (pSrcDrawable -> type == DRAWABLE_PIXMAP &&
             pDstDrawable -> type == DRAWABLE_PIXMAP)
@@ -730,7 +730,7 @@ RegionPtr nxagentCopyArea(DrawablePtr pSrcDrawable, DrawablePtr pDstDrawable,
    * to the check in Image.c, this is of little use.
    */
 
-  if (!nxagentOption(IgnoreVisibility) && pDstDrawable -> type == DRAWABLE_WINDOW &&
+  if (nxagentOption(IgnoreVisibility) == 0 && pDstDrawable -> type == DRAWABLE_WINDOW &&
           (nxagentWindowIsVisible((WindowPtr) pDstDrawable) == 0 ||
               (nxagentDefaultWindowIsVisible() == 0 && nxagentCompositeEnable == 0)))
   {
@@ -934,7 +934,7 @@ RegionPtr nxagentCopyPlane(DrawablePtr pSrcDrawable, DrawablePtr pDstDrawable,
                           (void *) pDstDrawable, srcx, srcy, dstx, dsty, width, height);
   #endif
 
-  if (nxagentGCTrap || nxagentShmTrap)
+  if (nxagentGCTrap == 1 || nxagentShmTrap == 1)
   {
     if (pSrcDrawable -> type == DRAWABLE_PIXMAP &&
             pDstDrawable -> type == DRAWABLE_PIXMAP)
@@ -1118,7 +1118,7 @@ void nxagentPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
               (void *) pDrawable, (void *) pGC, nPoints);
   #endif
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1175,7 +1175,7 @@ void nxagentPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode,
 void nxagentPolyLines(DrawablePtr pDrawable, GCPtr pGC, int mode,
                           int nPoints, xPoint *pPoints)
 {
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1248,7 +1248,7 @@ void nxagentPolySegment(DrawablePtr pDrawable, GCPtr pGC,
 
   #endif
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1325,7 +1325,7 @@ void nxagentPolyRectangle(DrawablePtr pDrawable, GCPtr pGC,
 
   #endif
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1390,7 +1390,7 @@ void nxagentPolyRectangle(DrawablePtr pDrawable, GCPtr pGC,
 void nxagentPolyArc(DrawablePtr pDrawable, GCPtr pGC,
                         int nArcs, xArc *pArcs)
 {
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1449,7 +1449,7 @@ void nxagentFillPolygon(DrawablePtr pDrawable, GCPtr pGC, int shape,
 {
   xPoint *newPoints = NULL;
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1571,7 +1571,7 @@ void nxagentPolyFillRect(DrawablePtr pDrawable, GCPtr pGC,
 
   #endif
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1719,7 +1719,7 @@ void nxagentPolyFillRect(DrawablePtr pDrawable, GCPtr pGC,
 void nxagentPolyFillArc(DrawablePtr pDrawable, GCPtr pGC,
                             int nArcs, xArc *pArcs)
 {
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1798,7 +1798,7 @@ int nxagentPolyText8(DrawablePtr pDrawable, GCPtr pGC, int x,
 
   width = XTextWidth(nxagentFontStruct(pGC->font), string, count);
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1871,7 +1871,7 @@ int nxagentPolyText16(DrawablePtr pDrawable, GCPtr pGC, int x,
 
   width = XTextWidth16(nxagentFontStruct(pGC->font), (XChar2b *)string, count);
 
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1930,7 +1930,7 @@ int nxagentPolyText16(DrawablePtr pDrawable, GCPtr pGC, int x,
 void nxagentImageText8(DrawablePtr pDrawable, GCPtr pGC, int x,
                            int y, int count, char *string)
 {
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {
@@ -1987,7 +1987,7 @@ void nxagentImageText8(DrawablePtr pDrawable, GCPtr pGC, int x,
 void nxagentImageText16(DrawablePtr pDrawable, GCPtr pGC, int x,
                             int y, int count, unsigned short *string)
 {
-  if (nxagentGCTrap)
+  if (nxagentGCTrap == 1)
   {
     if ((pDrawable)->type == DRAWABLE_PIXMAP)
     {

--- a/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
@@ -680,7 +680,7 @@ void nxagentWakeupHandler(void * data, int count, void * mask)
    * the session.
    */
 
-  if (nxagentOption(Xdmcp) && nxagentXdmcpUp == 0)
+  if (nxagentOption(Xdmcp) == 1 && nxagentXdmcpUp == 0)
   {
     #ifdef DEBUG
     fprintf(stderr, "nxagentWakeupHandler: XdmcpState [%d].\n", XdmcpState);

--- a/nx-X11/programs/Xserver/hw/nxagent/Image.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Image.c
@@ -428,7 +428,7 @@ FIXME: Here the split trap is always set and so the caching of
               resource, nxagentSplitTrap);
   #endif
 
-  if (nxagentSplitTrap || nxagentUnpackAlpha[resource] == NULL ||
+  if (nxagentSplitTrap == 1 || nxagentUnpackAlpha[resource] == NULL ||
           nxagentUnpackAlpha[resource] -> size != size ||
               memcmp(nxagentUnpackAlpha[resource] -> data, data, size) != 0)
   {
@@ -584,8 +584,8 @@ FIXME: Should use these.
   int framebuffer = 1;
   int realize     = 1;
 */
-  if (nxagentGCTrap && !nxagentReconnectTrap &&
-          !nxagentFBTrap && !nxagentShmTrap)
+  if (nxagentGCTrap == 1 && nxagentReconnectTrap == 0 &&
+          nxagentFBTrap == 0 && nxagentShmTrap == 0)
   {
     if (pDrawable -> type == DRAWABLE_PIXMAP)
     {
@@ -601,10 +601,11 @@ FIXME: Should use these.
     goto nxagentPutImageEnd;
   }
 
-  if (!nxagentReconnectTrap && !nxagentSplitTrap)
+  if (nxagentReconnectTrap == 0 &&
+          nxagentSplitTrap == 0)
   {
     if (pDrawable -> type == DRAWABLE_PIXMAP &&
-            !nxagentFBTrap && !nxagentShmTrap)
+            nxagentFBTrap == 0 && nxagentShmTrap == 0)
     {
       fbPutImage(nxagentVirtualDrawable(pDrawable), pGC, depth,
                      dstX, dstY, dstWidth, dstHeight, leftPad, format, data);
@@ -692,11 +693,11 @@ FIXME: Should use these.
 /*
 FIXME: Should we disable the split with link LAN?
 
-  split = (nxagentOption(Streaming) &&
+  split = (nxagentOption(Streaming) == 1 &&
                nxagentOption(LinkType) != LINK_TYPE_NONE &&
                    nxagentOption(LinkType) != LINK_TYPE_LAN
 */
-  split = (nxagentOption(Streaming) &&
+  split = (nxagentOption(Streaming) == 1 &&
                nxagentOption(LinkType) != LINK_TYPE_NONE
 /*
 FIXME: Do we stream the images from GLX or Xv? If we do that,
@@ -709,8 +710,8 @@ FIXME: Do we stream the images from GLX or Xv? If we do that,
 /*
 FIXME: Temporarily stream the GLX data.
 
-                           && !nxagentGlxTrap
-                               && !nxagentXvTrap
+                           && nxagentGlxTrap == 0
+                               && nxagentXvTrap == 0
 */
 );
 
@@ -719,11 +720,12 @@ FIXME: Temporarily stream the GLX data.
    * is less than 15.
    */
 
-  if (split == 1 && (nxagentSplitTrap || depth < 15))
+  if (split == 1 && (nxagentSplitTrap == 1 || depth < 15))
   {
     #ifdef TEST
 
-    if (nxagentSplitTrap || nxagentReconnectTrap)
+    if (nxagentSplitTrap == 1 ||
+            nxagentReconnectTrap == 1)
     {
       fprintf(stderr, "nxagentPutImage: Not splitting with reconnection [%d] trap [%d] "
                   "depth [%d].\n", nxagentSplitTrap, nxagentReconnectTrap, depth);
@@ -765,7 +767,7 @@ FIXME: Temporarily stream the GLX data.
    */
 
   if (nxagentOption(LinkType) != LINK_TYPE_NONE &&
-          (nxagentGlxTrap || nxagentXvTrap))
+          (nxagentGlxTrap == 1 || nxagentXvTrap == 1))
   {
     #ifdef TEST
     fprintf(stderr, "nxagentPutImage: Disabling the use of the cache with GLX or Xvideo.\n");
@@ -972,7 +974,7 @@ void nxagentRealizeImage(DrawablePtr pDrawable, GCPtr pGC, int depth,
 
   bytesPerLine = nxagentImagePad(w, format, leftPad, depth);
 
-  if (nxagentOption(Shadow) && format == ZPixmap &&
+  if (nxagentOption(Shadow) == 1 && format == ZPixmap &&
           (nxagentOption(XRatio) != DONT_SCALE ||
               nxagentOption(YRatio) != DONT_SCALE) &&
                   pDrawable == (DrawablePtr) nxagentShadowPixmapPtr)
@@ -1195,7 +1197,7 @@ FIXME: Should use an unpack resource here.
 
     if (w <= IMAGE_PACK_WIDTH || h <= IMAGE_PACK_HEIGHT ||
             nxagentImageLength(w, h, format, leftPad, depth) <=
-                IMAGE_PACK_LENGTH || nxagentLosslessTrap)
+                IMAGE_PACK_LENGTH || nxagentLosslessTrap == 1)
     {
       if (nxagentPackLossless == PACK_NONE)
       {
@@ -1271,8 +1273,8 @@ FIXME: Should try to locate the image anyway, if the lossless
        again using the preferred method.
 */
     if (nxagentNeedCache(plainImage, packMethod) &&
-            !nxagentGlxTrap && !nxagentXvTrap &&
-                !nxagentLosslessTrap && NXImageCacheSize > 0)
+            nxagentGlxTrap == 0 && nxagentXvTrap == 0 &&
+                nxagentLosslessTrap == 0 && NXImageCacheSize > 0)
     {
       /*
        * Be sure that the padding bits are
@@ -1339,7 +1341,7 @@ FIXME: There should be a callback registered by the agent that
      * compress better.
      */
 
-    if (lossless == 0 && nxagentOption(Adaptive))
+    if (lossless == 0 && nxagentOption(Adaptive) == 1)
     {
       int ratio = nxagentUniquePixels(plainImage);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -753,7 +753,7 @@ XkbError:
         fprintf(stderr, "nxagentKeyboardProc: nxagentKeyboard is [%s].\n", nxagentKeyboard ? nxagentKeyboard : "NULL");
         #endif
 
-        if (nxagentX2go && nxagentKeyboard && (strcmp(nxagentKeyboard, "null/null") == 0))
+        if (nxagentX2go == 1 && nxagentKeyboard && (strcmp(nxagentKeyboard, "null/null") == 0))
         {
           #ifdef TEST
           fprintf(stderr, "%s: changing nxagentKeyboard from [null/null] to [clone].\n", __func__);
@@ -873,7 +873,7 @@ XkbError:
              * instead of a file. Which is achieved by passing NULL to
              * nxagentWriteKeyboardFile.
              */
-            if (nxagentX2go)
+            if (nxagentX2go == 1)
               nxagentWriteKeyboardDir();
           }
           else
@@ -891,7 +891,7 @@ XkbError:
              * know about that yet. Once x2go starts using clone
              * we can drop this here.
              */
-            if (nxagentX2go)
+            if (nxagentX2go == 1)
               nxagentWriteKeyboardFile(nxagentRemoteRules, nxagentRemoteModel, nxagentRemoteLayout, nxagentRemoteVariant, nxagentRemoteOptions);
           }
         }
@@ -935,7 +935,7 @@ XkbError:
             XkbDDXChangeControls(pDev, xkb->ctrls, xkb->ctrls);
         }
 
-        if (nxagentOption(Shadow) && pDev && pDev->key)
+        if (nxagentOption(Shadow) == 1 && pDev && pDev->key)
         {
           NXShadowInitKeymap(&(pDev->key->curKeySyms));
         }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -326,7 +326,7 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
 
         clientReady[0] = 0;
 
-        if (nxagentSplashWindow != None || (nxagentOption(Xdmcp) && nxagentXdmcpUp == 0))
+        if (nxagentSplashWindow != None || (nxagentOption(Xdmcp) == 1 && nxagentXdmcpUp == 0))
         {
           #ifdef TEST
           fprintf(stderr, "******Dispatch: Requesting a timeout of [%d] Ms.\n",
@@ -339,7 +339,7 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
 
         if (serverGeneration > nxagentMaxAllowedResets &&
                 nxagentSessionState == SESSION_STARTING &&
-                    (!nxagentOption(Xdmcp) || nxagentXdmcpUp == 1))
+                    (nxagentOption(Xdmcp) == 0 || nxagentXdmcpUp == 1))
         {
           #ifdef NX_DEBUG_INPUT
           fprintf(stderr, "Session: Session started at '%s' timestamp [%lu].\n",
@@ -568,7 +568,7 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
       fprintf(stderr, "Session: Session terminated at '%s'.\n", GetTimeAsString());
     }
 
-    if (nxagentOption(Shadow))
+    if (nxagentOption(Shadow) == 1)
     {
       NXShadowDestroy();
     }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -199,7 +199,7 @@ ActivatePointerGrab(register DeviceIntPtr mouse, register GrabPtr grab,
      * }
      */
 
-    if (nxagentOption(Rootless))
+    if (nxagentOption(Rootless) == 1)
     {
       /*
        * FIXME: We should use the correct value
@@ -245,7 +245,7 @@ DeactivatePointerGrab(register DeviceIntPtr mouse)
 
     #ifdef NXAGENT_SERVER
 
-    if (nxagentOption(Rootless))
+    if (nxagentOption(Rootless) == 1)
     {
       XUngrabPointer(nxagentDisplay, CurrentTime);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
@@ -116,7 +116,7 @@ static int __glXDispatch(ClientPtr client)
      * dispatching a GLX operation.
      */
 
-    nxagentGlxTrap = True;
+    nxagentGlxTrap = 1;
 
     #ifdef TEST
     fprintf(stderr, "__glXDispatch: Going to dispatch GLX operation [%d] for client [%d].\n", 
@@ -125,7 +125,7 @@ static int __glXDispatch(ClientPtr client)
     
     retval = (*proc)(cl, (GLbyte *) stuff);
 
-    nxagentGlxTrap = False;
+    nxagentGlxTrap = 0;
 
     #ifdef TEST
     fprintf(stderr, "__glXDispatch: Dispatched GLX operation [%d] for client [%d].\n", 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXproperty.c
@@ -189,7 +189,7 @@ ProcChangeProperty(ClientPtr client)
 	return err;
     else
     {
-      if (nxagentOption(Rootless))
+      if (nxagentOption(Rootless) == 1)
       {
         nxagentExportProperty(pWin, stuff->property, stuff->type, (int) format,
                                   (int) mode, len, (void *) &stuff[1]);

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -1683,11 +1683,11 @@ ProcRenderDispatch (ClientPtr client)
          * avoid reentrancy in GCOps.c.
          */
 
-        nxagentGCTrap = True;
+        nxagentGCTrap = 1;
 
         result = (*ProcRenderVector[stuff->data]) (client);
 
-        nxagentGCTrap = False;
+        nxagentGCTrap = 0;
 
         return result;
     }
@@ -1720,11 +1720,11 @@ SProcRenderDispatch (ClientPtr client)
          * avoid reentrancy in GCOps.c.
          */
 
-        nxagentGCTrap = True;
+        nxagentGCTrap = 1;
 
         result = (*SProcRenderVector[stuff->data]) (client);
 
-        nxagentGCTrap = False;
+        nxagentGCTrap = 0;
 
         return result;
     }

--- a/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXshm.c
@@ -96,7 +96,7 @@ ShmExtensionInit(void)
 #endif
 
 #ifdef NXAGENT_SERVER
-    if (!nxagentOption(SharedMemory))
+    if (nxagentOption(SharedMemory) == False)
     {
       return;
     }
@@ -207,11 +207,11 @@ miShmPutImage(dst, pGC, depth, format, w, h, sx, sy, sw, sh, dx, dy, data)
 {
     /* Careful! This wrapper DEACTIVATES the trap! */
 
-    nxagentShmTrap = False;
+    nxagentShmTrap = 0;
 
     nxagent_miShmPutImage(dst, pGC, depth, format, w, h, sx, sy, sw, sh, dx, dy, data);
 
-    nxagentShmTrap = True;
+    nxagentShmTrap = 1;
 
     return;
 }
@@ -476,11 +476,11 @@ fbShmCreatePixmap (pScreen, width, height, depth, addr)
 {
     PixmapPtr result;
 
-    nxagentShmPixmapTrap = True;
+    nxagentShmPixmapTrap = 1;
 
     result = nxagent_fbShmCreatePixmap(pScreen, width, height, depth, addr);
 
-    nxagentShmPixmapTrap = False;
+    nxagentShmPixmapTrap = 0;
 
     return result;
 }
@@ -553,11 +553,11 @@ ProcShmDispatch (register ClientPtr client)
 {
     int result;
 
-    nxagentShmTrap = True;
+    nxagentShmTrap = 1;
 
     result = nxagent_ProcShmDispatch(client);
 
-    nxagentShmTrap = False;
+    nxagentShmTrap = 0;
 
     return result;
 }
@@ -591,13 +591,13 @@ SProcShmDispatch (client)
         #endif
 
 #ifdef NXAGENT_SERVER
-        nxagentShmTrap = True;
+        nxagentShmTrap = 1;
 #endif
 
         result = SProcShmPutImage(client);
 
 #ifdef NXAGENT_SERVER
-        nxagentShmTrap = False;
+        nxagentShmTrap = 0;
 #endif
 
         #ifdef TEST

--- a/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXwindow.c
@@ -561,7 +561,7 @@ ConfigureWindow(register WindowPtr pWin, register Mask mask, XID *vlist, ClientP
 
     if (nxagentOption(Rootless) && nxagentWindowTopLevel(pWin) &&
             pWin -> overrideRedirect == 0 &&
-                !nxagentScreenTrap)
+                nxagentScreenTrap == 0)
     {
       nxagentConfigureRootlessWindow(pWin, x, y, w, h, bw, pSib, smode, mask);
 

--- a/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
@@ -162,11 +162,11 @@ ProcXvDispatch(ClientPtr client)
               stuff->data, client -> index);
   #endif
 
-  nxagentXvTrap = True;
+  nxagentXvTrap = 1;
 
   result = nxagent_ProcXvDispatch(client);
 
-  nxagentXvTrap = False;
+  nxagentXvTrap = 0;
 
   #ifdef TEST
   fprintf(stderr, "ProcXvDispatch: Dispatched XVideo operation [%d] for client [%d].\n",
@@ -239,11 +239,11 @@ SProcXvDispatch(ClientPtr client)
               stuff->data, client -> index);
   #endif
 
-  nxagentXvTrap = True;
+  nxagentXvTrap = 1;
 
   result = nxagent_SProcXvDispatch(client);
 
-  nxagentXvTrap = False;
+  nxagentXvTrap = 0;
 
   #ifdef TEST
   fprintf(stderr, "SProcXvDispatch: Dispatched XVideo operation [%d] for client [%d].\n",

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixels.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixels.h
@@ -145,7 +145,7 @@ FIXME: Changed macro: NXAGENT_SHOULD_DEFER_COMPOSITE
 
 
 #define NXAGENT_SHOULD_DEFER_PUTIMAGE(pDrawable) \
-    (!nxagentSplitTrap &&                    \
+    (nxagentSplitTrap == 0 &&                    \
          nxagentOption(DeferLevel) > 0)
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
@@ -217,7 +217,7 @@ PixmapPtr nxagentCreatePixmap(ScreenPtr pScreen, int width, int height,
    * id of the drawable in the checksum.
    */
 
-  if (width != 0 && height != 0 && !nxagentGCTrap)
+  if (width != 0 && height != 0 && nxagentGCTrap == 0)
   {
     pPixmapPriv -> id = XCreatePixmap(nxagentDisplay,
                                       nxagentDefaultWindows[pScreen -> myNum],
@@ -348,7 +348,7 @@ PixmapPtr nxagentCreatePixmap(ScreenPtr pScreen, int width, int height,
       fprintf(stderr, "Warning: Disabling render extension due to missing pixmap format.\n");
       #endif
 
-      nxagentRenderTrap = True;
+      nxagentRenderTrap = 1;
     }
 
     nxagentDestroyPixmap(pPixmap);
@@ -923,11 +923,11 @@ void nxagentReconnectPixmap(void *p0, XID x1, void *p2)
       return;
     }
 
-    nxagentSplitTrap = True;
+    nxagentSplitTrap = 1;
 
     *pBool = nxagentSynchronizeDrawableData((DrawablePtr) pPixmap, NEVER_BREAK, NULL);
 
-    nxagentSplitTrap = False;
+    nxagentSplitTrap = 0;
 
     if (!*pBool)
     {
@@ -1256,11 +1256,11 @@ void nxagentSynchronizeShmPixmap(DrawablePtr pDrawable, int xPict, int yPict,
 
     saveTrap = nxagentGCTrap;
 
-    nxagentGCTrap = False;
+    nxagentGCTrap = 0;
 
-    nxagentSplitTrap = True;
+    nxagentSplitTrap = 1;
 
-    nxagentFBTrap = True;
+    nxagentFBTrap = 1;
 
     if ((data = malloc(length)) != NULL)
     {
@@ -1281,9 +1281,9 @@ void nxagentSynchronizeShmPixmap(DrawablePtr pDrawable, int xPict, int yPict,
 
     nxagentGCTrap = saveTrap;
 
-    nxagentSplitTrap = False;
+    nxagentSplitTrap = 0;
 
-    nxagentFBTrap = False;
+    nxagentFBTrap = 0;
 
     nxagentFreeScratchGC(pGC);
   }

--- a/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
@@ -85,7 +85,7 @@ void nxagentChangePointerControl(DeviceIntPtr pDev, PtrCtrl *ctrl)
    * window.
    */
 
-  if (nxagentOption(DeviceControl))
+  if (nxagentOption(DeviceControl) == True)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentChangePointerControl: WARNING! Propagating changes to pointer settings.\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Reconnect.c
@@ -240,7 +240,7 @@ TODO: This should be reset only when
 */
     nxagentException.ioError = 0;
 
-    if (nxagentOption(Persistent) && nxagentSessionState != SESSION_STARTING)
+    if (nxagentOption(Persistent) == 1 && nxagentSessionState != SESSION_STARTING)
     {
       if (nxagentSessionState == SESSION_UP)
       {
@@ -338,7 +338,7 @@ void nxagentInitializeRecLossyLevel(void)
 
 void nxagentInitReconnector(void)
 {
-  nxagentReconnectTrap = False;
+  nxagentReconnectTrap = 0;
 
   reconnectLossyLevel[DISPLAY_STEP]    = malloc(sizeof(int));
   reconnectLossyLevel[SCREEN_STEP]     = malloc(sizeof(int));
@@ -608,8 +608,8 @@ Bool nxagentReconnectSession(void)
     nxagentOldKeyboard = NULL;
   }
 
-  if (nxagentOption(ResetKeyboardAtResume) &&
-         (nxagentKeyboard == NULL || nxagentOldKeyboard == NULL ||
+  if (nxagentOption(ResetKeyboardAtResume) == 1 &&
+         (nxagentKeyboard  == NULL || nxagentOldKeyboard == NULL ||
              strcmp(nxagentKeyboard, nxagentOldKeyboard) != 0 ||
                  strcmp(nxagentKeyboard, "query") == 0 ||
                      strcmp(nxagentKeyboard, "clone") == 0))
@@ -648,7 +648,7 @@ Bool nxagentReconnectSession(void)
 
   nxagentRedirectDefaultWindows();
 
-  if (nxagentResizeDesktopAtStartup || nxagentOption(Rootless) || nxagentOption(Xinerama))
+  if (nxagentResizeDesktopAtStartup || nxagentOption(Rootless) == True || nxagentOption(Xinerama) == True)
   {
     nxagentChangeScreenConfig(0, nxagentOption(RootWidth),
                                   nxagentOption(RootHeight));

--- a/nx-X11/programs/Xserver/hw/nxagent/Render.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Render.c
@@ -569,11 +569,11 @@ int nxagentRenderRealizeCursor(ScreenPtr pScreen, CursorPtr pCursor)
 
   nxagentMarkCorruptedRegion(pPicture -> pDrawable, NULL);
 
-  nxagentLosslessTrap = True;
+  nxagentLosslessTrap = 1;
 
   nxagentSynchronizeDrawable(pPicture -> pDrawable, DO_WAIT, NEVER_BREAK, NULL);
 
-  nxagentLosslessTrap = False;
+  nxagentLosslessTrap = 0;
 
   cid = XRenderCreateCursor(nxagentDisplay, nxagentPicture(pPicture), x, y);
 
@@ -2741,7 +2741,7 @@ void nxagentReconnectGlyphSet(void* p0, XID x1, void *p2)
 
   int i;
 
-  if (!nxagentReconnectTrap)
+  if (nxagentReconnectTrap == 0)
   {
     #ifdef DEBUG
     fprintf(stderr, "nxagentReconnectGlyphSet: GlyphSet at [%p].\n", (void *) pGly);

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -373,9 +373,9 @@ void nxagentRootlessRestack(unsigned long children[], unsigned int nchildren)
       mask = CWSibling | CWStackMode;
       values[0] = pWin -> drawable.id;
       pClient = wClient(toplevel[ntoplevel]);
-      nxagentScreenTrap = True;
+      nxagentScreenTrap = 1;
       ConfigureWindow(toplevel[ntoplevel], mask, (XID *) values, pClient);
-      nxagentScreenTrap = False;
+      nxagentScreenTrap = 0;
 
       #ifdef TEST
       fprintf(stderr, "nxagentRootlessRestack: Restacked window [%p].\n", (void*) toplevel[ntoplevel]);

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -596,7 +596,7 @@ FIXME: Do we need to check the key grab if the
 
         raise(SIGTERM);
       }
-      else if (!nxagentOption(Persistent))
+      else if (nxagentOption(Persistent) == 0)
       {
         fprintf(stderr, "Info: Terminating session with persistence not allowed.\n");
 
@@ -871,7 +871,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
               pScreen->myNum);
   #endif
 
-  if (nxagentRenderEnable && !nxagentReconnectTrap)
+  if (nxagentRenderEnable && nxagentReconnectTrap == False)
   {
     PictureScreenPrivateIndex = -1;
   }
@@ -926,7 +926,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
    * user geometry then.
    */
 
-  if (!nxagentReconnectTrap && !nxagentOption(Rootless))
+  if (nxagentReconnectTrap == False && !nxagentOption(Rootless))
   {
     if (nxagentUserGeometry.flag & XValue)
     {
@@ -970,7 +970,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
    * the screen if we are either in rootless or in fullscreen mode.
    */
 
-  if (!nxagentOption(Rootless) && !nxagentWMIsRunning)
+  if (nxagentOption(Rootless) == False && !nxagentWMIsRunning)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentOpenScreen: Forcing fullscreen mode with no window manager running.\n");
@@ -979,7 +979,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
     nxagentChangeOption(Fullscreen, True);
 
     if (nxagentOption(ClientOs) == ClientOsWinnt &&
-            (!nxagentReconnectTrap || nxagentResizeDesktopAtStartup))
+            (nxagentReconnectTrap == False || nxagentResizeDesktopAtStartup))
     {
       NXSetExposeParameters(nxagentDisplay, 0, 0, 0);
     }
@@ -988,7 +988,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
   if (nxagentOption(Fullscreen) &&
           nxagentWMIsRunning &&
               nxagentReconnectTrap &&
-                  !nxagentResizeDesktopAtStartup &&
+                  nxagentResizeDesktopAtStartup == False &&
                       nxagentXServerGeometryChanged())
   {
     #ifdef TEST
@@ -1019,7 +1019,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
     nxagentChangeOption(Height, h);
 
     /* first time screen initialization or resize during reconnect */
-    if (!nxagentReconnectTrap || nxagentResizeDesktopAtStartup)
+    if (nxagentReconnectTrap == False || nxagentResizeDesktopAtStartup)
     {
       if (nxagentOption(RootWidth) >= w)
       {
@@ -1072,7 +1072,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
      * screen is initialized for the first time.
      */
 
-    if (!nxagentReconnectTrap)
+    if (nxagentReconnectTrap == False)
     {
       nxagentChangeOption(RootX, 0);
       nxagentChangeOption(RootY, 0);
@@ -1111,7 +1111,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
      * the root window isn't bigger than the X server root window..
      */
 
-    if (!nxagentReconnectTrap)
+    if (nxagentReconnectTrap == False)
     {
       if ((nxagentOption(RootWidth) < w) &&
               !(nxagentUserGeometry.flag & WidthValue))
@@ -1143,7 +1143,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
   nxagentChangeOption(ViewportXSpan, nxagentOption(Width) - nxagentOption(RootWidth));
   nxagentChangeOption(ViewportYSpan, nxagentOption(Height) - nxagentOption(RootHeight));
 
-  if (!nxagentReconnectTrap)
+  if (nxagentReconnectTrap == 0)
   {
     if (nxagentOption(Persistent))
     {
@@ -1344,11 +1344,11 @@ Bool nxagentOpenScreen(ScreenPtr pScreen,
                   rootDepth, (long unsigned int)defaultVisual);
     #endif
 
-    if ((monitorResolution < 1) && !nxagentAutoDPI)
+    if ((monitorResolution < 1) && (nxagentAutoDPI == False))
     {
       monitorResolution = NXAGENT_DEFAULT_DPI;
     }
-    else if ((monitorResolution < 1) && nxagentAutoDPI)
+    else if ((monitorResolution < 1) && (nxagentAutoDPI == True))
     {
       monitorResolution = NXAGENT_AUTO_DPI;
     }
@@ -1699,21 +1699,21 @@ N/A
   #endif
 
   if (nxagentDoFullGeneration == 1 ||
-          nxagentReconnectTrap)
+          nxagentReconnectTrap == 1)
   {
     valuemask = CWBackPixel | CWEventMask | CWColormap |
-                    (nxagentOption(AllScreens) ? CWOverrideRedirect : 0);
+                    (nxagentOption(AllScreens) == 1 ? CWOverrideRedirect : 0);
 
     attributes.background_pixel = nxagentBlackPixel;
     attributes.event_mask = nxagentGetDefaultEventMask();
     attributes.colormap = nxagentDefaultVisualColormap(nxagentDefaultVisual(pScreen));
 
-    if (nxagentOption(AllScreens))
+    if (nxagentOption(AllScreens) == 1)
     {
       attributes.override_redirect = True;
     }
 
-    if (nxagentOption(Fullscreen))
+    if (nxagentOption(Fullscreen) == 1)
     {
       if (nxagentReconnectTrap)
       {
@@ -1749,7 +1749,7 @@ N/A
        * handling the splash screen.
        */
 
-      if (nxagentOption(Rootless))
+      if (nxagentOption(Rootless) == True)
       {
         nxagentDefaultWindows[pScreen->myNum] = DefaultRootWindow(nxagentDisplay);
 
@@ -1776,7 +1776,7 @@ N/A
                         nxagentDefaultVisual(pScreen),
                         valuemask, &attributes);
 
-       if (!nxagentOption(Rootless))
+       if (nxagentOption(Rootless) == 0)
        {
          valuemask = CWEventMask;
          mask = PointerMotionMask;
@@ -1884,7 +1884,7 @@ N/A
       sizeHints->width = nxagentOption(RootWidth);
       sizeHints->height = nxagentOption(RootHeight);
 
-      if (nxagentOption(DesktopResize) || nxagentOption(Fullscreen))
+      if (nxagentOption(DesktopResize) == 1 || nxagentOption(Fullscreen) == 1)
       {
         sizeHints->max_width = WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay));
         sizeHints->max_height = HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay));
@@ -2000,7 +2000,7 @@ N/A
 
     /* FIXME: This doing the same thing in both cases. The
        comments do not seem accurate (anymore?) */
-    if (!nxagentOption(Rootless))
+    if (nxagentOption(Rootless) == False)
     {
       /*
        * Set the WM_DELETE_WINDOW protocol for the main agent
@@ -2049,7 +2049,7 @@ N/A
    * and pointer settings.
    */
 
-  if (!nxagentOption(DeviceControl))
+  if (nxagentOption(DeviceControl) == False)
   {
     fprintf(stderr, "Info: Not using local device configuration changes.\n");
   }
@@ -2428,13 +2428,13 @@ FIXME: We should try to restore the previously
    * Change agent window size and size hints.
    */
 
-  if (!nxagentOption(Fullscreen) && !nxagentOption(AllScreens))
+  if ((nxagentOption(Fullscreen) == 0 && nxagentOption(AllScreens) == 0))
   {
     nxagentSetWMNormalHints(pScreen->myNum, width, height);
 
     XResizeWindow(nxagentDisplay, nxagentDefaultWindows[pScreen->myNum], width, height);
 
-    if (!nxagentOption(Rootless))
+    if (nxagentOption(Rootless) == 0)
     {
       XResizeWindow(nxagentDisplay, nxagentInputWindows[pScreen -> myNum], width, height);
     }
@@ -2589,7 +2589,7 @@ int nxagentShadowInit(ScreenPtr pScreen, WindowPtr pWin)
     NXShadowSetDisplayUid(nxagentShadowUid);
   }
 
-  if (!nxagentOption(UseDamage))
+  if (nxagentOption(UseDamage) == 0)
   {
     NXShadowDisableDamage();
   }
@@ -2634,7 +2634,7 @@ int nxagentShadowInit(ScreenPtr pScreen, WindowPtr pWin)
 
   #ifndef __CYGWIN32__
 
-  if (nxagentOption(Fullscreen))
+  if (nxagentOption(Fullscreen) == 1)
   {
     nxagentShadowSetRatio(WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay)) * 1.0 / nxagentShadowWidth,
                               HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay)) * 1.0 / nxagentShadowHeight);
@@ -4571,7 +4571,7 @@ void nxagentSetWMNormalHints(int screen, int width, int height)
   sizeHints->width = width;
   sizeHints->height = height;
 
-  if (nxagentOption(DesktopResize))
+  if (nxagentOption(DesktopResize) == 1)
   {
     sizeHints->max_width = WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay));
     sizeHints->max_height = HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay));

--- a/nx-X11/programs/Xserver/hw/nxagent/Trap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Trap.c
@@ -31,7 +31,7 @@
  * reentrancy in GC operations.
  */
 
-int nxagentGCTrap = False;
+int nxagentGCTrap = 0;
 
 /*
  * Set if we are enqueing an internal
@@ -39,14 +39,14 @@ int nxagentGCTrap = False;
  * Window. Used to remove any screen operation.
  */
 
-int nxagentScreenTrap = False;
+int nxagentScreenTrap = 0;
 
 /*
  * Set if we detected that our RENDER
  * implementation is faulty.
  */
 
-int nxagentRenderTrap = False;
+int nxagentRenderTrap = 0;
 
 /*
  * Set if we are executing a GC operation
@@ -54,55 +54,55 @@ int nxagentRenderTrap = False;
  * reentrancy in FB layer.
  */
 
-int nxagentFBTrap = False;
+int nxagentFBTrap = 0;
 
 /*
  * Set if we are dispatching a shared
  * memory extension request.
  */
 
-int nxagentShmTrap = False;
+int nxagentShmTrap = 0;
 
 /*
  * Set if a shared pixmap operation is
  * requested by the client.
  */
 
-int nxagentShmPixmapTrap = False;
+int nxagentShmPixmapTrap = 0;
 
 /*
  * Set if we are dispatching a XVideo
  * extension request.
  */
 
-int nxagentXvTrap = False;
+int nxagentXvTrap = 0;
 
 /*
  * Set if we are dispatching a GLX
  * extension request.
  */
 
-int nxagentGlxTrap = False;
+int nxagentGlxTrap = 0;
 
 /*
  * Set while we are resuming the session.
  */
 
-int nxagentReconnectTrap = False;
+int nxagentReconnectTrap = 0;
 
 /*
  * Set if we need to realize a drawable
  * by using a lossless encoding.
  */
 
-int nxagentLosslessTrap = False;
+int nxagentLosslessTrap = 0;
 
 /*
  * Set to force the synchronization of
  * a drawable.
  */
 
-int nxagentSplitTrap = False;
+int nxagentSplitTrap = 0;
 
 /*
  * Set to avoid CapsLock synchronization
@@ -110,7 +110,7 @@ int nxagentSplitTrap = False;
  * key to be pressed in the session.
  */
 
-int nxagentXkbCapsTrap = False;
+int nxagentXkbCapsTrap = 0;
 
 /*
  * Set to avoid NumLock synchronization
@@ -118,5 +118,5 @@ int nxagentXkbCapsTrap = False;
  * key to be pressed in the session.
  */
 
-int nxagentXkbNumTrap = False;
+int nxagentXkbNumTrap = 0;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Trap.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Trap.h
@@ -26,14 +26,6 @@
 #ifndef __Traps_H__
 #define __Traps_H__
 
-#ifndef True
-# define True 1
-#endif
-
-#ifndef False
-# define False 0
-#endif
-
 /*
  * Set if we are dispatching a render
  * extension request. Used to avoid

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -397,7 +397,7 @@ Bool nxagentCreateWindow(WindowPtr pWin)
   nxagentWindowPriv(pWin) -> corruptedTimestamp = 0;
   nxagentWindowPriv(pWin) -> splitResource = NULL;
 
-  if (nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == 1)
   {
     if (pWin != nxagentRootlessWindow)
     {
@@ -557,7 +557,7 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
 {
   nxagentPrivWindowPtr pWindowPriv;
 
-  if (nxagentScreenTrap)
+  if (nxagentScreenTrap == 1)
   {
     return 1;
   }
@@ -685,7 +685,7 @@ Bool nxagentDestroyWindow(WindowPtr pWin)
 
 Bool nxagentPositionWindow(WindowPtr pWin, int x, int y)
 {
-  if (nxagentScreenTrap)
+  if (nxagentScreenTrap == 1)
   {
     return True;
   }
@@ -703,7 +703,7 @@ Bool nxagentPositionWindow(WindowPtr pWin, int x, int y)
 
 void nxagentRestackWindow(WindowPtr pWin, WindowPtr pOldNextSib)
 {
-  if (nxagentScreenTrap)
+  if (nxagentScreenTrap == 1)
   {
     return;
   }
@@ -713,7 +713,7 @@ void nxagentRestackWindow(WindowPtr pWin, WindowPtr pOldNextSib)
 
 void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
 {
-  if (nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == 1)
   {
     return;
   }
@@ -908,9 +908,9 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
       XCheckTypedWindowEvent(nxagentDisplay, w, LeaveNotify, &e);
       nxagentFullscreenWindow = w;
 
-      if (nxagentOption(DesktopResize))
+      if (nxagentOption(DesktopResize) == 1)
       {
-        if (!nxagentOption(Shadow))
+        if (nxagentOption(Shadow) == 0)
         {
           nxagentChangeScreenConfig(0, WidthOfScreen(DefaultScreenOfDisplay(nxagentDisplay)),
                                         HeightOfScreen(DefaultScreenOfDisplay(nxagentDisplay)));
@@ -959,12 +959,12 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
     nxagentIconWindow = nxagentFullscreenWindow = None;
 
-    if (nxagentOption(DesktopResize))
+    if (nxagentOption(DesktopResize) == 1)
     {
       nxagentChangeOption(RootWidth, nxagentOption(SavedRootWidth));
       nxagentChangeOption(RootHeight, nxagentOption(SavedRootHeight));
 
-      if (!nxagentOption(Shadow))
+      if (nxagentOption(Shadow) == 0)
       {
         nxagentChangeScreenConfig(0, nxagentOption(RootWidth),
                                       nxagentOption(RootHeight));
@@ -985,7 +985,7 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
     nxagentChangeOption(Width, nxagentOption(SavedWidth));
     nxagentChangeOption(Height, nxagentOption(SavedHeight));
 
-    if (nxagentOption(Shadow) && nxagentOption(DesktopResize))
+    if (nxagentOption(Shadow) == 1 && nxagentOption(DesktopResize) == 1)
     {
       nxagentShadowAdaptToRatio();
     }
@@ -1225,7 +1225,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
   int offX = nxagentWindowPriv(pWin)->x - pWin->origin.x;
   int offY = nxagentWindowPriv(pWin)->y - pWin->origin.y;
 
-  if (nxagentScreenTrap)
+  if (nxagentScreenTrap == 1)
   {
     #ifdef TEST
     fprintf(stderr, "nxagentConfigureWindow: WARNING: Called with the screen trap set.\n");
@@ -1234,7 +1234,7 @@ void nxagentConfigureWindow(WindowPtr pWin, unsigned int mask)
     return;
   }
 
-  if (nxagentOption(Rootless) &&
+  if (nxagentOption(Rootless) == 1 &&
           nxagentWindowTopLevel(pWin) == 1)
   {
     mask &= ~(CWSibling | CWStackMode);
@@ -1836,7 +1836,7 @@ void nxagentSetWMState(WindowPtr pWin, CARD32 desired)
 
 Bool nxagentRealizeWindow(WindowPtr pWin)
 {
-  if (nxagentScreenTrap)
+  if (nxagentScreenTrap == 1)
   {
     return True;
   }
@@ -2427,7 +2427,7 @@ void nxagentRefreshWindows(WindowPtr pWin)
 
 void nxagentUnmapWindows(void)
 {
-  if (nxagentOption(Fullscreen))
+  if (nxagentOption(Fullscreen) == 1)
   {
     for (int i = 0; i < screenInfo.numScreens; i++)
     {
@@ -2450,7 +2450,7 @@ void nxagentMapDefaultWindows(void)
 
     MapWindow(pWin, serverClient);
 
-    if (!nxagentOption(Rootless))
+    if (nxagentOption(Rootless) == 0)
     {
       /*
        * Show the NX splash screen.
@@ -2470,7 +2470,7 @@ void nxagentMapDefaultWindows(void)
        * Windows client.
        */
 
-      if (!nxagentOption(Shadow) || !nxagentWMIsRunning)
+      if (nxagentOption(Shadow) == 0 || !nxagentWMIsRunning)
       {
         #ifdef TEST
         fprintf(stderr, "nxagentMapDefaultWindows: Mapping default window id [%ld].\n",
@@ -2479,7 +2479,7 @@ void nxagentMapDefaultWindows(void)
 
         XMapWindow(nxagentDisplay, nxagentDefaultWindows[pScreen->myNum]);
 
-        if (nxagentOption(Fullscreen) && nxagentWMIsRunning)
+        if (nxagentOption(Fullscreen) == 1 && nxagentWMIsRunning)
         {
           nxagentMaximizeToFullScreen(pScreen);
         }
@@ -2497,7 +2497,7 @@ void nxagentMapDefaultWindows(void)
        * after the Root Window is mapped.
        */
 
-      if (!nxagentReconnectTrap)
+      if (nxagentReconnectTrap == 0)
       {
         XRaiseWindow(nxagentDisplay, nxagentInputWindows[pScreen->myNum]);
       }
@@ -2693,7 +2693,7 @@ Bool nxagentReconnectAllWindows(void *p0)
    * Windows is raised.
    */
 
-  if (!nxagentOption(Rootless))
+  if (nxagentOption(Rootless) == 0)
   {
     for (int i = 0; i < screenInfo.numScreens; i++)
     {
@@ -3196,7 +3196,7 @@ XXX: This would break Motif menus.
       XIconifyWindow(nxagentDisplay, nxagentWindow(pWin), pWin -> drawable.pScreen -> myNum);
     }
   }
-  else if (!nxagentOption(Rootless))
+  else if (nxagentOption(Rootless) == 0)
   {
     /*
      * Map the root window.


### PR DESCRIPTION
This reverts commit 16cd2bbe1c4425e3fa557f9ca0723aa94a50b071.

It turned out that I had missed some of the Booleans being actually
tristate variables. I think I can fix this (they do not need to be
tristate) but I revert this for now to get back to a working state
(there are reports about non-working fullscreen mode and reconnect
problems).