### PR TITLE
rework xkb device private handling

### DIFF
--- a/nx-X11/programs/Xserver/dix/devices.c
+++ b/nx-X11/programs/Xserver/dix/devices.c
@@ -73,6 +73,8 @@ SOFTWARE.
 #include "swaprep.h"
 #include "dixevents.h"
 
+extern void XkbFreePrivates(DeviceIntPtr device);
+
 DeviceIntPtr
 AddInputDevice(DeviceProc deviceProc, Bool autoStart)
 {
@@ -275,6 +277,13 @@ CloseDevice(register DeviceIntPtr dev)
 #endif
 	free(l);
     }
+
+#ifdef XKB
+    XkbFreePrivates(dev);
+#endif
+
+    free(dev->devPrivates);
+
     free(dev->sync.event);
     free(dev);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -1034,14 +1034,6 @@ Reply   Total	Cached	Bits In			Bits Out		Bits/Reply	  Ratio
       fprintf(stderr, "nxagentKeyboardProc: Called for [DEVICE_CLOSE].\n");
       #endif
 
-      for (int i = 0; i < pDev->nPrivates; i++)
-      {
-        free(pDev->devPrivates[i].ptr);
-        pDev->devPrivates[i].ptr = NULL;
-      }
-      free(pDev->devPrivates);
-      pDev->devPrivates = NULL;
-
       break;
   }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pointer.c
@@ -166,14 +166,6 @@ int nxagentPointerProc(DeviceIntPtr pDev, int onoff)
       fprintf(stderr, "nxagentPointerProc: Called for [DEVICE_CLOSE].\n");
       #endif
 
-      for (int i = 0; i < pDev->nPrivates; i++)
-      {
-        free(pDev->devPrivates[i].ptr);
-        pDev->devPrivates[i].ptr = NULL;
-      }
-      free(pDev->devPrivates);
-      pDev->devPrivates = NULL;
-
       break;
     }
 

--- a/nx-X11/programs/Xserver/xkb/xkbActions.c
+++ b/nx-X11/programs/Xserver/xkb/xkbActions.c
@@ -81,6 +81,20 @@ XkbSetExtension(DeviceIntPtr device, ProcessInputProc proc)
 			    proc,xkbUnwrapProc);
 }
 
+void
+XkbFreePrivates(DeviceIntPtr device)
+{
+  if (device &&
+      device->devPrivates &&
+      device->nPrivates > 0 &&
+      xkbDevicePrivateIndex != -1 &&
+      xkbDevicePrivateIndex < device->nPrivates)
+    {
+      free(device->devPrivates[xkbDevicePrivateIndex].ptr);
+      device->devPrivates[xkbDevicePrivateIndex].ptr = NULL;
+    }
+}
+
 #ifdef XINPUT
 extern	void	ProcessOtherEvent(
     xEvent *		/* xE */,


### PR DESCRIPTION
We can only free the xkbDevicePrivate because we do not know the
details if any other (possible) extension. So let's limit to that one
private for now and call the new xkbFreePrivates from dix (where such
a function is completely missing).