### PR TITLE
nx-X11: Add support for riscv64 architecture

### DIFF
--- a/nx-X11/config/cf/Imake.cf
+++ b/nx-X11/config/cf/Imake.cf
@@ -878,6 +878,11 @@ XCOMM Keep cpp from replacing path elements containing i486/i586/i686
 #  undef __powerpc64__
 #  undef tmp_set_big_endian
 # endif
+# ifdef __riscv
+#  if __riscv_xlen == 64
+#   define Riscv64Architecture
+#  endif
+# endif
 # ifdef sparc
 #  define SparcArchitecture
 #  undef sparc

--- a/nx-X11/config/cf/Imake.tmpl
+++ b/nx-X11/config/cf/Imake.tmpl
@@ -509,6 +509,8 @@ XCOMM the platform-specific parameters - edit site.def to change
 #define ByteOrder		X_BIG_ENDIAN
 #elif defined(Ppc64LeArchitecture)
 #define ByteOrder		X_LITTLE_ENDIAN
+#elif defined(Riscv64Architecture)
+#define ByteOrder		X_LITTLE_ENDIAN
 #elif defined(HPArchitecture)
 #define ByteOrder		X_BIG_ENDIAN
 #elif defined(SuperHArchitecture)

--- a/nx-X11/config/cf/linux.cf
+++ b/nx-X11/config/cf/linux.cf
@@ -783,6 +783,15 @@ XCOMM binutils:	(LinuxBinUtilsMajorVersion)
 # define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines
 #endif /* PpcArchitecture */
 
+#ifdef Riscv64Architecture
+# ifndef OptimizedCDebugFlags
+#  define OptimizedCDebugFlags	-O3
+# endif
+# define LinuxMachineDefines	-D__riscv64__
+# define ServerOSDefines	XFree86ServerOSDefines
+# define ServerExtraDefines	-DGCCUSESGAS XFree86ServerDefines -D_XSERVER64
+#endif /* Riscv64Achitecture */
+
 #ifdef s390Architecture
 # ifndef OptimizedCDebugFlags
 #  define OptimizedCDebugFlags	-O2 -fomit-frame-pointer GccAliasingArgs


### PR DESCRIPTION
With this patch (slightly reordered), I was able to build a riscv64 ubuntu package:

https://launchpad.net/~alexghiti/+archive/ubuntu/riscv/+build/22054458

I'm unsure though of what is expected for `LinuxMachineDefines` define.