### PR TITLE
Compext.c: fix comparisons of 16bit sequence numbers

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/compext/Compext.c
@@ -3435,7 +3435,7 @@ static Bool _NXCollectImageHandler(Display *dpy, xReply *rep, char *buf,
   state = (_NXCollectImageState *) data;
 
   if ((rep -> generic.sequenceNumber % 65536) !=
-          ((int)(state -> sequence) % 65536))
+          ((CARD16)(state -> sequence) % 65536))
   {
     #ifdef TEST
     fprintf(stderr, "******_NXCollectImageHandler: Unmatched sequence [%d] for opcode [%d] "
@@ -3819,7 +3819,7 @@ static Bool _NXCollectPropertyHandler(Display *dpy, xReply *rep, char *buf,
   state = (_NXCollectPropertyState *) data;
 
   if ((rep -> generic.sequenceNumber % 65536) !=
-          ((int)(state -> sequence) % 65536))
+          ((CARD16)(state -> sequence) % 65536))
   {
     #ifdef TEST
     fprintf(stderr, "******_NXCollectPropertyHandler: Unmatched sequence [%d] for opcode [%d] "
@@ -4173,7 +4173,7 @@ static Bool _NXCollectGrabPointerHandler(Display *dpy, xReply *rep, char *buf,
   state = (_NXCollectGrabPointerState *) data;
 
   if ((rep -> generic.sequenceNumber % 65536) !=
-          ((int)(state -> sequence) % 65536))
+          ((CARD16)(state -> sequence) % 65536))
   {
     #ifdef TEST
     fprintf(stderr, "******_NXCollectGrabPointerHandler: Unmatched sequence [%d] for opcode [%d] "
@@ -4447,7 +4447,7 @@ static Bool _NXCollectInputFocusHandler(Display *dpy, xReply *rep, char *buf,
   state = (_NXCollectInputFocusState *) data;
 
   if ((rep -> generic.sequenceNumber % 65536) !=
-          ((int)(state -> sequence) % 65536))
+          ((CARD16)(state -> sequence) % 65536))
   {
     #ifdef TEST
     fprintf(stderr, "******_NXCollectInputFocusHandler: Unmatched sequence [%d] for opcode [%d] "


### PR DESCRIPTION
rep->generic.sequenceNumber is of type CARD16
state->sequence is of type unsigned long

Converting state->sequence to an int as it has been done since the
first version of nxcomp I know of (1.3.0-18 from 2003) is wrong here
because for numbers > INT_MAX this will result in a negative number,
which, after applying the 16bit modulo, will not match
rep->generic.sequenceNumber.

Example with numbers:

CARD16 c = 24565
unsigned long u = 3179110389

c % 65536 = 24565
u % 65536 = 24565

(int)(u) = -1115856907
(int)(u) % 65536 = -40971

-40971 will not match 24565

To fix this we need to ensure the number stays positive. We use CARD16
for this to match the type in the request which is a 16bit number. On
my system CARD16 is unsigned short which is guaranteed to contain _at
least_ the 0-65,535 range. As there is no upper limit of the range we
cannot drop the modulo because we need this value to be 16bit and not
more.

Thanks to Norm Green for providing log after log until we could
finally identify the reason for him seeing "Xlib: unexpected async
reply (sequence 0x94b01439)!" when pasting stopped working.