### PR TITLE
nxagent: drop nxagentRenderTrap

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/NXextension.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXextension.c
@@ -95,13 +95,6 @@ ProcQueryExtension(ClientPtr client)
     {
 	i = FindExtension((char *)&stuff[1], stuff->nbytes);
         if (i < 0
-
-            /*
-             * Hide RENDER if our implementation
-             * is faulty.
-             */
-
-            || (nxagentRenderTrap && strcmp(extensions[i]->name, "RENDER") == 0)
 #ifdef XCSECURITY
 	    /* don't show insecure extensions to untrusted clients */
 	    || (client->trustLevel == XSecurityClientUntrusted &&
@@ -149,14 +142,6 @@ ProcListExtensions(ClientPtr client)
 		!extensions[i]->secure)
 		continue;
 #endif
-            /*
-             * Hide RENDER if our implementation
-             * is faulty.
-             */
-
-            if (nxagentRenderTrap && strcmp(extensions[i]->name, "RENDER") == 0)
-                continue;
-
 	    total_length += strlen(extensions[i]->name) + 1;
 	    reply.nExtensions += 1 + extensions[i]->num_aliases;
 	    for (j = extensions[i]->num_aliases; --j >= 0;)

--- a/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXrender.c
@@ -1665,16 +1665,6 @@ ProcRenderDispatch (ClientPtr client)
 
     REQUEST(xReq);
 
-    /*
-     * Let the client fail if we are
-     * hiding the RENDER extension.
-     */
-    
-    if (nxagentRenderTrap)
-    {
-        return BadRequest;
-    }
-
     if (stuff->data < RenderNumberRequests)
     {
         #ifdef TEST
@@ -1707,16 +1697,6 @@ SProcRenderDispatch (ClientPtr client)
 
     REQUEST(xReq);
     
-    /*
-     * Let the client fail if we are
-     * hiding the RENDER extension.
-     */
-    
-    if (nxagentRenderTrap)
-    {
-        return BadRequest;
-    }
-
     if (stuff->data < RenderNumberRequests)
     {
         /*

--- a/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Pixmap.c
@@ -322,41 +322,6 @@ PixmapPtr nxagentCreatePixmap(ScreenPtr pScreen, int width, int height,
   pVirtualPriv -> pVirtualPixmap = NULL;
   pVirtualPriv -> pPicture = NULL;
 
-  /*
-   * Check that the virtual pixmap is created with
-   * the appropriate bits-per-plane, otherwise free
-   * everything and return.
-   */
-
-  if (pVirtual -> drawable.bitsPerPixel == 0)
-  {
-    #ifdef WARNING
-
-    fprintf(stderr, "nxagentCreatePixmap: WARNING! Virtual pixmap at [%p] has invalid "
-                "bits per pixel.\n", (void *) pVirtual);
-
-    fprintf(stderr, "nxagentCreatePixmap: WARNING! Real pixmap created with width [%d] "
-                "height [%d] depth [%d] bits per pixel [%d] and allocation hint [%d].\n",
-                pPixmap -> drawable.width,
-                    pPixmap -> drawable.height = height, pPixmap -> drawable.depth,
-                        pPixmap -> drawable.bitsPerPixel,
-                           usage_hint);
-    #endif
-
-    if (!nxagentRenderTrap)
-    {
-      #ifdef WARNING
-      fprintf(stderr, "Warning: Disabling render extension due to missing pixmap format.\n");
-      #endif
-
-      nxagentRenderTrap = 1;
-    }
-
-    nxagentDestroyPixmap(pPixmap);
-
-    return NullPixmap;
-  }
-
   #ifdef TEST
   fprintf(stderr, "nxagentCreatePixmap: Created pixmap at [%p] virtual at [%p] with width [%d] "
               "height [%d] depth [%d] and allocation hint [%d].\n",

--- a/nx-X11/programs/Xserver/hw/nxagent/Trap.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Trap.c
@@ -42,13 +42,6 @@ int nxagentGCTrap = 0;
 int nxagentScreenTrap = 0;
 
 /*
- * Set if we detected that our RENDER
- * implementation is faulty.
- */
-
-int nxagentRenderTrap = 0;
-
-/*
  * Set if we are executing a GC operation
  * only on the X side. Used to avoid
  * reentrancy in FB layer.

--- a/nx-X11/programs/Xserver/hw/nxagent/Trap.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Trap.h
@@ -43,13 +43,6 @@ extern int nxagentGCTrap;
 extern int nxagentScreenTrap;
 
 /*
- * Set if we detected that our RENDER
- * implementation is faulty.
- */
-
-extern int nxagentRenderTrap;
-
-/*
  * Set if we are executing a GC operation
  * only on the X side. Used to avoid
  * reentrancy in FB layer.


### PR DESCRIPTION
This flag is set when internal pixmap creation returns a pixmap with
depth 0. Following that the RENDER extension is effectively
disabled. However: there's no code that could create a pixmap with
depth 0, so let's simplify our code by removing nxagentRenderTrap
altogether.