### PR TITLE
mi: define NXAGENT_SERVER

### DIFF
--- a/nx-X11/programs/Xserver/mi/Imakefile
+++ b/nx-X11/programs/Xserver/mi/Imakefile
@@ -123,6 +123,9 @@ OBJS =  $(CBRT_OBJ)             \
 
 #if NXLibraries
 
+NX_DEFINES = -DNXAGENT_SERVER  \
+             $(NULL)
+
 /*
  * To build the NX agent we need the XINPUT symbol
  * in order to build the XInputExtension, since we
@@ -155,7 +158,7 @@ LINTLIBS =                      \
            ../os/llib-los.ln    \
            $(NULL)
 
-DEFINES  = $(FFS_DEFINES)
+DEFINES  = $(FFS_DEFINES) $(NX_DEFINES)
 
 NormalLibraryObjectRule()
 NormalLibraryTarget(mi,$(OBJS))


### PR DESCRIPTION
In commit f48e2da3e86b2d7600de3d5d4ef6f81ba2c17bed I marked NX changes
by using #ifdef NXAGENT_SERVER. But I had missed that this define was
never set in mi. So let's change that now and make it work like
before.

Fixes ArcticaProject/nx-libs#926