### PR TITLE
Fix segfault in argument parsing

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1103,6 +1103,9 @@ static void nxagentParseSingleOption(char *name, char *value)
 
   URLDecodeInPlace(value);
 
+  if (!value)
+    value = "";
+
   if (!strcmp(name, "kbtype") ||
           !strcmp(name, "keyboard") ||
               !strcmp(name, "id") ||


### PR DESCRIPTION
Using arguments that need a parameter without providing one would lead
a segfault due to calling strcmp() will NULL. Triggered by running
"nxagent -ac :1 -options nx/nx,fullscreen" or similar,

Fixes ArcticaProject/nx-libs#847