### PR TITLE
nxagent: make full screen mode selectable at startup

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -571,11 +571,15 @@ int ddxProcessArgument(int argc, char *argv[], int i)
   {
     if (++i < argc)
     {
-      if (!strcmp(argv[i],"fullscreen"))
+      if (!strcmp(argv[i],"fullscreen") || !strcmp(argv[i],"allscreens"))
       {
         nxagentChangeOption(Fullscreen, True);
-
         nxagentChangeOption(AllScreens, True);
+      }
+      else if (!strcmp(argv[i],"onescreen"))
+      {
+        nxagentChangeOption(Fullscreen, True);
+        nxagentChangeOption(AllScreens, False);
       }
       else
       { 
@@ -1111,6 +1115,11 @@ static void nxagentParseSingleOption(char *name, char *value)
       #ifdef DEBUG
       fprintf(stderr, "nxagentParseSingleOption: Ignoring option 'fullscreen' at reconnection.\n");
       #endif
+    }
+    else if (!strcmp(value, "2"))
+    {
+      nxagentChangeOption(Fullscreen, True);
+      nxagentChangeOption(AllScreens, False);
     }
     else if (!strcmp(value, "1"))
     {

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -337,6 +337,12 @@ void nxagentMinimizeFromFullScreen(ScreenPtr pScreen)
  */
 void nxagentMaximizeToFullScreen(ScreenPtr pScreen)
 {
+  if (nxagentOption(AllScreens))
+    nxagentSwitchAllScreens(pScreen, True);
+  else
+    nxagentSwitchFullscreen(pScreen, True);
+  return;
+
 /*
   XUnmapWindow(nxagentDisplay, nxagentIconWindow);
 */
@@ -363,7 +369,7 @@ FIXME: We'll check for ReparentNotify and LeaveNotify events after
       XEvent e;
 
       #ifdef TEST
-      fprintf(stderr, "nxagentMaximizeToFullscreen: WARNING! Going to wait for the ReparentNotify event [%d].\n", i);
+      fprintf(stderr, "%d: WARNING! Going to wait for the ReparentNotify event [%d].\n", __func__, i);
       #endif
 
       if (XCheckTypedWindowEvent(nxagentDisplay, nxagentFullscreenWindow, ReparentNotify, &e))

--- a/nx-X11/programs/Xserver/hw/nxagent/Window.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Window.c
@@ -729,7 +729,7 @@ void nxagentSwitchFullscreen(ScreenPtr pScreen, Bool switchOn)
   }
 
   #ifdef TEST
-  fprintf(stderr, "nxagentSwitchFullscreen: Switching to %s mode.\n",
+  fprintf(stderr, "%s: Switching to %s mode.\n", __func__,
               switchOn ? "fullscreen" : "windowed");
   #endif
 

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -281,7 +281,9 @@ not specified, \fBnxagent\fR will choose
 .I W
 and
 .I H
-to be 3/4ths the dimensions of the root window of the real server.
+to be 3/4ths the dimensions of the root window of the real server. For
+further values accepted see the documentation of
+\fBgeometry=<string>\fR below.
 .TP 8
 .B \-dpi \fIresolution\fP
 sets the resolution for all screens, in dots per inch. If this option
@@ -626,13 +628,20 @@ line, no-op when resuming (default: \fI0\fR, disabled)
 .TP 8
 .B geometry=<string>
 desktop geometry when starting or resuming a session, no-op in
-rootless mode (default 66% of the underlying X server geometry)
+rootless mode (default 66% of the underlying X server geometry). You
+can either specify a standard X geometry string
+(WxH+X+Y) or \fIallscreens\fR for a window covering
+all available screens or \fRonescreen\fR for a window covering only
+one screen. For historical reasons \fIfullscreen\fR (as a synonym to
+\fIallscreens\fR) is also accepted.
+.TP 8
+.B fullscreen=<int>
+start or resume a session in fullscreen mode (default: \fI0\fR, off). Specify \fI1\fR for
+a fullscreen window covering all available screens or \fI2\fR for a fullscreen window
+covering only the first screen.
 .TP 8
 .B resize=<bool>
 set resizing support (default: \fI1\fR, enabled)
-.TP 8
-.B fullscreen=<bool>
-start or resume a session in fullscreen mode (default: \fI0\fR, off)
 .TP 8
 .B keyboard=<string> or kbtype=<string>
 


### PR DESCRIPTION
fullscreen= now accepts the new value "2" for a fullscreen covering
only one screen. -geometry and geometry= now know additional keywords
"allscreens" and "onescreen".

Fixes ArcticaProject/nx-libs#923