### PR TITLE
dix: remove unused requestLogIndex

### DIFF
--- a/nx-X11/programs/Xserver/dix/dispatch.c
+++ b/nx-X11/programs/Xserver/dix/dispatch.c
@@ -416,12 +416,6 @@ Dispatch(void)
 	        }
 
 		client->sequence++;
-#ifdef DEBUG
-		if (client->requestLogIndex == MAX_REQUEST_LOG)
-		    client->requestLogIndex = 0;
-		client->requestLog[client->requestLogIndex] = MAJOROP;
-		client->requestLogIndex++;
-#endif
 		if (result > (maxBigRequestSize << 2))
 		    result = BadLength;
 		else
@@ -3622,9 +3616,6 @@ void InitClient(ClientPtr client, int i, void * ospriv)
     client->numSaved = 0;
     client->saveSet = (SaveSetElt *)NULL;
     client->noClientException = Success;
-#ifdef DEBUG
-    client->requestLogIndex = 0;
-#endif
     client->requestVector = InitialVector;
     client->osPrivate = ospriv;
     client->swapped = FALSE;

--- a/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c
@@ -468,12 +468,6 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
 #endif
 
 		client->sequence++;
-#ifdef DEBUG
-		if ((client->requestLogIndex >= MAX_REQUEST_LOG) || (client->requestLogIndex <= 0))
-		    client->requestLogIndex = 0;
-		client->requestLog[client->requestLogIndex] = MAJOROP;
-		client->requestLogIndex++;
-#endif
 		if (result > (maxBigRequestSize << 2))
 		    result = BadLength;
 		else

--- a/nx-X11/programs/Xserver/include/dixstruct.h
+++ b/nx-X11/programs/Xserver/include/dixstruct.h
@@ -37,10 +37,6 @@ SOFTWARE.
  *      translation from client ids to server addresses.
  */
 
-#ifdef DEBUG
-#define MAX_REQUEST_LOG 100
-#endif
-
 extern CallbackListPtr ClientStateCallback;
 
 typedef struct {
@@ -121,10 +117,6 @@ typedef struct _Client {
     KeyCode		minKC,maxKC;
 #endif
 
-#ifdef DEBUG
-    unsigned char requestLog[MAX_REQUEST_LOG];
-    int         requestLogIndex;
-#endif
     unsigned long replyBytesRemaining;
 #ifdef XCSECURITY
     XID		authId;


### PR DESCRIPTION
As done in these commits:

  commit 6583477035234e23ead2fad9db7a07e5862447a4
  Author: Nicolai Hähnle <nhaehnle@gmail.com>
  Date:   Sat May 23 13:35:24 2009 +0200

    Remove reference to non-existing requestLog and requestLogIndex

    These fields were removed in 252ec504817e05b185e4896a2d899e9c00b8aeef.

    Signed-off-by: Nicolai Haehnle <nhaehnle@gmail.com>
    Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>

  commit 252ec504817e05b185e4896a2d899e9c00b8aeef
  Author: Adam Jackson <ajax@redhat.com>
  Date:   Mon Mar 30 15:18:30 2009 -0400

    Document which bits of ClientRec are currently unused