### PR TITLE
nxagent: fix stack smashing

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -1188,7 +1188,7 @@ static void transferSelection(int resource)
 
 void nxagentCollectPropertyEvent(int resource)
 {
-  Atom                  atomReturnType;
+  XlibAtom              atomReturnType;
   int                   resultFormat;
   unsigned long         ulReturnItems;
   unsigned long         ulReturnBytesLeft;

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -3924,7 +3924,7 @@ void nxagentHandleCollectPropertyEvent(XEvent *X)
   }
   else
   {
-    Atom atomReturnType;
+    XlibAtom atomReturnType;
     int resultFormat;
     unsigned long ulReturnItems;
     unsigned long ulReturnBytesLeft;
@@ -3940,8 +3940,8 @@ void nxagentHandleCollectPropertyEvent(XEvent *X)
 
     if (result == True)
     {
-      Window window = nxagentPropertyRequests[resource].window;
-      Atom property = nxagentPropertyRequests[resource].property;
+      XlibWindow window = nxagentPropertyRequests[resource].window;
+      XlibAtom property = nxagentPropertyRequests[resource].property;
 
       nxagentImportProperty(window, property, atomReturnType, resultFormat,
                                 ulReturnItems, ulReturnBytesLeft, pszReturnData);

--- a/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c
@@ -23,6 +23,12 @@
 /*                                                                        */
 /**************************************************************************/
 
+/*
+ * let the types be the Xlib types by undefining _XSERVER64. This
+ * means, when calling the functions of this file from nxagent (where
+ * Agent.h has been included) you need to use/provide XlibAtom and
+ * XlibWindow instead of Atom and Window
+ */
 #undef _XSERVER64
 
 #include <sys/socket.h>

--- a/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.h
@@ -827,11 +827,19 @@ extern int NXCollectProperty(
     Display*            /* display */,
     unsigned int        /* resource */,
     Window              /* window */,
+#ifdef XlibAtom
+    XlibAtom            /* property */,
+#else
     Atom                /* property */,
+#endif
     long                /* long_offset */,
     long                /* long_length */,
     Bool                /* delete */,
+#ifdef XlibAtom
+    XlibAtom            /* req_type */
+#else
     Atom                /* req_type */
+#endif
 #endif
 );
 
@@ -839,7 +847,11 @@ extern int NXGetCollectedProperty(
 #if NeedFunctionPrototypes
     Display*            /* display */,
     unsigned int        /* resource */,
+#ifdef XlibAtom
+    XlibAtom*           /* actual_type_return */,
+#else
     Atom*               /* actual_type_return */,
+#endif
     int*                /* actual_format_return */,
     unsigned long*      /* nitems_return */,
     unsigned long*      /* bytes_after_return */,


### PR DESCRIPTION
In compext Atom has the size of XlibAtom. Therefore calling functions
of Compext.c requires to use/pass XlibAtom. Same for Window/XlibWindow.

==15438==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffffcdc0 at pc 0x5555556a81b5 bp 0x7fffffffcd10 sp 0x7fffffffcd08
WRITE of size 8 at 0x7fffffffcdc0 thread T0
    #0 0x5555556a81b4 in NXGetCollectedProperty nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c:4124
    #1 0x5555557d0488 in nxagentCollectPropertyEvent nx-X11/programs/Xserver/hw/nxagent/Clipboard.c:1202
    #2 0x555555723340 in nxagentHandleCollectPropertyEvent nx-X11/programs/Xserver/hw/nxagent/Events.c:3923
    #3 0x55555571d4db in nxagentHandleProxyEvent nx-X11/programs/Xserver/hw/nxagent/Events.c:3007
    #4 0x55555571bb92 in nxagentHandleClientMessageEvent nx-X11/programs/Xserver/hw/nxagent/Events.c:2595
    #5 0x555555717dfc in nxagentDispatchEvents nx-X11/programs/Xserver/hw/nxagent/Events.c:1827
    #6 0x555555750813 in nxagentBlockHandler nx-X11/programs/Xserver/hw/nxagent/Handlers.c:437
    #7 0x5555556c1b5d in BlockHandler nx-X11/programs/Xserver/dix/dixutils.c:403
    #8 0x5555556d47ff in WaitForSomething nx-X11/programs/Xserver/os/WaitFor.c:232
    #9 0x555555665b22 in Dispatch nx-X11/programs/Xserver/hw/nxagent/NXdispatch.c:365
    #10 0x5555555ed760 in main nx-X11/programs/Xserver/dix/main.c:350
    #11 0x7ffff604909a in __libc_start_main ../csu/libc-start.c:308
    #12 0x5555555edc09 in _start (nx-X11/programs/Xserver/nxagent+0x99c09)

Address 0x7fffffffcdc0 is located in stack of thread T0 at offset 32 in frame
    #0 0x5555557d0324 in nxagentCollectPropertyEvent nx-X11/programs/Xserver/hw/nxagent/Clipboard.c:1190

  This frame has 5 object(s):
    [32, 36) 'atomReturnType' <== Memory access at offset 32 partially overflows this variable
    [96, 100) 'resultFormat'
    [160, 168) 'ulReturnItems'
    [224, 232) 'ulReturnBytesLeft'
    [288, 296) 'pszReturnData'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c:4124 in NXGetCollectedProperty
...