### PR TITLE
nxagent: add keystrokes to switch clipboard mode on the fly

### DIFF
--- a/doc/nxagent/README.keystrokes
+++ b/doc/nxagent/README.keystrokes
@@ -133,6 +133,18 @@ dump_clipboard
   print the current internal clipboard state (for debugging) to the
   log.
 
+clipboard_both
+  allow copy/paste from/to real X server
+
+clipboard_client
+  allow copy/paste from real X server
+
+clipboard_server
+  allow copy/paste to real X server
+
+clipboard_none
+  forbid copy/paste from/to real X server
+
 force_synchronization
   Forces immediate drawing of elements to be synchronized which can
   fix some visual bugs.

--- a/etc/keystrokes.cfg
+++ b/etc/keystrokes.cfg
@@ -26,4 +26,8 @@
 <keystroke action="reread_keystrokes" Control="1" AltMeta="1" key="k" />
 <keystroke action="autograb" Control="1" AltMeta="1" key="g" />
 <keystroke action="dump_clipboard" Control="1" Shift="1" AltMeta="1" key="c" />
+<keystroke action="clipboard_both" Control="1" Shift="1" AltMeta="1" key="1" />
+<keystroke action="clipboard_client" Control="1" Shift="1" AltMeta="1" key="2" />
+<keystroke action="clipboard_server" Control="1" Shift="1" AltMeta="1" key="3" />
+<keystroke action="clipboard_none" Control="1" Shift="1" AltMeta="1" key="4" />
 </keystrokes>

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -519,6 +519,16 @@ void nxagentDumpClipboardStat(void)
   fprintf(stderr, "\\------------------------------------------------------------------------------\n");
 }
 
+void nxagentSwitchClipboardMode(int new_mode) {
+  int old_mode = nxagentOption(Clipboard);
+  if (old_mode == new_mode)
+    return;
+  nxagentChangeOption(Clipboard, new_mode);
+  fprintf(stderr, "Switched clipboard mode from %s to %s.\n",
+          getClipboardModeString(old_mode),
+          getClipboardModeString(new_mode));
+}
+
 /*
  * Helper to handle data transfer
  */

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.c
@@ -253,6 +253,18 @@ static char szAgentCLIPBOARD[] = "CLIPBOARD";
  * Some helpers for debugging output
  */
 
+static const char * getClipboardModeString(int mode)
+{
+  switch(mode)
+  {
+    case ClipboardBoth:    return("[Both]"); break;;
+    case ClipboardClient:  return("[Client]"); break;;
+    case ClipboardServer:  return("[Server]"); break;;
+    case ClipboardNone:    return("[None]"); break;;
+    default:               return("[UNKNOWN] (FAIL!)"); break;;
+  }
+}
+
 static const char * getClientSelectionStageString(int stage)
 {
   switch(stage)
@@ -438,14 +450,7 @@ void nxagentDumpClipboardStat(void)
   fprintf(stderr, "  serverWindow              (XlibWindow) [0x%lx]\n", serverWindow);
 
   fprintf(stderr, "  Clipboard mode                         ");
-  switch(nxagentOption(Clipboard))
-  {
-    case ClipboardBoth:    fprintf(stderr, "[Both]"); break;;
-    case ClipboardClient:  fprintf(stderr, "[Client]"); break;;
-    case ClipboardServer:  fprintf(stderr, "[Server]"); break;;
-    case ClipboardNone:    fprintf(stderr, "[None]"); break;;
-    default:               fprintf(stderr, "[UNKNOWN] (FAIL!)"); break;;
-  }
+  fprintf(stderr, getClipboardModeString(nxagentOption(Clipboard)));
   fprintf(stderr, "\n");
 
   if (serverLastRequestedSelection == -1)

--- a/nx-X11/programs/Xserver/hw/nxagent/Clipboard.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Clipboard.h
@@ -82,5 +82,6 @@ extern WindowPtr nxagentGetClipboardWindow(Atom property);
 extern int nxagentSendNotificationToSelfViaXServer(xEvent *event);
 
 extern void nxagentDumpClipboardStat(void);
+extern void nxagentSwitchClipboardMode(int new_mode);
 
 #endif /* __Clipboard_H__ */

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.c
@@ -1071,6 +1071,14 @@ void nxagentDispatchEvents(PredicateFuncPtr predicate)
             nxagentDumpClipboardStat();
             break;
           }
+          case doClipboardBoth:
+          case doClipboardClient:
+          case doClipboardServer:
+          case doClipboardNone:
+          {
+            nxagentSwitchClipboardMode(ClipboardBoth + result - doClipboardBoth);
+            break;
+          }
           default:
           {
             FatalError("nxagentDispatchEvent: handleKeyPress returned unknown value\n");

--- a/nx-X11/programs/Xserver/hw/nxagent/Events.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Events.h
@@ -52,7 +52,11 @@ enum HandleEventResult
   doSwitchResizeMode,
   doSwitchDeferMode,
   doAutoGrab,
-  doDumpClipboard
+  doDumpClipboard,
+  doClipboardBoth,
+  doClipboardClient,
+  doClipboardServer,
+  doClipboardNone
 };
 
 extern CARD32 nxagentLastEventTime;

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.c
@@ -103,6 +103,10 @@ char * nxagentSpecialKeystrokeNames[] = {
        "autograb",
 
        "dump_clipboard",
+       "clipboard_both",
+       "clipboard_client",
+       "clipboard_server",
+       "clipboard_none",
 
        NULL,
 };
@@ -145,6 +149,10 @@ struct nxagentSpecialKeystrokeMap default_map[] = {
   {KEYSTROKE_REREAD_KEYSTROKES, ControlMask, True, XK_k},
   {KEYSTROKE_AUTOGRAB, ControlMask, True, XK_g},
   {KEYSTROKE_DUMP_CLIPBOARD, ControlMask | ShiftMask, True, XK_c},
+  {KEYSTROKE_SET_CLIPBOARD_BOTH, ControlMask | ShiftMask, True, XK_1},
+  {KEYSTROKE_SET_CLIPBOARD_CLIENT, ControlMask | ShiftMask, True, XK_2},
+  {KEYSTROKE_SET_CLIPBOARD_SERVER, ControlMask | ShiftMask, True, XK_3},
+  {KEYSTROKE_SET_CLIPBOARD_NONE, ControlMask | ShiftMask, True, XK_4},
   {KEYSTROKE_END_MARKER, 0, False, NoSymbol},
 };
 struct nxagentSpecialKeystrokeMap *map = default_map;
@@ -724,6 +732,12 @@ Bool nxagentCheckSpecialKeystroke(XKeyEvent *X, enum HandleEventResult *result)
       break;
     case KEYSTROKE_DUMP_CLIPBOARD:
       *result = doDumpClipboard;
+      break;
+    case KEYSTROKE_SET_CLIPBOARD_BOTH:
+    case KEYSTROKE_SET_CLIPBOARD_CLIENT:
+    case KEYSTROKE_SET_CLIPBOARD_SERVER:
+    case KEYSTROKE_SET_CLIPBOARD_NONE:
+      *result = doClipboardBoth + stroke - KEYSTROKE_SET_CLIPBOARD_BOTH;
       break;
     case KEYSTROKE_NOTHING: /* do nothing. difference to KEYSTROKE_IGNORE is the return value */
     case KEYSTROKE_END_MARKER: /* just to make gcc STFU */

--- a/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
+++ b/nx-X11/programs/Xserver/hw/nxagent/Keystroke.h
@@ -79,6 +79,10 @@ enum nxagentSpecialKeystroke {
        KEYSTROKE_AUTOGRAB,
 
        KEYSTROKE_DUMP_CLIPBOARD,
+       KEYSTROKE_SET_CLIPBOARD_BOTH,
+       KEYSTROKE_SET_CLIPBOARD_CLIENT,
+       KEYSTROKE_SET_CLIPBOARD_SERVER,
+       KEYSTROKE_SET_CLIPBOARD_NONE,
 
        /* insert more here and in the string translation */
 

--- a/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
+++ b/nx-X11/programs/Xserver/hw/nxagent/man/nxagent.1
@@ -706,6 +706,7 @@ model. Using \fIoff\fR this conversion can be suppressed and with
 
 .TP 8
 .B clipboard=<string>
+Set initial clipboard mode. Can be toggled during session via keystroke.
 
 .BR both | client | server | none
 


### PR DESCRIPTION
This pull request adds nxagent keystrokes to switch clipboard mode on the fly.
A typical use case for this feature is to prevent access to the real X server's clipboard most of the time, except for a couple seconds when this actually proves necessary. Otherly put, it simply makes nxagent's"clipboard mode" feature more flexible. Should it prove unnecessary or harmful to some users, the whole thing can be disabled by reconfiguring keystrokes.