### PR TITLE
Pr/fix fullscreen

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Args.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Args.c
@@ -2083,7 +2083,7 @@ void ddxUseMsg(void)
   ErrorF("-full                  utilize full regeneration\n");
   ErrorF("-class string          default visual class\n");
   ErrorF("-depth int             default depth\n");
-  ErrorF("-geometry WxH+X+Y      window size and position\n");
+  ErrorF("-geometry string       window size and position (WXH+X+Y) or 'allscreens' / 'onescreen'\n");
   ErrorF("-bw int                window border width\n");
   ErrorF("-name string           window name\n");
   ErrorF("-scrns int             number of screens to generate\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -337,12 +337,6 @@ void nxagentMinimizeFromFullScreen(ScreenPtr pScreen)
  */
 void nxagentMaximizeToFullScreen(ScreenPtr pScreen)
 {
-  if (nxagentOption(AllScreens))
-    nxagentSwitchAllScreens(pScreen, True);
-  else
-    nxagentSwitchFullscreen(pScreen, True);
-  return;
-
 /*
   XUnmapWindow(nxagentDisplay, nxagentIconWindow);
 */


### PR DESCRIPTION
This fixed the crash and extends the usage output, but it does not fix `-geometry singlescreen` not working. I would still merge it since fixes the crash. I will try to find the real bug soon...