### PR TITLE
travis.yml: Update clang 7.0 => 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,10 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-7
+            - llvm-toolchain-xenial-8
             - ubuntu-toolchain-r-test
           packages:
-            - clang-7
+            - clang-8
             # imake
             - xutils-dev
             # X11 libaries
@@ -109,7 +109,7 @@ matrix:
             - x11-xkb-utils
 
       env:
-        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
         - STATIC_ANALYSIS="no"
 
 before_install:


### PR DESCRIPTION
Hi @sunweaver,

This is a trivial update for TravisCI, from clang 7.0 to 8.0.