### PR TITLE
Simplify (NX)xvdisp.c

### DIFF
--- a/nx-X11/programs/Xserver/Xext/Imakefile
+++ b/nx-X11/programs/Xserver/Xext/Imakefile
@@ -43,10 +43,7 @@ XF86BIGFOBJS = xf86bigfont.o
 #endif
 #endif
 
-#if BuildXvExt && ( (defined(NXAgentServer) && NXAgentServer) && !defined(SunArchitecture) && !defined(cygwinArchitecture) )
-      XVSRCS = xvmain.c xvmc.c
-      XVOBJS = xvmain.o xvmc.o
-#elif BuildXvExt
+#if BuildXvExt
       XVSRCS = xvmain.c xvdisp.c xvmc.c
       XVOBJS = xvmain.o xvdisp.o xvmc.o
 #endif

--- a/nx-X11/programs/Xserver/Xext/xvdisp.c
+++ b/nx-X11/programs/Xserver/Xext/xvdisp.c
@@ -224,10 +224,12 @@ static int SWriteImageFormatInfo(ClientPtr, xvImageFormatInfo*);
 **
 */
 
-#if !defined(NXAGENT_SERVER) || defined(__sun) || defined(__CYGWIN__)
-
 int
+#ifdef NXAGENT_SERVER
+xorg_ProcXvDispatch(ClientPtr client)
+#else
 ProcXvDispatch(ClientPtr client)
+#endif
 {
   REQUEST(xReq);
 
@@ -309,7 +311,11 @@ ProcXvDispatch(ClientPtr client)
 }
 
 int
+#ifdef NXAGENT_SERVER
+xorg_SProcXvDispatch(ClientPtr client)
+#else
 SProcXvDispatch(ClientPtr client)
+#endif
 {
   REQUEST(xReq);
 
@@ -353,7 +359,6 @@ SProcXvDispatch(ClientPtr client)
 	}
     }
 }
-#endif /* !defined(NXAGENT_SERVER) || defined(__sun) || defined(__CYGWIN__) */
 
 
 static int

--- a/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXxvdisp.c
@@ -47,11 +47,12 @@ SOFTWARE.
 
 ******************************************************************/
 
-#if !defined(__sun) && !defined(__CYGWIN__)
-
 #include "Trap.h"
 
-#include "../../Xext/xvdisp.c"
+#include "misc.h"
+
+extern int xorg_ProcXvDispatch(ClientPtr);
+extern int xorg_SProcXvDispatch(ClientPtr);
 
 #undef  TEST
 #undef  DEBUG
@@ -62,90 +63,6 @@ SOFTWARE.
 **
 **
 */
-
-int
-nxagent_ProcXvDispatch(ClientPtr client)
-{
-  REQUEST(xReq);
-
-  UpdateCurrentTime();
-
-  switch (stuff->data) 
-    {
-    case xv_QueryExtension: return(ProcXvQueryExtension(client));
-    case xv_QueryAdaptors: return(ProcXvQueryAdaptors(client));
-    case xv_QueryEncodings: return(ProcXvQueryEncodings(client));
-    case xv_PutVideo:
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-            return(XineramaXvPutVideo(client));
-        else
-#endif
-	    return(ProcXvPutVideo(client));
-    case xv_PutStill:
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-            return(XineramaXvPutStill(client));
-        else
-#endif
-	{
-	    return(ProcXvPutStill(client));
-	}
-    case xv_GetVideo: return(ProcXvGetVideo(client));
-    case xv_GetStill: return(ProcXvGetStill(client));
-    case xv_GrabPort: return(ProcXvGrabPort(client));
-    case xv_UngrabPort: return(ProcXvUngrabPort(client));
-    case xv_SelectVideoNotify: return(ProcXvSelectVideoNotify(client));
-    case xv_SelectPortNotify: return(ProcXvSelectPortNotify(client));
-    case xv_StopVideo: 
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-	    return(XineramaXvStopVideo(client));
-	else
-#endif
-	    return(ProcXvStopVideo(client));
-    case xv_SetPortAttribute: 
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-	    return(XineramaXvSetPortAttribute(client));
-	else
-#endif
-	    return(ProcXvSetPortAttribute(client));
-    case xv_GetPortAttribute: return(ProcXvGetPortAttribute(client));
-    case xv_QueryBestSize: return(ProcXvQueryBestSize(client));
-    case xv_QueryPortAttributes: return(ProcXvQueryPortAttributes(client));
-    case xv_PutImage:
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-	    return(XineramaXvPutImage(client));
-	else
-#endif
-	    return(ProcXvPutImage(client));
-#ifdef MITSHM
-    case xv_ShmPutImage: 
-#ifdef PANORAMIX
-        if(!noPanoramiXExtension)
-	    return(XineramaXvShmPutImage(client));
-	else
-#endif
-	    return(ProcXvShmPutImage(client));
-#endif
-    case xv_QueryImageAttributes: return(ProcXvQueryImageAttributes(client));
-    case xv_ListImageFormats: return(ProcXvListImageFormats(client));
-    default:
-      if (stuff->data < xvNumRequests)
-	{
-	  SendErrorToClient(client, XvReqCode, stuff->data, 0, 
-			    BadImplementation);
-	  return(BadImplementation);
-	}
-      else
-	{
-	  SendErrorToClient(client, XvReqCode, stuff->data, 0, BadRequest);
-	  return(BadRequest);
-	}
-    }
-}
 
 int
 ProcXvDispatch(ClientPtr client)
@@ -164,7 +81,7 @@ ProcXvDispatch(ClientPtr client)
 
   nxagentXvTrap = 1;
 
-  result = nxagent_ProcXvDispatch(client);
+  result = xorg_ProcXvDispatch(client);
 
   nxagentXvTrap = 0;
 
@@ -175,54 +92,6 @@ ProcXvDispatch(ClientPtr client)
 
   return result;
 }
-
-
-int
-nxagent_SProcXvDispatch(ClientPtr client)
-{
-  REQUEST(xReq);
-
-  UpdateCurrentTime();
-
-  switch (stuff->data) 
-    {
-    case xv_QueryExtension: return(SProcXvQueryExtension(client));
-    case xv_QueryAdaptors: return(SProcXvQueryAdaptors(client));
-    case xv_QueryEncodings: return(SProcXvQueryEncodings(client));
-    case xv_PutVideo: return(SProcXvPutVideo(client));
-    case xv_PutStill: return(SProcXvPutStill(client));
-    case xv_GetVideo: return(SProcXvGetVideo(client));
-    case xv_GetStill: return(SProcXvGetStill(client));
-    case xv_GrabPort: return(SProcXvGrabPort(client));
-    case xv_UngrabPort: return(SProcXvUngrabPort(client));
-    case xv_SelectVideoNotify: return(SProcXvSelectVideoNotify(client));
-    case xv_SelectPortNotify: return(SProcXvSelectPortNotify(client));
-    case xv_StopVideo: return(SProcXvStopVideo(client));
-    case xv_SetPortAttribute: return(SProcXvSetPortAttribute(client));
-    case xv_GetPortAttribute: return(SProcXvGetPortAttribute(client));
-    case xv_QueryBestSize: return(SProcXvQueryBestSize(client));
-    case xv_QueryPortAttributes: return(SProcXvQueryPortAttributes(client));
-    case xv_PutImage: return(SProcXvPutImage(client));
-#ifdef MITSHM
-    case xv_ShmPutImage: return(SProcXvShmPutImage(client));
-#endif
-    case xv_QueryImageAttributes: return(SProcXvQueryImageAttributes(client));
-    case xv_ListImageFormats: return(SProcXvListImageFormats(client));
-    default:
-      if (stuff->data < xvNumRequests)
-	{
-	  SendErrorToClient(client, XvReqCode, stuff->data, 0, 
-			    BadImplementation);
-	  return(BadImplementation);
-	}
-      else
-	{
-	  SendErrorToClient(client, XvReqCode, stuff->data, 0, BadRequest);
-	  return(BadRequest);
-	}
-    }
-}
-
 
 int
 SProcXvDispatch(ClientPtr client)
@@ -241,7 +110,7 @@ SProcXvDispatch(ClientPtr client)
 
   nxagentXvTrap = 1;
 
-  result = nxagent_SProcXvDispatch(client);
+  result = xorg_SProcXvDispatch(client);
 
   nxagentXvTrap = 0;
 
@@ -252,7 +121,3 @@ SProcXvDispatch(ClientPtr client)
 
   return result;
 }
-
-
-
-#endif /* !defined(__sun) && !defined(__CYGWIN__) */


### PR DESCRIPTION
NXxvdisp.c only exists to set/unset nxagentXvTrap before/after
dispatch. There's no need to duplicate the original code. We now
rename the original dispatch functions and call them in our dispatch
code.

Also drop check for sun and cygwin, as they never appeared in xorg
upstream code.