### PR TITLE
nxagent: Use XlibAtom data type where appropriate

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Atoms.c
@@ -325,7 +325,7 @@ int nxagentQueryAtoms(ScreenPtr pScreen)
 
 typedef struct {
     Atom local;
-    Atom remote;
+    XlibAtom remote;
     const char *string;
     int  length;
 } AtomMap;
@@ -335,8 +335,8 @@ static unsigned int privAtomMapSize = 0;
 static unsigned int privLastAtom = 0;
 
 static void nxagentExpandCache(void);
-static void nxagentWriteAtom(Atom, Atom, const char*, Bool);
-static AtomMap* nxagentFindAtomByRemoteValue(Atom);
+static void nxagentWriteAtom(Atom, XlibAtom, const char*, Bool);
+static AtomMap* nxagentFindAtomByRemoteValue(XlibAtom);
 static AtomMap* nxagentFindAtomByLocalValue(Atom);
 static AtomMap* nxagentFindAtomByName(char*, unsigned);
 
@@ -357,7 +357,7 @@ static void nxagentExpandCache(void)
  * consequent allocation, then cache the atom-couple.
  */
 
-static void nxagentWriteAtom(Atom local, Atom remote, const char *string, Bool duplicate)
+static void nxagentWriteAtom(Atom local, XlibAtom remote, const char *string, Bool duplicate)
 {
   const char *s;
 
@@ -532,7 +532,7 @@ static AtomMap* nxagentFindAtomByLocalValue(Atom local)
   return NULL;
 }
 
-static AtomMap* nxagentFindAtomByRemoteValue(Atom remote)
+static AtomMap* nxagentFindAtomByRemoteValue(XlibAtom remote)
 {
   if (remote == None || remote == BAD_RESOURCE)
   {
@@ -574,7 +574,7 @@ static AtomMap* nxagentFindAtomByName(char *string, unsigned int length)
  *        I think this and the 2 .*Find.* are the only functions to look for performances.
  */
 
-Atom nxagentMakeAtom(char *string, unsigned int length, Bool Makeit)
+XlibAtom nxagentMakeAtom(char *string, unsigned int length, Bool Makeit)
 {
   AtomMap *current;
 
@@ -622,7 +622,7 @@ Atom nxagentMakeAtom(char *string, unsigned int length, Bool Makeit)
    */
 
   {
-    Atom remote = XInternAtom(nxagentDisplay, string, !Makeit);
+    XlibAtom remote = XInternAtom(nxagentDisplay, string, !Makeit);
 
     if (remote == None)
     {
@@ -639,7 +639,7 @@ Atom nxagentMakeAtom(char *string, unsigned int length, Bool Makeit)
   }
 }
 
-Atom nxagentLocalToRemoteAtom(Atom local)
+XlibAtom nxagentLocalToRemoteAtom(Atom local)
 {
   #ifdef TEST
   fprintf(stderr, "%s: entering\n", __func__);
@@ -673,7 +673,7 @@ Atom nxagentLocalToRemoteAtom(Atom local)
 
   const char *string = NameForAtom(local);
 
-  Atom remote = XInternAtom(nxagentDisplay, string, False);
+  XlibAtom remote = XInternAtom(nxagentDisplay, string, False);
 
   if (remote == None)
   {
@@ -693,7 +693,7 @@ Atom nxagentLocalToRemoteAtom(Atom local)
   return remote;
 }
 
-Atom nxagentRemoteToLocalAtom(Atom remote)
+Atom nxagentRemoteToLocalAtom(XlibAtom remote)
 {
   if (remote == None || remote == BAD_RESOURCE)
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Atoms.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Atoms.h
@@ -51,23 +51,33 @@ void nxagentInitAtoms();
 
 int nxagentQueryAtoms(ScreenPtr pScreen);
 
+void nxagentResetAtomMap(void);
+
+void nxagentWMDetect(void);
+
+#ifdef XlibAtom
+
+/*
+ * only provide these protoypes if the including file knows about Xlib
+ * types. This allows us including Atoms.h without having to use the
+ * Xlib type magic of Agent.h
+ */
+
 /*
  * Create the atoms on the remote X server
  * and cache the couple local-remote atoms.
  */
 
-Atom nxagentMakeAtom(char *, unsigned, Bool);
+XlibAtom nxagentMakeAtom(char *, unsigned, Bool);
 
 /*
  * Converts local atoms in remote atoms and
  * viceversa.
  */
 
-Atom nxagentRemoteToLocalAtom(Atom);
-Atom nxagentLocalToRemoteAtom(Atom);
+Atom nxagentRemoteToLocalAtom(XlibAtom);
+XlibAtom nxagentLocalToRemoteAtom(Atom);
 
-void nxagentResetAtomMap(void);
-
-void nxagentWMDetect(void);
+#endif
 
 #endif /* __Atoms_H__ */

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -30,9 +30,9 @@
 #include "windowstr.h"
 #include "scrnintstr.h"
 
+#include "Agent.h"
 #include "Windows.h"
 #include "Atoms.h"
-#include "Agent.h"
 #include "Args.h"
 #include "Trap.h"
 #include "Rootless.h"
@@ -72,7 +72,7 @@ static int agentClipboardStatus;
 static int clientAccum;
 #endif
 
-Atom serverCutProperty;
+XlibAtom serverCutProperty;
 Atom clientCutProperty;
 static Window serverWindow;
 
@@ -82,7 +82,7 @@ const int nxagentMaxSelections = 2;
 
 typedef struct _SelectionOwner
 {
-  Atom selection;       /* _external_ Atom */
+  XlibAtom selection;   /* _external_ Atom */
   ClientPtr client;     /* internal client */
   Window window;        /* internal window id */
   WindowPtr windowPtr;  /* internal window struct */
@@ -96,7 +96,7 @@ typedef struct _SelectionOwner
  * external atom of the selection
  */
 static SelectionOwner *lastSelectionOwner;
-static Atom nxagentLastRequestedSelection;
+static XlibAtom nxagentLastRequestedSelection;
 
 /*
  * Needed to handle the notify selection event to
@@ -125,16 +125,16 @@ static unsigned long lastClientPropertySize;
 
 static ClientSelectionStage lastClientStage;
 
-static Window lastServerRequestor;
-static Atom   lastServerProperty;
-static Atom   lastServerTarget;
-static Time   lastServerTime;
+static Window        lastServerRequestor;
+static XlibAtom      lastServerProperty;
+static XlibAtom      lastServerTarget;
+static Time          lastServerTime;
 
-static Atom serverTARGETS;
-static Atom serverTIMESTAMP;
-static Atom serverTEXT;
-static Atom serverUTF8_STRING;
-static Atom serverClientCutProperty;
+static XlibAtom serverTARGETS;
+static XlibAtom serverTIMESTAMP;
+static XlibAtom serverTEXT;
+static XlibAtom serverUTF8_STRING;
+static XlibAtom serverClientCutProperty;
 static Atom clientTARGETS;
 static Atom clientTEXT;
 static Atom clientCOMPOUND_TEXT;
@@ -209,7 +209,7 @@ XFixesAgentInfoRec nxagentXFixesInfo = { -1, -1, -1, 0 };
 
 extern Display *nxagentDisplay;
 
-Bool nxagentValidServerTargets(Atom target);
+Bool nxagentValidServerTargets(XlibAtom target);
 static void endTransfer(Bool success);
 #define SELECTION_SUCCESS True
 #define SELECTION_FAULT False
@@ -448,7 +448,7 @@ int SendSelectionNotifyEventToClient(ClientPtr client,
  * server, like .e.g XA_STRING or UTF8_STRING. Other, non content type
  * targets like "TARGETS" or "TIMESTAMP" will return false.
  */
-Bool nxagentValidServerTargets(Atom target)
+Bool nxagentValidServerTargets(XlibAtom target)
 {
   if (target == XA_STRING)
   {
@@ -553,7 +553,7 @@ void nxagentClearClipboard(ClientPtr pClient, WindowPtr pWindow)
   nxagentPrintClipboardStat("after nxagentClearClipboard");
 }
 
-int nxagentFindLastSelectionOwnerIndex(Atom sel)
+int nxagentFindLastSelectionOwnerIndex(XlibAtom sel)
 {
   int i = 0;
   while ((i < nxagentMaxSelections) &&
@@ -1992,7 +1992,6 @@ int nxagentSendNotify(xEvent *event)
 WindowPtr nxagentGetClipboardWindow(Atom property)
 {
   int i = nxagentFindLastSelectionOwnerIndex(nxagentLastRequestedSelection);
-
   if ((i < nxagentMaxSelections) && (property == clientCutProperty) &&
           (lastSelectionOwner[i].windowPtr != NULL))
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -1355,25 +1355,21 @@ static void nxagentXkbGetNames(void)
   if (nxagentRemoteRules)
     return;
 
-  Atom atom = XInternAtom(nxagentDisplay, "_XKB_RULES_NAMES", 1);
+  XlibAtom rulesprop = XInternAtom(nxagentDisplay, "_XKB_RULES_NAMES", 1);
 
-  if (atom == 0)
+  if (rulesprop == 0)
   {
     return;
   }
 
-  #ifdef _XSERVER64
-  Atom64 type;
-  #else
-  Atom type;
-  #endif
+  XlibAtom type;
   int format;
   unsigned long n;
   unsigned long after;
   char *data = NULL;
 
   Status result = XGetWindowProperty(nxagentDisplay, DefaultRootWindow(nxagentDisplay),
-                                         atom, 0, 256, 0, XA_STRING, &type, &format,
+                                         rulesprop, 0, 256, 0, XA_STRING, &type, &format,
                                              &n, &after, (unsigned char **)&data);
 
   if (result != Success || !data)

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.c
@@ -706,8 +706,8 @@ int nxagentExportProperty(WindowPtr pWin,
 
   if (export)
   {
-    Atom propertyX = nxagentLocalToRemoteAtom(property);
-    Atom typeX = nxagentLocalToRemoteAtom(type);
+    XlibAtom propertyX = nxagentLocalToRemoteAtom(property);
+    XlibAtom typeX = nxagentLocalToRemoteAtom(type);
 
     if (propertyX == None || typeX == None)
     {
@@ -794,8 +794,8 @@ int nxagentExportProperty(WindowPtr pWin,
 }
 
 void nxagentImportProperty(Window window,
-                           Atom property,
-                           Atom type,
+                           XlibAtom property,
+                           XlibAtom type,
                            int format,
                            unsigned long nitems,
                            unsigned long bytes_after,
@@ -1001,7 +1001,7 @@ void nxagentImportProperty(Window window,
   else if (strcmp(typeS, "ATOM") == 0)
   {
     Atom *atoms = malloc(nitems * sizeof(Atom));
-    Atom *input = (Atom*) buffer;
+    XlibAtom *input = (XlibAtom*) buffer;
 
     if (atoms == NULL)
     {
@@ -1107,7 +1107,7 @@ void nxagentImportProperty(Window window,
 
 struct nxagentPropertyRec{
   Window window;
-  Atom property;
+  XlibAtom property;
   struct nxagentPropertyRec *next;
 };
 
@@ -1148,7 +1148,7 @@ void nxagentRemovePropertyFromList(void)
  * Add the record to the list.
  */
 
-void nxagentAddPropertyToList(Atom property, WindowPtr pWin)
+void nxagentAddPropertyToList(XlibAtom property, WindowPtr pWin)
 {
   if (NXDisplayError(nxagentDisplay) == 1)
   {

--- a/nx-X11/programs/Xserver/hw/nxagent/Rootless.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Rootless.h
@@ -46,13 +46,15 @@ extern WindowPtr nxagentRootlessWindow;
  * connected to the real X server.
  */
 
+#ifdef XlibAtom
 typedef struct
 {
   Window window;
-  Atom property;
+  XlibAtom property;
 } PropertyRequestRec;
 
 extern PropertyRequestRec nxagentPropertyRequests[256];
+#endif
 
 Window nxagentRootlessWindowParent(WindowPtr pWin);
 
@@ -75,14 +77,18 @@ int nxagentExportProperty(WindowPtr pWin, Atom property, Atom type, int format,
 
 #define MAX_RETRIEVED_PROPERTY_SIZE 256 * 1024
 
-void nxagentImportProperty(Window window, Atom property, Atom type, int format,
+#ifdef XlibAtom
+void nxagentImportProperty(Window window, XlibAtom property, XlibAtom type, int format,
                                unsigned long nitems, unsigned long bytes_after, unsigned char *buffer);
+#endif
 
 /*
  * Push last ChangeProperty to the list.
  */
 
-void nxagentAddPropertyToList(Atom property, WindowPtr pWin);
+#ifdef XlibAtom
+void nxagentAddPropertyToList(XlibAtom property, WindowPtr pWin);
+#endif
 
 /*
  * Check if a PropertyNotify match the top

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -149,7 +149,7 @@ Window nxagentInputWindows[MAXSCREENS];
 Window nxagentScreenSaverWindows[MAXSCREENS];
 
 #ifdef NXAGENT_ONSTART
-Atom nxagentReadyAtom;
+XlibAtom nxagentReadyAtom;
 #endif
 
 ScreenPtr nxagentDefaultScreen = NULL;

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.h
@@ -49,6 +49,12 @@ is" without express or implied warranty.
 #define nxagentSetPrintGeometry(screen) \
     nxagentPrintGeometryFlags = (1 << (screen));
 
+#ifdef NXAGENT_ONSTART
+#ifdef XlibAtom
+extern XlibAtom nxagentReadyAtom;
+#endif
+#endif
+
 extern int nxagentClients;
 
 extern int nxagentAutoDisconnectTimeout;

--- a/nx-X11/programs/Xserver/hw/nxagent/Splash.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Splash.c
@@ -69,20 +69,6 @@ Bool nxagentWMPassed = False;
 
 static void nxagentPaintLogo(Window win, GC gc, int scale, int width, int height);
 
-/*
- * From Screen.c.
- */
-
-#ifdef NXAGENT_ONSTART
-extern Atom nxagentReadyAtom;
-#endif
-
-/*
- * From Clipboard.c.
- */
-
-extern Atom serverCutProperty;
-
 void nxagentShowSplashWindow(Window parentWindow)
 {
   XWindowAttributes getAttributes;

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -422,7 +422,7 @@ Bool nxagentCreateWindow(WindowPtr pWin)
 
   if (nxagentOption(Rootless) && nxagentWindowTopLevel(pWin))
   {
-    Atom prop = nxagentMakeAtom("WM_PROTOCOLS", strlen("WM_PROTOCOLS"), True);
+    XlibAtom prop = nxagentMakeAtom("WM_PROTOCOLS", strlen("WM_PROTOCOLS"), True);
     XlibAtom atom = nxagentMakeAtom("WM_DELETE_WINDOW", strlen("WM_DELETE_WINDOW"), True);
 
     XSetWMProtocols(nxagentDisplay, nxagentWindowPriv(pWin)->window, &atom, 1);
@@ -3054,8 +3054,7 @@ static void nxagentReconnectWindow(void * param0, XID param1, void * data_buffer
   {
     if (nxagentWindowTopLevel(pWin))
     {
-      Atom prop = nxagentMakeAtom("WM_PROTOCOLS", strlen("WM_PROTOCOLS"), True);
-
+      XlibAtom prop = nxagentMakeAtom("WM_PROTOCOLS", strlen("WM_PROTOCOLS"), True);
       XlibAtom atom = nxagentMakeAtom("WM_DELETE_WINDOW", strlen("WM_DELETE_WINDOW"), True);
 
       XSetWMProtocols(nxagentDisplay, nxagentWindow(pWin), &atom, 1);

--- a/nx-X11/programs/Xserver/hw/nxagent/Windows.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Windows.h
@@ -177,7 +177,9 @@ do\
 
 WindowPtr nxagentWindowPtr(Window window);
 
-extern Atom serverCutProperty;
+#ifdef XlibAtom
+extern XlibAtom serverCutProperty;
+#endif
 
 /*
  * If the rectangles in an exposed region exceed


### PR DESCRIPTION
XlibAtom should be used wherever remote atoms are handled. This is
important as Xlib data types and server data types of the same name do
not always have identical sizes.

See also https://lists.freedesktop.org/archives/xorg-devel/2015-August/047245.html

I wanted to create a 32bit version of this for testing but I did not manage to instruct imake to do so...