### PR TITLE
Forward ClientMessages to nxproxy side

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Events.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.h
@@ -222,4 +222,6 @@ int nxagentPendingEvents(Display *dpy);
 
 int nxagentWaitEvents(Display *, useconds_t msec);
 
+void ForwardClientMessage(ClientPtr client, xSendEventReq *stuff);
+
 #endif /* __Events_H__ */

--- a/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/NXevents.c
@@ -425,6 +425,12 @@ ProcSendEvent(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xSendEventReq);
 
+    if (nxagentOption(Rootless) && stuff->event.u.u.type == ClientMessage)
+    {
+        ForwardClientMessage(client, stuff);
+        return Success;
+    }
+
     if (stuff -> event.u.u.type == SelectionNotify)
     {
 	if (nxagentSendNotify(&stuff->event) == 1)


### PR DESCRIPTION
This should help with clients requesting window manager actions like
maximizing or minimizing. This is a first version as it only handles
messages of type WM_STATE_CHANGE and _NET_WM_STATE. But ICCCM and EWMH
know some more.

The other direction, setting of properties by the WM, is already
implemented in Rootless.c.

Fixes ArcticaProject/nx-libs#1015