### PR TITLE
Support Cygwin64

### DIFF
--- a/nxcomp/src/Auth.cpp
+++ b/nxcomp/src/Auth.cpp
@@ -238,7 +238,7 @@ int Auth::getCookie()
 
   char command[DEFAULT_STRING_LIMIT];
 
-  #if defined(__CYGWIN32__)
+  #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
   snprintf(command, DEFAULT_STRING_LIMIT,
                "%s/bin/nxauth", control -> SystemPath);

--- a/nxcomp/src/BlockCacheSet.cpp
+++ b/nxcomp/src/BlockCacheSet.cpp
@@ -51,13 +51,13 @@ BlockCacheSet::~BlockCacheSet()
   // failure happens in this destructor.
   //
 
-  #ifndef __CYGWIN32__
+  #if !(defined(__CYGWIN__) || defined(__CYGWIN32__))
 
   for (unsigned int i = 0; i < size_; i++)
     delete caches_[i];
   delete[]caches_;
 
-  #endif /* ifdef __CYGWIN32__ */
+  #endif /* if defined(__CYGWIN__) || defined(__CYGWIN32__) */
 }
 
 

--- a/nxcomp/src/BlockCacheSet.cpp
+++ b/nxcomp/src/BlockCacheSet.cpp
@@ -57,7 +57,7 @@ BlockCacheSet::~BlockCacheSet()
     delete caches_[i];
   delete[]caches_;
 
-  #endif /* if defined(__CYGWIN__) || defined(__CYGWIN32__) */
+  #endif /* if !(defined(__CYGWIN__) || defined(__CYGWIN32__)) */
 }
 
 

--- a/nxcomp/src/ChannelEndPoint.cpp
+++ b/nxcomp/src/ChannelEndPoint.cpp
@@ -253,7 +253,7 @@ getComputerName() {
 
   const char *hostname = NULL;
 
-  #ifdef __CYGWIN32__
+  #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
   hostname = getenv("COMPUTERNAME");
 

--- a/nxcomp/src/Children.cpp
+++ b/nxcomp/src/Children.cpp
@@ -295,7 +295,7 @@ int NXTransDialog(const char *caption, const char *message,
       strcat(newPath, "/Applications/NX Client for OSX.app/Contents/MacOS:");
       #endif
 
-      #ifdef __CYGWIN32__
+      #if defined(__CYGWIN__) || defined(__CYGWIN32__)
       // FIXME: missing length limitation!
       strcat(newPath, ".:");
       #endif
@@ -505,7 +505,7 @@ int NXTransClient(const char* display)
 
       #endif
 
-      #ifdef __CYGWIN32__
+      #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
       strcat(newPath, ".:");
 

--- a/nxcomp/src/Fork.cpp
+++ b/nxcomp/src/Fork.cpp
@@ -53,7 +53,7 @@
 
 int Fork()
 {
-  #ifdef __CYGWIN32__
+  #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
   int limit   = RETRY_LIMIT;
   int timeout = RETRY_TIMEOUT;

--- a/nxcomp/src/Loop.cpp
+++ b/nxcomp/src/Loop.cpp
@@ -79,7 +79,7 @@ typedef int socklen_t;
 #include <sys/select.h>
 #endif
 
-#ifndef __CYGWIN32__
+#if !(defined(__CYGWIN__) || defined(__CYGWIN32__))
 #include <netinet/tcp.h>
 #endif
 
@@ -4702,7 +4702,7 @@ void CleanupStreams()
   // at the time the proxy is being shut down.
   //
 
-  #ifndef __CYGWIN32__
+  #if !(defined(__CYGWIN__) || defined(__CYGWIN32__))
 
   nxinfo << "Loop: Freeing up streams in process "
          << "with pid '" << getpid() << "'.\n"
@@ -4753,7 +4753,7 @@ void CleanupStreams()
     errofs = NULL;
   }
 
-  #endif /* #ifndef __CYGWIN32__ */
+  #endif /* #if !(defined(__CYGWIN__) || defined(__CYGWIN32__)) */
 
   //
   // Reset these as they can't be reset
@@ -5705,7 +5705,7 @@ void HandleSignal(int signal)
       break;
     }
 
-    #ifdef __CYGWIN32__
+    #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
     case 12:
     {
@@ -6753,7 +6753,7 @@ int ConnectToRemote(ChannelEndPoint &socketAddress)
               // on Windows.
               //
 
-              #ifdef __CYGWIN32__
+              #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
               KillProcess(lastDialog, "dialog", SIGKILL, 1);
 
@@ -9849,7 +9849,7 @@ char *GetClientPath()
       clientEnv = "/Applications/NX Client for OSX.app/Contents/MacOS/nxclient";
 
       #else
-      #  if defined(__CYGWIN32__)
+      #  if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
       clientEnv = "C:\\Program Files\\NX Client for Windows\\nxclient";
 
@@ -13633,7 +13633,7 @@ int CheckSignal(int signal)
     }
     default:
     {
-      #ifdef __CYGWIN32__
+      #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
       //
       // This signal can be raised by the Cygwin
@@ -14968,7 +14968,7 @@ static void handleAlertInLoop()
         // on Windows.
         //
 
-        #ifdef __CYGWIN32__
+        #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
         KillProcess(lastDialog, "dialog", SIGKILL, 0);
 

--- a/nxcomp/src/MD5.c
+++ b/nxcomp/src/MD5.c
@@ -64,7 +64,7 @@
  * at compile time.
  */
 
-#if defined(__linux) || defined(__CYGWIN32__)
+#if defined(__linux) || defined(__CYGWIN__) || defined(__CYGWIN32__)
 
 #include <endian.h>
 
@@ -74,7 +74,7 @@
 #define ARCH_IS_BIG_ENDIAN 1
 #endif
 
-#endif /* #if defined(__linux) || defined(__CYGWIN32__) */
+#endif /* #if defined(__linux) || defined(__CYGWIN__) || defined(__CYGWIN32__) */
 
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN

--- a/nxcomp/src/Proxy.cpp
+++ b/nxcomp/src/Proxy.cpp
@@ -44,7 +44,7 @@
 
 #include "Misc.h"
 
-#if defined(__CYGWIN32__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#if defined(__CYGWIN__) || defined(__CYGWIN32__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
 #include <netinet/in_systm.h>
 #endif
 
@@ -788,7 +788,7 @@ const char *Proxy::getComputerName()
 
   const char *hostname = NULL;
 
-  #ifdef __CYGWIN32__
+  #if defined(__CYGWIN__) || defined(__CYGWIN32__)
 
   hostname = getenv("COMPUTERNAME");
 

--- a/nxcomp/src/ServerChannel.cpp
+++ b/nxcomp/src/ServerChannel.cpp
@@ -6972,7 +6972,7 @@ int ServerChannel::handleShmemRequest(DecodeBuffer &decodeBuffer, unsigned char 
         // 0600 mask doesn't seem to work).
         //
 
-        #if defined(__CYGWIN32__) || defined(__APPLE__)
+        #if defined(__CYGWIN__) || defined(__CYGWIN32__) || defined(__APPLE__)
 
         int permissions = 0777;
 
@@ -7047,7 +7047,7 @@ int ServerChannel::handleShmemRequest(DecodeBuffer &decodeBuffer, unsigned char 
         }
         else
         {
-          #ifndef __CYGWIN32__
+          #if !(defined(__CYGWIN__) || defined(__CYGWIN32__))
 
           #ifdef WARNING
           *logofs << "handleShmemRequest: WARNING! Can't create the shared "

--- a/nxcomp/src/Socket.cpp
+++ b/nxcomp/src/Socket.cpp
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 
-#if defined(__CYGWIN32__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#if defined(__CYGWIN__) || defined(__CYGWIN32__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
 #include <netinet/in_systm.h>
 #endif
 
@@ -65,7 +65,7 @@
 // disabled when running on MacOS/X.
 //
 
-#ifdef __CYGWIN32__
+#if defined(__CYGWIN__) || defined(__CYGWIN32__)
 #define TIOCOUTQ  ((unsigned int) -1)
 #endif
 
@@ -101,7 +101,7 @@ int GetKernelStep()
     // in the relevant OS dependent functions.
     //
 
-    #if defined(__CYGWIN32__) || defined(__APPLE__)
+    #if defined(__CYGWIN__) || defined(__CYGWIN32__) || defined(__APPLE__)
 
     _kernelStep = 0;
 
@@ -183,7 +183,7 @@ int GetKernelStep()
       }
     }
 
-    #endif /* #if defined(__CYGWIN32__) || defined(__APPLE__) */
+    #endif /* #if defined(__CYGWIN__) || defined(__CYGWIN32__) || defined(__APPLE__) */
   }
 
   return _kernelStep;


### PR DESCRIPTION
Hello! I've been getting things up to date here, and thought I'd do a 64 bit build of recent code.

It turns out that 64 bit Cygwin defines `__CYGWIN__` instead of `__CYGWIN32__`, but other than that things seem to be working okay in my testing so far.
