### PR TITLE
Screen.c: fix handling of AllScreens without a running window manager

### DIFF
--- a/nx-X11/programs/Xserver/hw/nxagent/Screen.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Screen.c
@@ -967,6 +967,7 @@ Bool nxagentOpenScreen(ScreenPtr pScreen, int argc, char *argv[])
     #endif
 
     nxagentChangeOption(Fullscreen, True);
+    nxagentChangeOption(AllScreens, True);
 
     if (nxagentOption(ClientOs) == ClientOsWinnt &&
             (!nxagentReconnectTrap || nxagentResizeDesktopAtStartup))


### PR DESCRIPTION
When used with the old nomachine nxclient (nxclient-3.5.0-9.exe) on
Windows for running a desktop session the screen size was wrong (set
to 3/4 of the requested size while also activating fullscreen because
in that case nomachine's nxwin does not offer a window manager).

Fix this by always setting AllScreens to true when there's no window
manager, just as it was already done with the FullScreen variable.

Fixes: ArcticaProject/nx-libs#1030