### PR TITLE
randr: fix broken macros / memory corruption

### DIFF
--- a/nx-X11/programs/Xserver/randr/randr.c
+++ b/nx-X11/programs/Xserver/randr/randr.c
@@ -69,12 +69,12 @@
 static int RRNScreens;
 
 #define wrap(priv,real,mem,func) {\
-    ((ScreenPtr)priv)->mem = ((ScreenPtr)real)->mem; \
-    ((ScreenPtr)real)->mem = func; \
+    priv->mem = real->mem; \
+    real->mem = func; \
 }
 
 #define unwrap(priv,real,mem) {\
-    ((ScreenPtr)real)->mem = ((ScreenPtr)priv)->mem; \
+    real->mem = priv->mem; \
 }
 
 static int ProcRRDispatch(ClientPtr pClient);


### PR DESCRIPTION
By casting the rrScrPriv to ScreenPtr we are using the offsets from
the Screen structure for referencing data in the rrScrPriv structure
causing data corruption. As both macros use the same casting this
still works until the location where the data resides is overwritten. For
64bit the location was the rotations member in rrScrPriv which was not
problematic because it is barely used. But on 32bit it was numCrtcs
which is heavily used. On unwrap this was 0 and lead to a segfault.

Fixes ArcticaProject/nx-libs#943