### PR TITLE
keystrokes.cfg: Add missing Shift=1 for viewport_move_up/down/right

### DIFF
--- a/etc/keystrokes.cfg
+++ b/etc/keystrokes.cfg
@@ -10,12 +10,12 @@
 <keystroke action="resize" Control="1" AltMeta="1" key="r" />
 <keystroke action="viewport_move_left" Control="1" Shift="1" AltMeta="1" key="Left" />
 <keystroke action="viewport_move_left" Control="1" Shift="1" AltMeta="1" key="KP_Left" />
-<keystroke action="viewport_move_up" Control="1" AltMeta="1" key="Up" />
-<keystroke action="viewport_move_up" Control="1" AltMeta="1" key="KP_Up" />
-<keystroke action="viewport_move_right" Control="1" AltMeta="1" key="Right" />
-<keystroke action="viewport_move_right" Control="1" AltMeta="1" key="KP_Right" />
-<keystroke action="viewport_move_down" Control="1" AltMeta="1" key="Down" />
-<keystroke action="viewport_move_down" Control="1" AltMeta="1" key="KP_Down" />
+<keystroke action="viewport_move_up" Control="1" Shift="1" AltMeta="1" key="Up" />
+<keystroke action="viewport_move_up" Control="1" Shift="1" AltMeta="1" key="KP_Up" />
+<keystroke action="viewport_move_right" Control="1" Shift="1" AltMeta="1" key="Right" />
+<keystroke action="viewport_move_right" Control="1" Shift="1" AltMeta="1" key="KP_Right" />
+<keystroke action="viewport_move_down" Control="1" Shift="1" AltMeta="1" key="Down" />
+<keystroke action="viewport_move_down" Control="1" Shift="1" AltMeta="1" key="KP_Down" />
 <keystroke action="viewport_scroll_left" Control="1" AltMeta="1" key="Left" />
 <keystroke action="viewport_scroll_left" Control="1" AltMeta="1" key="KP_Left" />
 <keystroke action="viewport_scroll_up" Control="1" AltMeta="1" key="Up" />


### PR DESCRIPTION
These keystrokes where the same as their viewport_scroll variants and made
the latter being disabled.

Fixes ArcticaProject/nx-libs#770