### PR TITLE
Fix dlopen() privilege escalation.

### DIFF
--- a/nx-X11/extras/Mesa.patches_6.4.2/5003_dlopen-escalation.patch
+++ b/nx-X11/extras/Mesa.patches_6.4.2/5003_dlopen-escalation.patch
@@ -1,0 +1,13 @@
+Index: Mesa_6.4.2/src/glx/x11/dri_glx.c
+===================================================================
+--- Mesa_6.4.2.orig/src/glx/x11/dri_glx.c
++++ Mesa_6.4.2/src/glx/x11/dri_glx.c
+@@ -196,7 +196,7 @@ static __DRIdriver *OpenDriver(const cha
+       }
+    }
+ 
+-   if (geteuid() == getuid()) {
++   if (geteuid() == getuid() && getgid() == getegid()) {
+       /* don't allow setuid apps to use LIBGL_DRIVERS_PATH */
+       libPaths = getenv("LIBGL_DRIVERS_PATH");
+       if (!libPaths)

--- a/nx-X11/extras/Mesa.patches_6.4.2/series
+++ b/nx-X11/extras/Mesa.patches_6.4.2/series
@@ -6,3 +6,4 @@
 4005_adapt-all-libX11-include-paths-to-libNX_X11.patch
 5002_silence-uninitialized.diff
 1001_support_musl
+5003_dlopen-escalation.patch


### PR DESCRIPTION
Fixed by implementing the recommended GID check.

Closes #1067