### PR TITLE
Display.c: drop icon file support

### DIFF
--- a/debian/nxagent.install
+++ b/debian/nxagent.install
@@ -3,6 +3,5 @@ usr/bin/nxagent
 usr/lib/*/nx/X11/
 usr/share/man/man1/nxagent.1*
 usr/share/nx/VERSION.nxagent
-usr/share/pixmaps/nxagent.xpm
 # FIXME: compatibility symlink, drop for 3.6.0 release
 usr/lib/*/nx/bin/nxagent

--- a/nx-X11/programs/Xserver/hw/nxagent/X11/include/xpm_nxagent.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/X11/include/xpm_nxagent.h
@@ -238,21 +238,13 @@ typedef struct {
 
 _XFUNCPROTOBEGIN
 
-/* Keep for hw/nxagent/Holder.c */
+/* Keep for hw/nxagent/Display.c */
 FUNC(XpmCreatePixmapFromData, int, (Display *display,
 				    Drawable d,
 				    char **data,
 				    Pixmap *pixmap_return,
 				    Pixmap *shapemask_return,
 				    XpmAttributes *attributes));
-/* Keep for hw/nxagent/Display.c */
-FUNC(XpmReadFileToPixmap, int, (Display *display,
-                                Drawable d,
-                                const char *filename,
-                                Pixmap *pixmap_return,
-                                Pixmap *shapemask_return,
-                                XpmAttributes *attributes));
-
 _XFUNCPROTOEND
 
 #endif /* XPM_NUMBERS */


### PR DESCRIPTION
It would read nothing because the default path is non-existing on most
systems. So the builtin icons are used anyway. Also remove the xpm
files from the distribution.