### PR TITLE
randr: Do not update ConnectionInfo if NULL

### DIFF
--- a/nx-X11/programs/Xserver/randr/rrscreen.c
+++ b/nx-X11/programs/Xserver/randr/rrscreen.c
@@ -66,6 +66,9 @@ RREditConnectionInfo(ScreenPtr pScreen)
     int screen = 0;
     int d;
 
+    if (ConnectionInfo == NULL)
+        return;
+
     connSetup = (xConnSetup *) ConnectionInfo;
     vendor = (char *) connSetup + sizeof(xConnSetup);
     formats = (xPixmapFormat *) ((char *) vendor +


### PR DESCRIPTION
Backport of this xorg-xserver commit:

  commit 941aeb3b92e644923bd112eef8023f033a140ee6
  Author: Olivier Fourdan <ofourdan@redhat.com>
  Date:   Fri May 13 08:58:58 2016 +0200

    randr: Do not update ConnectionInfo if NULL

    RRScreenSizeNotify() will update the connection information block, but
    if this occurs during initialization before ConnectionInfo is even
    initialized, this will lead to a crash.

    Simply check for ConnectionInfo prior to update it to avoid the crash.

    Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=95337
    Reviewed-by: Adam Jackson <ajax@redhat.com>
    Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>

Fixes ArcticaProject/nx-libs#1009