### PR TITLE
Screen.c: initialize RandR only on startup...

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -1735,14 +1735,14 @@ N/A
 
     #define POSITION_OFFSET (pScreen->myNum * (nxagentOption(Width) + \
                                nxagentOption(Height)) / 32)
+
+    /*
+     * Complete the initialization of the RANDR
+     * extension.
+     */
+
+    nxagentInitRandRExtension(pScreen);
   }
-
-  /*
-   * Complete the initialization of the RANDR
-   * extension.
-   */
-
-  nxagentInitRandRExtension(pScreen);
 
   #ifdef TEST
   nxagentPrintAgentGeometry(NULL, "nxagentOpenScreen:");


### PR DESCRIPTION
... not on reconnect. After the reconnect RRCloseScreen was called
twice which caused a double free. This was introduced with
3b06ad51d91ff2b9442f159cddf34ed03bc2dd35

Fixes ArcticaProject/nx-libs#833

Had this previously as part of pr/various2 but I know prefer a separate PR to allow for a quick merge.