### PR TITLE
nxagent: Pass down if window manager has been detected

### DIFF
--- a/nx-X11/programs/Xserver/dix/events.c
+++ b/nx-X11/programs/Xserver/dix/events.c
@@ -2970,7 +2970,11 @@ OtherClientGone(void * value, XID id)
 }
 
 int
+#ifdef NXAGENT_SERVER
+Xorg_EventSelectForWindow(register WindowPtr pWin, register ClientPtr client, Mask mask)
+#else
 EventSelectForWindow(register WindowPtr pWin, register ClientPtr client, Mask mask)
+#endif
 {
     Mask check;
     OtherClients * others;


### PR DESCRIPTION
At start a rootless nxagent checks if the real X server has a Window
Manager running. It uses a standard detection routine that tries to
select a special input (SubStructureRedirect). As only one client per
X server is allowed to select that input one can deduce from the
success of this operation if a Window Manager is running.

If nxagent is run in rootless mode and has not found a Window Manager
on the real X server it will grab all input (see
Screen.c:nxagentOpenScreen).

If any client of the nxagent runs the standard Window Manager
detection routine against a rootless nxagent it will _not_ see the
Window Manager. If this client happens to be a rootless nxagent again
it will then grab all input which is undesired here. Other clients
might do other undesired stuff in that case.

To avoid all that a rootless nxagent now tries to detect if a client
runs that detection routine and returns the result of its own check to
the client.