### PR TITLE
Pr/strings fixes

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -1296,7 +1296,17 @@ static void nxagentParseSingleOption(char *name, char *value)
   }
   else if (strcmp(name, "clients") == 0)
   {
-    snprintf(nxagentClientsLogName, NXAGENTCLIENTSLOGNAMELENGTH, "%s", value);
+    char *new = strdup(value);
+    if (new)
+    {
+      SAFE_free(nxagentClientsLogName);
+      nxagentClientsLogName = new;
+    }
+    else
+    {
+      fprintf(stderr, "Warning: Ignoring option [%s] because of memory problems\n",
+                      validateString(name));
+    }
     return;
   }
   else if (strcmp(name, "client") == 0)

--- a/nx-X11/programs/Xserver/hw/nxagent/Error.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Error.c
@@ -334,7 +334,7 @@ char *nxagentGetHomePath(void)
 
     char *homeEnv = getenv("NX_HOME");
 
-    if (homeEnv == NULL || *homeEnv == '\0')
+    if (!homeEnv || *homeEnv == '\0')
     {
       #ifdef TEST
       fprintf(stderr, "%s: No environment for NX_HOME.\n", __func__);
@@ -342,7 +342,7 @@ char *nxagentGetHomePath(void)
 
       homeEnv = getenv("HOME");
 
-      if (homeEnv == NULL || *homeEnv == '\0')
+      if (!homeEnv || *homeEnv == '\0')
       {
         #ifdef PANIC
         fprintf(stderr, "%s: PANIC! No environment for HOME.\n", __func__);
@@ -386,7 +386,7 @@ char *nxagentGetRootPath(void)
 
     char *rootEnv = getenv("NX_ROOT");
 
-    if (rootEnv == NULL || *rootEnv == '\0')
+    if (!rootEnv || *rootEnv == '\0')
     {
       #ifdef TEST
       fprintf(stderr, "%s: WARNING! No environment for NX_ROOT.\n", __func__);
@@ -399,7 +399,7 @@ char *nxagentGetRootPath(void)
 
       char *homeEnv = nxagentGetHomePath();
 
-      if (homeEnv == NULL)
+      if (!homeEnv)
       {
         return NULL;
       }

--- a/nx-X11/programs/Xserver/hw/nxagent/Error.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Error.c
@@ -72,9 +72,6 @@ static int nxagentStderrBackup = -1;
 
 static int nxagentClientsLog = -1;
 
-#define DEFAULT_STRING_LENGTH 256
-
-
 /*
  * Clients log file name.
  */

--- a/nx-X11/programs/Xserver/hw/nxagent/Error.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Error.h
@@ -30,8 +30,7 @@
  * Clients log file name.
  */
 
-#define NXAGENTCLIENTSLOGNAMELENGTH 256
-extern char nxagentClientsLogName[NXAGENTCLIENTSLOGNAMELENGTH];
+extern char *nxagentClientsLogName;
 
 extern char nxagentVerbose;
 

--- a/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keyboard.c
@@ -1449,12 +1449,7 @@ static char* getKeyboardFilePath(void)
   {
     if ((asprintf(&keyboard_file_path, "%s/keyboard", sessionpath) == -1))
     {
-      SAFE_free(sessionpath);
       FatalError("malloc for keyboard file path failed.");
-    }
-    else
-    {
-      SAFE_free(sessionpath);
     }
   }
   else


### PR DESCRIPTION
fix some compiler warnings. This lead to rework string handling in Error.c: instead of using preallocated string arrays the strings are allocated using asprintf