### PR TITLE
Remove Debian build references to `xtestext1.h`

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -2246,35 +2246,6 @@ Copyright: 1989, 1998, The Open Group
   1996, 1998, The Open Group
 License: MIT~OpenGroup
 
-Files: nx-X11/include/extensions/xtestext1.h
- nx-X11/programs/Xserver/Xext/xtest1dd.c
- nx-X11/programs/Xserver/Xext/xtest1di.c
-Copyright: 1986-1988, 1998, The Open Group
-  1986-1988, Hewlett-Packard Corporation
-License: MIT~OpenGroup
-Comment:
- Contributions by Hewlett-Packard Corporation have been licensed
- under the following license:
- .
- Permission to use, copy, modify, and distribute this
- software and its documentation for any purpose and without
- fee is hereby granted, provided that the above copyright
- notice appear in all copies and that both that copyright
- notice and this permission notice appear in supporting
- documentation, and that the name of Hewlett-Packard not be used in
- advertising or publicity pertaining to distribution of the
- software without specific, written prior permission.
- .
- Hewlett-Packard makes no representations about the
- suitability of this software for any purpose.  It is provided
- "as is" without express or implied warranty.
- .
- As additional note, we find:
- .
- This software is not subject to any license of the American
- Telephone and Telegraph Company or of the Regents of the
- University of California.
-
 Files: nx-X11/programs/Xserver/hw/nxagent/NXdamage.c
  nx-X11/programs/Xserver/randr/rrmode.c
  nx-X11/programs/Xserver/randr/rrscreen.c

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -2122,15 +2122,6 @@ Copyright: 1992, X Consortium
 License: MIT/X11 (BSD like)
  FIXME
 
-Files: nx-X11/include/extensions/xtestext1.h
- nx-X11/programs/Xserver/Xext/xtest1dd.c
- nx-X11/programs/Xserver/Xext/xtest1di.c
- nx-X11/programs/Xserver/mi/mibstore.c
-Copyright: 1986-1988, 1998, The Open Group
-  1987, 1998, The Open Group
-License: NTP
- FIXME
-
 Files: nx-X11/programs/Xserver/miext/cw/cw.c
  nx-X11/programs/Xserver/miext/cw/cw.h
  nx-X11/programs/Xserver/miext/cw/cw_ops.c

--- a/debian/nx-x11proto-xext-dev.install
+++ b/debian/nx-x11proto-xext-dev.install
@@ -12,5 +12,4 @@ usr/include/*/nx-X11/extensions/xcmiscstr.h
 usr/include/*/nx-X11/extensions/xf86bigfont.h
 usr/include/*/nx-X11/extensions/xf86bigfproto.h
 usr/include/*/nx-X11/extensions/xtestconst.h
-usr/include/*/nx-X11/extensions/xtestext1.h
 usr/include/*/nx-X11/extensions/xteststr.h

--- a/nx-libs.spec
+++ b/nx-libs.spec
@@ -598,7 +598,6 @@ rm -f %{buildroot}%{_datadir}/man/man1/nxdialog.1*
 %{_includedir}/nx-X11/extensions/xfixesproto.h
 %{_includedir}/nx-X11/extensions/xfixeswire.h
 %{_includedir}/nx-X11/extensions/xtestconst.h
-%{_includedir}/nx-X11/extensions/xtestext1.h
 %{_includedir}/nx-X11/extensions/xteststr.h
 
 %files -n nxagent


### PR DESCRIPTION
This file has been deleted, but references to it in the build remain, causing `debuild` to fail.