### PR TITLE
nxagent: simplify nxagentWaitEvents()

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Client.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Client.c
@@ -400,7 +400,7 @@ void nxagentWaitWakeupBySplit(ClientPtr client)
     fprintf(stderr, "++++++nxagentWaitWakeupBySplit: Yielding control to the NX transport.\n");
     #endif
 
-    nxagentWaitEvents(nxagentDisplay, NULL);
+    nxagentWaitEvents(nxagentDisplay, 0);
   }
 }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -3309,7 +3309,6 @@ int nxagentHandleConfigureNotify(XEvent* X)
     ScreenPtr pScreen = nxagentScreen(X -> xconfigure.window);
 
     Bool doRandR = False;
-    struct timeval timeout;
 
     if (X -> xconfigure.window == nxagentDefaultWindows[pScreen -> myNum])
     {
@@ -3345,10 +3344,7 @@ int nxagentHandleConfigureNotify(XEvent* X)
             {
               newEvents = False;
 
-              timeout.tv_sec  = 0;
-              timeout.tv_usec = 500 * 1000;
-
-              nxagentWaitEvents(nxagentDisplay, &timeout);
+              nxagentWaitEvents(nxagentDisplay, 500);
 
               /*
                * This should also flush the NX link for us.
@@ -3827,7 +3823,7 @@ int nxagentWaitForResource(GetResourceFuncPtr pGetResource, PredicateFuncPtr pPr
 
   while ((resource = (*pGetResource)(nxagentDisplay)) == -1)
   {
-    if (nxagentWaitEvents(nxagentDisplay, NULL) == -1)
+    if (nxagentWaitEvents(nxagentDisplay, 0) == -1)
     {
       return -1;
     }
@@ -4511,14 +4507,11 @@ int nxagentPendingEvents(Display *dpy)
 }
 
 /*
- * Blocks until an event becomes
- * available.
+ * Blocks until an event becomes available.
  */
 
-int nxagentWaitEvents(Display *dpy, struct timeval *tm)
+int nxagentWaitEvents(Display *dpy, useconds_t msec)
 {
-  XEvent ev;
-
   #ifdef DEBUG
   fprintf(stderr, "nxagentWaitEvents called.\n");
   #endif
@@ -4526,33 +4519,41 @@ int nxagentWaitEvents(Display *dpy, struct timeval *tm)
   NXFlushDisplay(dpy, NXFlushLink);
 
   /*
-   * If the transport is not running we
-   * have to rely on Xlib to wait for an
-   * event. In this case the timeout is
-   * ignored.
+   * If the transport is not running we have to rely on Xlib to wait
+   * for an event. In this case the timeout is ignored.
    */
 
   if (NXTransRunning(NX_FD_ANY) == 1)
   {
-    NXTransContinue(tm);
+    if (msec > 0)
+    {
+      struct timeval tm = {
+	  .tv_sec  = 0,
+	  .tv_usec = msec * 1000
+      };
+      NXTransContinue(&tm);
+    }
+    else
+    {
+      NXTransContinue(NULL);
+    }
   }
   else
   {
+    XEvent ev;
     XPeekEvent(dpy, &ev);
   }
 
   /*
-   * Check if we encountered a display
-   * error. If we did, wait for the
+   * Check if we encountered a display error. If we did, wait for the
    * time requested by the caller.
    */
 
   if (NXDisplayError(dpy) == 1)
   {
-    if (tm != NULL)
+    if (msec > 0)
     {
-      usleep(tm -> tv_sec * 1000 * 1000 +
-                 tm -> tv_usec);
+      usleep(msec * 1000);
     }
 
     return -1;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.h
@@ -232,6 +232,6 @@ Bool nxagentPendingEvents(Display *dpy);
 #define nxagentCheckEvents(display, event, predicate, argument) \
     XCheckIfEventNoFlush((display), (event), (predicate), (argument))
 
-int nxagentWaitEvents(Display *, struct timeval *);
+int nxagentWaitEvents(Display *, useconds_t msec);
 
 #endif /* __Events_H__ */

--- a/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Handlers.c
@@ -1255,7 +1255,7 @@ void nxagentDispatchHandler(ClientPtr client, int in, int out)
 
       while (nxagentTokens.pending == TOKENS_PENDING_LIMIT)
       {
-        if (nxagentWaitEvents(nxagentDisplay, NULL) == -1)
+        if (nxagentWaitEvents(nxagentDisplay, 0) == -1)
         {
           nxagentTokens.pending = 0;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -365,7 +365,6 @@ FIXME: We'll check for ReparentNotify and LeaveNotify events after
 
       for (int i = 0; i < 100 && nxagentWMIsRunning; i++)
       {
-        struct timeval timeout;
         XEvent e;
 
         #ifdef TEST
@@ -379,10 +378,7 @@ FIXME: We'll check for ReparentNotify and LeaveNotify events after
 
         XSync(nxagentDisplay, 0);
 
-        timeout.tv_sec = 0;
-        timeout.tv_usec = 50 * 1000;
-
-        nxagentWaitEvents(nxagentDisplay, &timeout);
+        nxagentWaitEvents(nxagentDisplay, 50);
       }
     }
     else

--- a/nx-X11/programs/Xserver/hw/nxagent/Split.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Split.c
@@ -804,7 +804,7 @@ void nxagentWaitDrawable(DrawablePtr pDrawable)
     fprintf(stderr, "nxagentWaitDrawable: Yielding control to the NX transport.\n");
     #endif
 
-    nxagentWaitEvents(nxagentDisplay, NULL);
+    nxagentWaitEvents(nxagentDisplay, 0);
   }
 }
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -849,7 +849,6 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
      * Change to fullscreen mode.
      */
 
-    struct timeval timeout;
     int i;
     XEvent e;
 
@@ -874,10 +873,7 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
       XSync(nxagentDisplay, 0);
 
-      timeout.tv_sec  = 0;
-      timeout.tv_usec = 50 * 1000;
-
-      nxagentWaitEvents(nxagentDisplay, &timeout);
+      nxagentWaitEvents(nxagentDisplay, 50);
     }
 
     if (i < 100)

--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -1565,6 +1565,10 @@ int NXTransRunning(int fd)
   return (control != NULL);
 }
 
+//
+// FIXME: why timeval? Passing milliseconds would be more convenient,
+// the timeval struct/T_timestamp could be built on demand.
+//
 int NXTransContinue(struct timeval *selectTs)
 {
   if (control != NULL)


### PR DESCRIPTION
no more need to pass down a struct, we now only pass the milliseconds
and let the function do the rest.