### PR TITLE
TravisCI: Update GCC from 8.x to 9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,5 +117,7 @@ before_install:
 script:
    # run static analysis tools
    - ./run-static-analysis.sh
+   # print compiler version
+   - ${CC} --version
    # build all packages
    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-8
+            - g++-9
             # imake
             - xutils-dev
             # X11 libaries
@@ -56,7 +56,7 @@ matrix:
             - x11-xkb-utils
 
       env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
         - STATIC_ANALYSIS="no"
 
     - os: linux


### PR DESCRIPTION
Hi @sunweaver,

This update the latest GCC used from 8.x to 9.x. See this [RHEL article](https://developers.redhat.com/blog/2019/03/08/usability-improvements-in-gcc-9/). 
I also added a `${CC} --version` command, so we can see exactly which compiler version was used, as this flag works with both GCC and CLANG. 