### PR TITLE
NXglxext.c: use upstream versions of Dispatch functions

### DIFF
--- a/nx-X11/programs/Xserver/GL/glx/glxext.c
+++ b/nx-X11/programs/Xserver/GL/glx/glxext.c
@@ -387,12 +387,15 @@ __GLXcontext *__glXForceCurrent(__GLXclientState *cl, GLXContextTag tag,
 
 /************************************************************************/
 
-#ifndef NXAGENT_SERVER
 
 /*
 ** Top level dispatcher; all commands are executed from here down.
 */
+#ifdef NXAGENT_SERVER
+static int xorg__glXDispatch(ClientPtr client)
+#else
 static int __glXDispatch(ClientPtr client)
+#endif
 {
     REQUEST(xGLXSingleReq);
     CARD8 opcode;
@@ -448,8 +451,6 @@ static int __glXDispatch(ClientPtr client)
 	proc = __glXSingleTable[opcode];
     return (*proc)(cl, (GLbyte *) stuff);
 }
-
-#endif /* NXAGENT_SERVER */
 
 
 int __glXNoSuchSingleOpcode(__GLXclientState *cl, GLbyte *pc)

--- a/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXglxext.c
@@ -57,59 +57,7 @@
 */
 static int __glXDispatch(ClientPtr client)
 {
-    REQUEST(xGLXSingleReq);
-    CARD8 opcode;
-    int (*proc)(__GLXclientState *cl, GLbyte *pc);
-    __GLXclientState *cl;
     int retval;
-
-    opcode = stuff->glxCode;
-    cl = __glXClients[client->index];
-    if (!cl) {
-	cl = (__GLXclientState *) malloc(sizeof(__GLXclientState));
-	 __glXClients[client->index] = cl;
-	if (!cl) {
-	    return BadAlloc;
-	}
-	memset(cl, 0, sizeof(__GLXclientState));
-    }
-    
-    if (!cl->inUse) {
-	/*
-	** This is first request from this client.  Associate a resource
-	** with the client so we will be notified when the client dies.
-	*/
-	XID xid = FakeClientID(client->index);
-	if (!AddResource( xid, __glXClientRes, (void *)(long)client->index)) {
-	    return BadAlloc;
-	}
-	ResetClientState(client->index);
-	cl->inUse = GL_TRUE;
-	cl->client = client;
-    }
-
-    /*
-    ** Check for valid opcode.
-    */
-    if (opcode >= __GLX_SINGLE_TABLE_SIZE) {
-	return BadRequest;
-    }
-
-    /*
-    ** If we're expecting a glXRenderLarge request, this better be one.
-    */
-    if ((cl->largeCmdRequestsSoFar != 0) && (opcode != X_GLXRenderLarge)) {
-	client->errorValue = stuff->glxCode;
-	return __glXBadLargeRequest;
-    }
-
-    /*
-    ** Use the opcode to index into the procedure table.
-    */
-    if (client->swapped)
-        proc = __glXSwapSingleTable[opcode];
-    else
-        proc = __glXSingleTable[opcode];
 
     /*
      * Report upstream that we are
@@ -123,7 +71,7 @@ static int __glXDispatch(ClientPtr client)
                 opcode, client -> index);
     #endif
     
-    retval = (*proc)(cl, (GLbyte *) stuff);
+    retval = xorg__glXDispatch(client);
 
     nxagentGlxTrap = 0;
 


### PR DESCRIPTION
instead of a full copy. We still have our own function because we
need to handle the nxagentGlxTrap. This trap is now set before the
start of the dispatcher while it has been set only directly before
calling the dispatched function.

Saves ~50 duplicated lines.