### PR TITLE
Fix NXevents.c: Reactivate errornously commented function

### DIFF
--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -245,6 +245,8 @@ static WindowPtr XYToWindow(
     int y
 );
 
+static Bool CheckMotion(xEvent *xE);
+
 extern int lastEvent;
 
 static Mask lastEventMask;
@@ -1951,6 +1953,7 @@ XYToWindow(int x, int y)
 }
 #endif /* NXAGENT_SERVER */
 
+#ifndef NXAGENT_SERVER
 static Bool
 CheckMotion(xEvent *xE)
 {
@@ -2015,6 +2018,7 @@ CheckMotion(xEvent *xE)
     }
     return TRUE;
 }
+#endif /* NXAGENT_SERVER */
 
 void
 WindowsRestructured()

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -381,79 +381,88 @@ XYToWindow(int x, int y)
     return spriteTrace[spriteTraceGood-1];
 }
 
-// static Bool
-// CheckMotion(xEvent *xE)
-// {
-//     WindowPtr prevSpriteWin = sprite.win;
-// 
+static Bool
+CheckMotion(xEvent *xE)
+{
+    WindowPtr prevSpriteWin = sprite.win;
+
 #ifdef PANORAMIX
-//     if(!noPanoramiXExtension)
-// 	return XineramaCheckMotion(xE);
+    if(!noPanoramiXExtension)
+	return XineramaCheckMotion(xE);
 #endif
 
-//     if (xE && !syncEvents.playingEvents)
-//     {
-// 	if (sprite.hot.pScreen != sprite.hotPhys.pScreen)
-// 	{
-// 	    sprite.hot.pScreen = sprite.hotPhys.pScreen;
-// 	    ROOT = sprite.hot.pScreen->root;
-// 	}
-// 	sprite.hot.x = XE_KBPTR.rootX;
-// 	sprite.hot.y = XE_KBPTR.rootY;
-// 	if (sprite.hot.x < sprite.physLimits.x1)
-// 	    sprite.hot.x = sprite.physLimits.x1;
-// 	else if (sprite.hot.x >= sprite.physLimits.x2)
-// 	    sprite.hot.x = sprite.physLimits.x2 - 1;
-// 	if (sprite.hot.y < sprite.physLimits.y1)
-// 	    sprite.hot.y = sprite.physLimits.y1;
-// 	else if (sprite.hot.y >= sprite.physLimits.y2)
-// 	    sprite.hot.y = sprite.physLimits.y2 - 1;
+    if (xE && !syncEvents.playingEvents)
+    {
+	if (sprite.hot.pScreen != sprite.hotPhys.pScreen)
+	{
+	    sprite.hot.pScreen = sprite.hotPhys.pScreen;
+	    ROOT = sprite.hot.pScreen->root;
+	}
+	sprite.hot.x = XE_KBPTR.rootX;
+	sprite.hot.y = XE_KBPTR.rootY;
+	if (sprite.hot.x < sprite.physLimits.x1)
+	    sprite.hot.x = sprite.physLimits.x1;
+	else if (sprite.hot.x >= sprite.physLimits.x2)
+	    sprite.hot.x = sprite.physLimits.x2 - 1;
+	if (sprite.hot.y < sprite.physLimits.y1)
+	    sprite.hot.y = sprite.physLimits.y1;
+	else if (sprite.hot.y >= sprite.physLimits.y2)
+	    sprite.hot.y = sprite.physLimits.y2 - 1;
 #ifdef SHAPE
-// 	if (sprite.hotShape)
-// 	    ConfineToShape(sprite.hotShape, &sprite.hot.x, &sprite.hot.y);
+	if (sprite.hotShape)
+	    ConfineToShape(sprite.hotShape, &sprite.hot.x, &sprite.hot.y);
 #endif
-// 	sprite.hotPhys = sprite.hot;
-// 
-//         /*
-//          * This code force cursor position to be inside the
-//          * root window of the agent. We can't view a reason
-//          * to do this and it interacts in an undesirable way
-//          * with toggling fullscreen.
-//          *
-//          * if ((sprite.hotPhys.x != XE_KBPTR.rootX) ||
-//          *          (sprite.hotPhys.y != XE_KBPTR.rootY))
-//          * {
-//          *   (*sprite.hotPhys.pScreen->SetCursorPosition)(
-//          *       sprite.hotPhys.pScreen,
-//          *           sprite.hotPhys.x, sprite.hotPhys.y, FALSE);
-//          * }
-//          */
-// 
-// 	XE_KBPTR.rootX = sprite.hot.x;
-// 	XE_KBPTR.rootY = sprite.hot.y;
-//     }
-// 
-//     sprite.win = XYToWindow(sprite.hot.x, sprite.hot.y);
+	sprite.hotPhys = sprite.hot;
+
+#ifdef NXAGENT_SERVER
+        /*
+         * This code force cursor position to be inside the
+         * root window of the agent. We can't view a reason
+         * to do this and it interacts in an undesirable way
+         * with toggling fullscreen.
+         *
+         * if ((sprite.hotPhys.x != XE_KBPTR.rootX) ||
+         *          (sprite.hotPhys.y != XE_KBPTR.rootY))
+         * {
+         *   (*sprite.hotPhys.pScreen->SetCursorPosition)(
+         *       sprite.hotPhys.pScreen,
+         *           sprite.hotPhys.x, sprite.hotPhys.y, FALSE);
+         * }
+         */
+#else
+	if ((sprite.hotPhys.x != XE_KBPTR.rootX) ||
+	    (sprite.hotPhys.y != XE_KBPTR.rootY))
+	{
+	    (*sprite.hotPhys.pScreen->SetCursorPosition)(
+		sprite.hotPhys.pScreen,
+		sprite.hotPhys.x, sprite.hotPhys.y, FALSE);
+	}
+#endif
+	XE_KBPTR.rootX = sprite.hot.x;
+	XE_KBPTR.rootY = sprite.hot.y;
+    }
+
+    sprite.win = XYToWindow(sprite.hot.x, sprite.hot.y);
 #ifdef notyet
-//     if (!(sprite.win->deliverableEvents &
-// 	  Motion_Filter(inputInfo.pointer->button))
-// 	!syncEvents.playingEvents)
-//     {
-// 	/* XXX Do PointerNonInterestBox here */
-//     }
+    if (!(sprite.win->deliverableEvents &
+	  Motion_Filter(inputInfo.pointer->button))
+	!syncEvents.playingEvents)
+    {
+	/* XXX Do PointerNonInterestBox here */
+    }
 #endif
-//     if (sprite.win != prevSpriteWin)
-//     {
-// 	if (prevSpriteWin != NullWindow) {
-// 	    if (!xE)
-// 		UpdateCurrentTimeIf();
-// 	    DoEnterLeaveEvents(prevSpriteWin, sprite.win, NotifyNormal);
-// 	}
-// 	PostNewCursor();
-//         return FALSE;
-//     }
-//     return TRUE;
-// }
+    if (sprite.win != prevSpriteWin)
+    {
+	if (prevSpriteWin != NullWindow) {
+	    if (!xE)
+		UpdateCurrentTimeIf();
+	    DoEnterLeaveEvents(prevSpriteWin, sprite.win, NotifyNormal);
+	}
+	PostNewCursor();
+        return FALSE;
+    }
+    return TRUE;
+}
 
 void
 DefineInitialRootWindow(register WindowPtr win)

--- a/nx-X11/programs/Xserver/os/io.c
+++ b/nx-X11/programs/Xserver/os/io.c
@@ -424,8 +424,6 @@ ReadRequestFromClient(ClientPtr client)
 
     if (oci->ignoreBytes > 0) {
 	assert(needed == oci->ignoreBytes || needed == oci->size);
-	oci->ignoreBytes -= gotnow;
-	needed = gotnow = 0;
 	/*
 	 * The _XSERVTransRead call above may return more or fewer bytes than we
 	 * want to ignore.  Ignore the smaller of the two sizes.

--- a/nx-X11/programs/Xserver/render/glyph.c
+++ b/nx-X11/programs/Xserver/render/glyph.c
@@ -589,7 +589,8 @@ miGlyphs(CARD8 op,
         height = extents.y2 - extents.y1;
         pMaskPixmap =
             (*pScreen->CreatePixmap) (pScreen, width, height,
-                                      maskFormat->depth);
+                                      maskFormat->depth,
+                                      CREATE_PIXMAP_USAGE_SCRATCH);
         if (!pMaskPixmap)
             return;
         component_alpha = NeedsComponent(maskFormat->format);


### PR DESCRIPTION
CheckMotion() had been commented in
add881931f2e702fb1952f4e1baba04b3dc536ee as it looked identical to the
version from dix/events.c except for some commented code. But this
based (probably) on a thinko - code that had been disabled by NX
became active again this way. Fix this by removing the comments and
by adding #ifdef/else to emphasize the difference.

Some other small fixes are also included 