### PR TITLE
Gh sunweaver/pr/autograb without inputlock

### DIFF
--- a/doc/nxagent/README.keystrokes
+++ b/doc/nxagent/README.keystrokes
@@ -126,6 +126,9 @@ reread_keystrokes
   Forces nxagent to re-read the keystroke configuration. Useful to
   add/change keystrokes to a running session.
 
+autograb
+  Toggles autograb mode
+
 force_synchronization
   Forces immediate drawing of elements to be synchronized which can
   fix some visual bugs.

--- a/etc/keystrokes.cfg
+++ b/etc/keystrokes.cfg
@@ -24,4 +24,5 @@
 <keystroke action="viewport_scroll_down" Control="1" AltMeta="1" key="Down" />
 <keystroke action="viewport_scroll_down" Control="1" AltMeta="1" key="KP_Down" />
 <keystroke action="reread_keystrokes" Control="1" AltMeta="1" key="k" />
+<keystroke action="autograb" Control="1" AltMeta="1" key="g" />
 </keystrokes>

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1547,6 +1547,19 @@ static void nxagentParseSingleOption(char *name, char *value)
 
     return;
   }
+  else if (!strcmp(name, "autograb"))
+  {
+    if (!strcmp(value, "0"))
+    {
+      nxagentChangeOption(AutoGrab, False);
+    }
+    else
+    {
+      nxagentChangeOption(AutoGrab, True);
+    }
+
+    return;
+  }
   else
   {
     #ifdef DEBUG

--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1039,6 +1039,14 @@ int ddxProcessArgument(int argc, char *argv[], int i)
     return 0;
   }
 
+  if (!strcmp(argv[i], "-autograb"))
+  {
+    nxagentChangeOption(AutoGrab, True);
+
+    return 1;
+  }
+
+
   /*
    * Disable Xinerama (i.e. fake it in Screen.c) if somehow Xinerama support
    * has been disabled on the cmdline.
@@ -2195,6 +2203,7 @@ void ddxUseMsg(void)
   ErrorF("-noignore              don't ignore pointer and keyboard configuration changes mandated by clients\n");
   ErrorF("-nokbreset             don't reset keyboard device if the session is resumed\n");
   ErrorF("-noxkblock             always allow applications to change layout through XKEYBOARD\n");
+  ErrorF("-autograb              enable autograb\n");
   ErrorF("-tile WxH              size of image tiles (minimum allowed: 32x32)\n");
   ErrorF("-keystrokefile file    file with keyboard shortcut definitions\n");
   ErrorF("-verbose               print more warning and error messages\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Dialog.c
@@ -63,6 +63,8 @@ int nxagentEnableRandRModeDialogPid = 0;
 int nxagentDisableRandRModeDialogPid = 0;
 int nxagentEnableDeferModePid = 0;
 int nxagentDisableDeferModePid = 0;
+int nxagentEnableAutograbModePid = 0;
+int nxagentDisableAutograbModePid = 0;
 
 static int nxagentFailedReconnectionDialogPid = 0;
 
@@ -157,6 +159,24 @@ void nxagentResetDialog(int pid)
     #endif
 
     nxagentDisableDeferModePid = 0;
+  }
+  else if (pid == nxagentEnableAutograbModePid)
+  {
+    #ifdef TEST
+    fprintf(stderr, "nxagentResetDialog: Resetting enable autograb mode dialog pid [%d].\n",
+                nxagentEnableAutograbModePid);
+    #endif
+
+    nxagentEnableAutograbModePid = 0;
+  }
+  else if (pid == nxagentDisableAutograbModePid)
+  {
+    #ifdef TEST
+    fprintf(stderr, "nxagentResetDialog: Resetting disable autograb mode dialog pid [%d].\n",
+                nxagentDisableAutograbModePid);
+    #endif
+
+    nxagentDisableAutograbModePid = 0;
   }
 }
 
@@ -260,6 +280,24 @@ void nxagentLaunchDialog(DialogType dialogType)
       type = DIALOG_DISABLE_DEFER_MODE_TYPE;
       local = DIALOG_DISABLE_DEFER_MODE_LOCAL;
       pid = &nxagentDisableDeferModePid;
+
+      break;
+    }
+    case DIALOG_ENABLE_AUTOGRAB_MODE:
+    {
+      message = DIALOG_ENABLE_AUTOGRAB_MODE_MESSAGE;
+      type = DIALOG_ENABLE_AUTOGRAB_MODE_TYPE;
+      local = DIALOG_ENABLE_AUTOGRAB_MODE_LOCAL;
+      pid = &nxagentEnableAutograbModePid;
+
+      break;
+    }
+    case DIALOG_DISABLE_AUTOGRAB_MODE:
+    {
+      message = DIALOG_DISABLE_AUTOGRAB_MODE_MESSAGE;
+      type = DIALOG_DISABLE_AUTOGRAB_MODE_TYPE;
+      local = DIALOG_DISABLE_AUTOGRAB_MODE_LOCAL;
+      pid = &nxagentDisableAutograbModePid;
 
       break;
     }
@@ -493,6 +531,18 @@ void nxagentTerminateDialog(DialogType type)
     case DIALOG_DISABLE_DEFER_MODE:
     {
       pid = nxagentDisableDeferModePid;
+
+      break;
+    }
+    case DIALOG_ENABLE_AUTOGRAB_MODE:
+    {
+      pid = nxagentEnableAutograbModePid;
+
+      break;
+    }
+    case DIALOG_DISABLE_AUTOGRAB_MODE:
+    {
+      pid = nxagentDisableAutograbModePid;
 
       break;
     }

--- a/nx-X11/programs/Xserver/hw/nxagent/Dialog.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Dialog.h
@@ -41,6 +41,8 @@ typedef enum
   DIALOG_FAILED_RECONNECTION,
   DIALOG_ENABLE_DEFER_MODE,
   DIALOG_DISABLE_DEFER_MODE,
+  DIALOG_ENABLE_AUTOGRAB_MODE,
+  DIALOG_DISABLE_AUTOGRAB_MODE,
   DIALOG_LAST_TAG
 
 } DialogType;
@@ -54,6 +56,8 @@ extern int nxagentEnableRandRModeDialogPid;
 extern int nxagentDisableRandRModeDialogPid;
 extern int nxagentEnableDeferModePid;
 extern int nxagentDisableDeferModePid;
+extern int nxagentEnableAutograbModePid;
+extern int nxagentDisableAutograbModePid;
 
 #define NXAGENTFAILEDRECONNECTIONMESSAGELENGTH 256
 extern char nxagentFailedReconnectionMessage[NXAGENTFAILEDRECONNECTIONMESSAGELENGTH];
@@ -87,6 +91,8 @@ extern void nxagentTerminateDialogs(void);
              (type) == DIALOG_FAILED_RECONNECTION ? "DIALOG_FAILED_RECONNECTION" : \
              (type) == DIALOG_ENABLE_DEFER_MODE ? "DIALOG_ENABLE_DEFER_MODE" : \
              (type) == DIALOG_DISABLE_DEFER_MODE ? "DIALOG_DISABLE_DEFER_MODE" : \
+             (type) == DIALOG_ENABLE_AUTOGRAB_MODE ? "DIALOG_ENABLE_AUTGRAB_MODE" : \
+             (type) == DIALOG_DISABLE_AUTOGRAB_MODE ? "DIALOG_DISABLE_AUTOGRAB_MODE" : \
              "UNKNOWN_DIALOG")
 
 /*
@@ -213,6 +219,30 @@ Ctrl+Alt+E to enable it again.\
 #define DIALOG_DISABLE_DEFER_MODE_TYPE "ok"
 
 #define DIALOG_DISABLE_DEFER_MODE_LOCAL 0
+
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_MESSAGE \
+\
+"\
+Keyboard auto-grabbing mode is now enabled. You can press\n\
+Ctrl+Alt+G again to disable auto-grabbing.\
+"
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_TYPE "ok"
+
+#define DIALOG_ENABLE_AUTOGRAB_MODE_LOCAL 0
+
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_MESSAGE \
+\
+"\
+Keyboard auto-grabbing mode is now disabled. You can press\n\
+Ctrl+Alt+G again to re-enable auto-grabbing.\
+"
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_TYPE "ok"
+
+#define DIALOG_DISABLE_AUTOGRAB_MODE_LOCAL 0
 
 #endif /* __Dialog_H__ */
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1597,8 +1597,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           }
         }
 
-        /* FIXME: only when in windowed mode! */
-        if (nxagentOption(AutoGrab))
+        if (nxagentOption(AutoGrab) && !(nxagentOption(AllScreens) || nxagentOption(Fullscreen) || nxagentOption(Rootless)))
         {
           if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
           {

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -712,6 +712,7 @@ static void nxagentEnableAutoGrab(void)
 
   nxagentGrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, True);
+  nxagentLaunchDialog(DIALOG_ENABLE_AUTOGRAB_MODE);
 }
 
 static void nxagentDisableAutoGrab(void)
@@ -722,6 +723,7 @@ static void nxagentDisableAutoGrab(void)
 
   nxagentUngrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, False);
+  nxagentLaunchDialog(DIALOG_DISABLE_AUTOGRAB_MODE);
 }
 
 static void nxagentToggleAutoGrab(void)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -115,6 +115,15 @@
 #undef  TEST
 #undef  DEBUG
 
+/* debug individual subsystems */
+#undef DEBUG_AUTOGRAB
+
+/* aktivate subsystems if generic DEBUG is activated */
+#ifdef DEBUG
+#ifndef DEBUG_AUTOGRAB
+#define DEBUG_AUTOGRAB
+#endif
+#endif
 /*
  * Log begin and end of the important handlers.
  */
@@ -706,9 +715,9 @@ static void nxagentSwitchDeferMode(void)
 
 static void nxagentEnableAutoGrab(void)
 {
-#ifdef DEBUG
+  #ifdef DEBUG_AUTOGRAB
   fprintf(stderr, "enabling autograb\n");
-#endif
+  #endif
 
   nxagentGrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, True);
@@ -717,9 +726,9 @@ static void nxagentEnableAutoGrab(void)
 
 static void nxagentDisableAutoGrab(void)
 {
-#ifdef DEBUG
+  #ifdef DEBUG_AUTOGRAB
   fprintf(stderr, "disabling autograb\n");
-#endif
+  #endif
 
   nxagentUngrabPointerAndKeyboard(NULL);
   nxagentChangeOption(AutoGrab, False);
@@ -1603,14 +1612,14 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         {
           if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
           {
-            #ifdef DEBUG
+            #if defined(DEBUG) || defined(DEBUG_AUTOGRAB)
             fprintf(stderr, "%s: (FocusIn): grabbing\n", __func__);
 	    #endif
             nxagentGrabPointerAndKeyboard(NULL);
           }
 	  /*	  else
           {
-            #ifdef DEBUG
+            #if defined(DEBUG) || defined(DEBUG_AUTOGRAB)
             fprintf(stderr, "%s: (FocusIn): ungrabbing\n", __func__);
 	    #endif
             nxagentUngrabPointerAndKeyboard(NULL);
@@ -1706,7 +1715,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           XGetInputFocus(nxagentDisplay, &w, &revert_to);
           if (w != nxagentDefaultWindows[0] && X.xfocus.mode == NotifyWhileGrabbed)
           {
-            #ifdef DEBUG
+            #if defined(DEBUG) || defined(DEBUG_AUTOGRAB)
             fprintf(stderr, "%s: (FocusOut): ungrabbing\n", __func__);
             #endif
             nxagentUngrabPointerAndKeyboard(NULL);

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1846,11 +1846,14 @@ FIXME: Don't enqueue the KeyRelease event if the key was
           nxagentLastEnteredWindow = NULL;
         }
 
-        if (X.xcrossing.window == nxagentDefaultWindows[0] &&
-                X.xcrossing.detail != NotifyInferior &&
-                    X.xcrossing.mode == NotifyNormal)
+        if (!nxagentOption(AutoGrab))
         {
-          nxagentUngrabPointerAndKeyboard(&X);
+          if (X.xcrossing.window == nxagentDefaultWindows[0] &&
+              X.xcrossing.detail != NotifyInferior &&
+              X.xcrossing.mode == NotifyNormal)
+          {
+             nxagentUngrabPointerAndKeyboard(&X);
+          }
         }
 
         if (X.xcrossing.detail != NotifyInferior)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -674,8 +674,6 @@ static void nxagentSwitchDeferMode(void)
   }
 }
 
-static Bool autograb = False;
-
 static void nxagentEnableAutoGrab(void)
 {
 #ifdef DEBUG
@@ -683,7 +681,7 @@ static void nxagentEnableAutoGrab(void)
 #endif
 
   nxagentGrabPointerAndKeyboard(NULL);
-  autograb = True;
+  nxagentChangeOption(AutoGrab, True);
 }
 
 static void nxagentDisableAutoGrab(void)
@@ -693,7 +691,7 @@ static void nxagentDisableAutoGrab(void)
 #endif
 
   nxagentUngrabPointerAndKeyboard(NULL);
-  autograb = False;
+  nxagentChangeOption(AutoGrab, False);
 }
 
 static void nxagentToggleAutoGrab(void)
@@ -702,7 +700,7 @@ static void nxagentToggleAutoGrab(void)
   if (nxagentOption(Rootless) || nxagentOption(Fullscreen))
     return;
 
-  if (!autograb)
+  if (!nxagentOption(AutoGrab))
     nxagentEnableAutoGrab();
   else
     nxagentDisableAutoGrab();
@@ -1560,7 +1558,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
         }
 
         /* FIXME: only when in windowed mode! */
-        if (autograb)
+        if (nxagentOption(AutoGrab))
         {
           if (X.xfocus.window == nxagentDefaultWindows[0] && X.xfocus.mode == NotifyNormal)
           {
@@ -1648,7 +1646,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         #endif /* NXAGENT_FIXKEYS */
 
-        if (autograb)
+        if (nxagentOption(AutoGrab))
         {
           XlibWindow w;
           int revert_to;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1699,7 +1699,7 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 
         #endif /* NXAGENT_FIXKEYS */
 
-        if (nxagentOption(AutoGrab))
+        if (nxagentOption(AutoGrab) && !nxagentFullscreenWindow)
         {
           XlibWindow w;
           int revert_to;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -292,6 +292,36 @@ void ProcessInputEvents(void)
   mieqProcessInputEvents();
 }
 
+#ifdef DEBUG
+char * nxagentGetNotifyMode(int mode)
+{
+  switch (mode)
+  {
+    case NotifyNormal:
+    {
+      return "NotifyNormal";
+      break;
+    }
+    case NotifyGrab:
+    {
+      return "NotifyGrab";
+      break;
+    }
+    case NotifyUngrab:
+    {
+      return "NotifyUngrab";
+      break;
+    }
+    case NotifyWhileGrabbed:
+    {
+      return "NotifyWhileGrabbed";
+      break;
+    }
+  }
+  return "Unknown";
+}
+#endif
+
 #ifdef DEBUG_TREE
 
 /*
@@ -1530,8 +1560,18 @@ FIXME: Don't enqueue the KeyRelease event if the key was
       {
         WindowPtr pWin;
 
-        #ifdef TEST
-        fprintf(stderr, "nxagentDispatchEvents: Going to handle new FocusIn event.\n");
+	#ifdef DEBUG
+	fprintf(stderr, "%s: Going to handle new FocusIn event [0x%x] mode: [%s]\n", __func__, X.xfocus.window, nxagentGetNotifyMode(X.xfocus.mode));
+	{
+	  XlibWindow w;
+          int revert_to;
+          XGetInputFocus(nxagentDisplay, &w, &revert_to);
+	  fprintf(stderr, "%s: (FocusIn): Event win [0x%x] Focus owner [0x%x] nxagentDefaultWindows[0] [0x%x]\n", __func__, X.xfocus.window, w, nxagentDefaultWindows[0]);
+	}
+        #else
+	  #ifdef TEST
+	fprintf(stderr, "%s: Going to handle new FocusIn event\n", __func__);
+	  #endif
         #endif
 
         /*
@@ -1567,13 +1607,25 @@ FIXME: Don't enqueue the KeyRelease event if the key was
 	    #endif
             nxagentGrabPointerAndKeyboard(NULL);
           }
+	  /*	  else
+          {
+            #ifdef DEBUG
+            fprintf(stderr, "%s: (FocusIn): ungrabbing\n", __func__);
+	    #endif
+            nxagentUngrabPointerAndKeyboard(NULL);
+          }
+	  */
         }
         break;
       }
       case FocusOut:
       {
-        #ifdef TEST
-        fprintf(stderr, "nxagentDispatchEvents: Going to handle new FocusOut event.\n");
+	#ifdef DEBUG
+	fprintf(stderr, "%s: Going to handle new FocusOut event [0x%x] mode: [%s]\n", __func__, X.xfocus.window, nxagentGetNotifyMode(X.xfocus.mode));
+	#else
+	  #ifdef TEST
+	  fprintf(stderr, "%s: Going to handle new FocusOut event.\n", __func__);
+          #endif
         #endif
 
         if (X.xfocus.detail != NotifyInferior)

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.h
@@ -50,7 +50,8 @@ enum HandleEventResult
   doViewportRight,
   doViewportDown,
   doSwitchResizeMode,
-  doSwitchDeferMode
+  doSwitchDeferMode,
+  doAutoGrab,
 };
 
 extern CARD32 nxagentLastEventTime;

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
@@ -99,6 +99,9 @@ char * nxagentSpecialKeystrokeNames[] = {
        "viewport_scroll_down",
 
        "reread_keystrokes",
+
+       "autograb",
+
        NULL,
 };
 
@@ -138,6 +141,7 @@ struct nxagentSpecialKeystrokeMap default_map[] = {
   {KEYSTROKE_VIEWPORT_SCROLL_DOWN, ControlMask, True, XK_Down},
   {KEYSTROKE_VIEWPORT_SCROLL_DOWN, ControlMask, True, XK_KP_Down},
   {KEYSTROKE_REREAD_KEYSTROKES, ControlMask, True, XK_k},
+  {KEYSTROKE_AUTOGRAB, ControlMask, True, XK_g},
   {KEYSTROKE_END_MARKER, 0, False, NoSymbol},
 };
 struct nxagentSpecialKeystrokeMap *map = default_map;
@@ -467,7 +471,7 @@ static enum nxagentSpecialKeystroke find_keystroke(XKeyEvent *X)
   #endif
   for (struct nxagentSpecialKeystrokeMap *cur = map; cur->stroke != KEYSTROKE_END_MARKER; cur++) {
     #ifdef DEBUG
-    fprintf(stderr, "%s: checking keysym '%c' (%d)\n", __func__, cur->keysym, cur->keysym);
+    fprintf(stderr,"%s: keysym %d stroke %d, type %d\n", __func__, cur->keysym, cur->stroke, X->type);
     #endif
     if (cur->keysym == keysym && modifier_matches(cur->modifierMask, cur->modifierAltMeta, X->state)) {
       #ifdef DEBUG
@@ -626,6 +630,9 @@ Bool nxagentCheckSpecialKeystroke(XKeyEvent *X, enum HandleEventResult *result)
       */
       if (X->type == KeyRelease)
 	nxagentInitKeystrokes(True);
+      break;
+    case KEYSTROKE_AUTOGRAB:
+      *result = doAutoGrab;
       break;
     case KEYSTROKE_NOTHING: /* do nothing. difference to KEYSTROKE_IGNORE is the return value */
     case KEYSTROKE_END_MARKER: /* just to make gcc STFU */

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
@@ -73,6 +73,8 @@ enum nxagentSpecialKeystroke {
 
        KEYSTROKE_REREAD_KEYSTROKES,
 
+       KEYSTROKE_AUTOGRAB,
+
        KEYSTROKE_NOTHING,
 
        /* insert more here and in the string translation */

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.c
@@ -172,6 +172,8 @@ void nxagentInitOptions(void)
   nxagentOptions.ReconnectTolerance = DEFAULT_TOLERANCE;
 
   nxagentOptions.KeycodeConversion = DEFAULT_KEYCODE_CONVERSION;
+
+  nxagentOptions.AutoGrab = False;
 }
 
 /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Options.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Options.h
@@ -450,6 +450,13 @@ typedef struct _AgentOptions
    * Convert evdev keycodes to pc105.
    */
   KeycodeConversionMode KeycodeConversion;
+
+  /*
+   * True if agent should grab the input in windowed mode whenever the
+   * agent window gets the focus
+   */
+  int AutoGrab;  /* Should be Bool but I do not want to include Xlib.h here */
+
 } AgentOptionsRec;
 
 typedef AgentOptionsRec *AgentOptionsPtr;

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -754,7 +754,12 @@ void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
   else
   {
     nxagentFullscreenWindow = None;
-    nxagentUngrabPointerAndKeyboard(NULL);
+
+    /* if we had AutoGrab before entering fullscreen reactivate it now */
+    if (nxagentOption(AutoGrab))
+      nxagentGrabPointerAndKeyboard(NULL);
+    else
+      nxagentUngrabPointerAndKeyboard(NULL);
   }
 }
 
@@ -1004,6 +1009,10 @@ void nxagentSwitchAllScreens(ScreenPtr pScreen, Bool switchOn)
 
   XMoveResizeWindow(nxagentDisplay, nxagentInputWindows[0], 0, 0,
                         nxagentOption(Width), nxagentOption(Height));
+
+  /* if we had AutoGrab before entering fullscreen reactivate it now */
+  if (nxagentOption(AutoGrab))
+    nxagentGrabPointerAndKeyboard(NULL);
 
   nxagentSetPrintGeometry(pScreen -> myNum);
 }

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -457,6 +457,9 @@ The nx-X11 system adds the following command line arguments:
 .B \-forcenx
 force use of NX protocol messages assuming communication through \fBnxproxy\fR
 .TP 8
+.B \-autograb
+enable autograb mode on \fBnxagent\fR startup. The autograb feature can be toggled via nxagent keystrokes
+.TP 8
 .B \-nxrealwindowprop
 set property NX_REAL_WINDOW for each X11 client inside \fBnxagent\fR,
 providing the window XID of the corresponding window object on the X

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -756,6 +756,10 @@ format must be included in both. This is potentially unsafe.
 means that all of these checks are essentially
 deactivated. This is a very bad idea.
 .RE
+.TP 8
+.B autograb=<int>
+enable or disable autograb (default: disabled)
+.RE
 
 If you want to use \fBnxagent\fR as a replacement for Xnest or Xephyr you
 can pass options like this:


### PR DESCRIPTION
Please have a look at this. Does it work for you?

I have noticed that with some window managers (metacity, marco, openbox, icewm) you cannot move the NX window anymore when the grab is active while with others you can (kwin, twm). This seems to be related to the WM and not to NX (see https://stackoverflow.com/questions/14555703/x11-unable-to-move-window-after-xgrabkeyboard?rq=1)

